### PR TITLE
chore: add safe gh comment rule and formatting cleanups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,7 @@ This document provides a set of rules and guidelines for AI agents (such as Jule
 
 4. **逸脱時の自己修正**:
    - もし確認や説明をスキップしてしまったことに気づいた場合、即座に中断し、謝罪した上で不足していた説明を行い、改めて指示を仰ぐこと。
+
+5. **GitHubコメント投稿時の安全な書式**:
+   - `gh pr comment` / `gh issue comment` で本文にバッククォート（`` ` ``）や `$` を含む場合、シェル展開を避けるため `--body-file` + シングルクォートheredoc（`<<'EOF'`）を使うこと。
+   - `--body "..."` へ直接埋め込む方法は原則禁止（コマンド置換や変数展開で本文が破損するため）。

--- a/src/pipeline/main.py
+++ b/src/pipeline/main.py
@@ -358,12 +358,20 @@ def run_pipeline(
 def main() -> None:
     import argparse
 
-    parser = argparse.ArgumentParser(description="Run the integrated detection and numbering pipeline.")
-    parser.add_argument("--config", type=Path, required=True, help="Path to the YAML configuration file.")
+    parser = argparse.ArgumentParser(
+        description="Run the integrated detection and numbering pipeline."
+    )
+    parser.add_argument(
+        "--config", type=Path, required=True, help="Path to the YAML configuration file."
+    )
     parser.add_argument("--run-id", type=str, help="Optional run identifier.")
     parser.add_argument("--output-root", type=Path, help="Optional output root directory.")
-    parser.add_argument("--dry-run", action="store_true", help="Log commands without executing them.")
-    parser.add_argument("--validate-only", action="store_true", help="Stop after input resolution and filtering.")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Log commands without executing them."
+    )
+    parser.add_argument(
+        "--validate-only", action="store_true", help="Stop after input resolution and filtering."
+    )
     parser.add_argument("--page-limit", type=int, help="Limit the number of pages to process.")
 
     args = parser.parse_args()

--- a/tools/run_full_pipeline.py
+++ b/tools/run_full_pipeline.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-DEPRECATED: This orchestrator is legacy. 
+DEPRECATED: This orchestrator is legacy.
 Please use 'python -m src.pipeline.main' instead for integrated features and model persistence.
 """
 

--- a/tools/select_trusted_templates.py
+++ b/tools/select_trusted_templates.py
@@ -120,7 +120,7 @@ def main() -> None:
         for p in pred_boxes:
             tps.append((0.0, p, p))
 
-    tps.sort(key=lambda t: (t[1][3] - t[1][1]), reverse=True)
+    tps.sort(key=lambda t: t[1][3] - t[1][1], reverse=True)
     tps = tps[: args.count]
 
     args.output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Add AGENTS rule for safe `gh pr/issue comment` usage (`--body-file` + `<<'EOF'`) to avoid shell expansion issues.
- Apply small formatting-only cleanups in existing files.

## Changes
- `AGENTS.md`
  - Added interactive protocol rule for safe GitHub comment posting.
- `src/pipeline/main.py`
  - Formatting-only line wrapping around argparse definitions.
- `tools/run_full_pipeline.py`
  - Trimmed trailing whitespace in module docstring.
- `tools/select_trusted_templates.py`
  - Simplified lambda expression formatting.

## Validation
- Formatting-only / docs change.
- No behavior change intended.

## Related
- Supports safer PR/Issue comment workflow used in recent PR handling.
