### PR TITLE
Issue #38: evaluation2 GT再構築ツールの棚卸しと運用導線の一本化

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -53,7 +53,7 @@ data/
 - `tools/gt_relabel_gui/evaluation2_config.json` を使うGT編集では、`output_raw` が存在する場合はそれを優先して再開する。
 - 初期候補（`boxes_provisional.json`）へ戻したい場合は GUI の `Reset To Initial` を使う。
 
-2026-02-22 時点の保存済みスナップショット（小節線GT）:
+保存済みスナップショット（小節線GT、2026-02-22 の作業完了時点）:
 - 対象作品数: 5
 - 保存ページ数: 68
 - 保存ファイル数: 136（`raw_boxes.json` と `boxes_sorted.json` のペア）

--- a/tools/check_gt_config.py
+++ b/tools/check_gt_config.py
@@ -1,8 +1,16 @@
 import json
 import os
 
+# Auxiliary diagnostic script for checking the currently configured GT GUI inputs.
+# This is not the canonical evaluation2 rebuild entrypoint; use
+# `tools/gt_relabel_gui/prepare_rebuild_eval2.py` for config generation.
+
 
 def main():
+    print(
+        "[AUX] check_gt_config.py validates the current GUI config/editable files. "
+        "For rebuilding evaluation2 config, use tools/gt_relabel_gui/prepare_rebuild_eval2.py."
+    )
     config_path = "tools/gt_relabel_gui/evaluation2_config.json"
     if not os.path.exists(config_path):
         print(f"Config not found: {config_path}")

--- a/tools/cnn_classifier/create_comprehensive_gt_config.py
+++ b/tools/cnn_classifier/create_comprehensive_gt_config.py
@@ -3,6 +3,12 @@ import json
 import os
 from pathlib import Path
 
+# LEGACY: Historical evaluation2 GUI config generator based on
+# `logs/hybrid_generalization` and mixed GT/candidate sources.
+# For the current evaluation2 GT rebuild workflow, use:
+#   tools/gt_relabel_gui/prepare_rebuild_eval2.py
+# and follow tools/verification/gt_preparation/README.md.
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -11,6 +17,10 @@ def main():
     parser.add_argument("--annotation-root", default="data/evaluation2/annotations")
     parser.add_argument("--candidate-root", default="logs/hybrid_generalization")
     args = parser.parse_args()
+    print(
+        "[LEGACY] create_comprehensive_gt_config.py is for an older workflow. "
+        "Use tools/gt_relabel_gui/prepare_rebuild_eval2.py for current evaluation2 GT rebuild."
+    )
 
     repo_root = Path(os.getcwd())
     image_root = repo_root / args.image_root

--- a/tools/cnn_classifier/create_gt_gui_config.py
+++ b/tools/cnn_classifier/create_gt_gui_config.py
@@ -2,6 +2,11 @@ import argparse
 import json
 from pathlib import Path
 
+# LEGACY: Historical GUI config generator for `annotations_provisional` workflows.
+# For the current evaluation2 GT rebuild workflow, use:
+#   tools/gt_relabel_gui/prepare_rebuild_eval2.py
+# and follow tools/verification/gt_preparation/README.md.
+
 
 def main():
     parser = argparse.ArgumentParser(description="Generate Config for GT Relabel GUI")
@@ -14,6 +19,10 @@ def main():
         help="Absolute path to repo root",
     )
     args = parser.parse_args()
+    print(
+        "[LEGACY] create_gt_gui_config.py targets an older provisional-GT workflow. "
+        "Use tools/gt_relabel_gui/prepare_rebuild_eval2.py for current evaluation2 GT rebuild."
+    )
 
     json_root = Path(args.json_root)
     image_root = Path(args.image_root)

--- a/tools/gt_relabel_gui/prepare_rebuild_eval2.py
+++ b/tools/gt_relabel_gui/prepare_rebuild_eval2.py
@@ -2,6 +2,9 @@ import json
 import shutil
 from pathlib import Path
 
+# Current entrypoint for evaluation2 GT rebuild config generation.
+# Canonical flow is documented in tools/verification/gt_preparation/README.md.
+
 
 def prepare_eval2_rebuild():
     repo_root = Path("/home/masaki_muramatsu/ws_PDFScoreBar")

--- a/tools/gt_relabel_gui/prepare_rebuild_eval2.py
+++ b/tools/gt_relabel_gui/prepare_rebuild_eval2.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 def prepare_eval2_rebuild():
-    repo_root = Path("/home/masaki_muramatsu/ws_PDFScoreBar")
+    repo_root = Path(__file__).resolve().parents[2]
     img_root = repo_root / "data/evaluation2/images"
     ann_root = repo_root / "data/evaluation2/annotations"
     logs_root = repo_root / "logs/hybrid_pipeline_bench"
@@ -23,6 +23,13 @@ def prepare_eval2_rebuild():
         repo_root / "logs/issue36_prep/probe_candidates_filtered_v6",
         repo_root / "logs/issue36_prep/probe_candidates_filtered_v5",
     ]
+
+    missing_inputs = [p for p in (img_root, ann_root.parent, logs_root) if not p.exists()]
+    if missing_inputs:
+        missing_str = ", ".join(str(p) for p in missing_inputs)
+        raise FileNotFoundError(
+            f"Required directories not found under repo root {repo_root}: {missing_str}"
+        )
 
     # 1. Map pages to their latest hybrid predictions
     # Pattern: eval2_{score}_{page}_{timestamp}

--- a/tools/populate_missing_gt.py
+++ b/tools/populate_missing_gt.py
@@ -2,8 +2,16 @@ import json
 import shutil
 from pathlib import Path
 
+# LEGACY: Historical helper for filling empty `editable` JSONs from
+# `logs/hybrid_generalization`. Not part of the current evaluation2 GT rebuild flow.
+# Current workflow: tools/gt_relabel_gui/prepare_rebuild_eval2.py + gt_relabel_gui.
+
 
 def main():
+    print(
+        "[LEGACY] populate_missing_gt.py uses the older hybrid_generalization workflow. "
+        "Use tools/gt_relabel_gui/prepare_rebuild_eval2.py for current evaluation2 GT rebuild."
+    )
     config_path = "tools/gt_relabel_gui/evaluation2_config.json"
     with open(config_path, "r") as f:
         config = json.load(f)

--- a/tools/populate_provisional_gt.py
+++ b/tools/populate_provisional_gt.py
@@ -2,8 +2,16 @@ import json
 import shutil
 from pathlib import Path
 
+# LEGACY: Historical helper for overwriting provisional GT from CNN-filtered
+# outputs in `logs/hybrid_generalization`. Not part of the current evaluation2
+# GT rebuild flow.
+
 
 def main():
+    print(
+        "[LEGACY] populate_provisional_gt.py uses the older hybrid_generalization/CNN workflow. "
+        "Use tools/gt_relabel_gui/prepare_rebuild_eval2.py for current evaluation2 GT rebuild."
+    )
     config_path = "tools/gt_relabel_gui/evaluation2_config.json"
     with open(config_path, "r") as f:
         config = json.load(f)

--- a/tools/split_double_barlines.py
+++ b/tools/split_double_barlines.py
@@ -100,9 +100,26 @@ def _extract_bbox(record):
     return None, False
 
 
-def _should_split(record, bbox, min_split_width):
+def _estimate_unit_size_from_bbox_height(bbox):
+    # Heuristic for GT barline boxes that typically span a single 5-line staff:
+    # staff-height ~= 4 * unit_size. This keeps the split gate scale-aware even
+    # when explicit unit_size metadata is unavailable in this offline utility.
+    x1, y1, x2, y2 = bbox
+    height = max(1, abs(y2 - y1))
+    return max(1.0, height / 4.0)
+
+
+def _resolve_min_split_width(bbox, min_split_width_px, min_split_width_unit_ratio):
+    if min_split_width_px is not None:
+        return max(1, int(min_split_width_px))
+    unit_size = _estimate_unit_size_from_bbox_height(bbox)
+    return max(2, int(round(unit_size * min_split_width_unit_ratio)))
+
+
+def _should_split(record, bbox, min_split_width_px, min_split_width_unit_ratio):
     x1, y1, x2, y2 = bbox
     width = abs(x2 - x1)
+    min_split_width = _resolve_min_split_width(bbox, min_split_width_px, min_split_width_unit_ratio)
     if width < min_split_width:
         return False
     if isinstance(record, dict):
@@ -112,7 +129,14 @@ def _should_split(record, bbox, min_split_width):
     return True
 
 
-def process_file(json_path, image_root, output_vis_dir, dry_run=True, min_split_width=12):
+def process_file(
+    json_path,
+    image_root,
+    output_vis_dir,
+    dry_run=True,
+    min_split_width=None,
+    min_split_width_unit_ratio=1.0,
+):
     data = load_json(json_path)
     image_path = get_image_path(json_path, image_root)
 
@@ -152,7 +176,7 @@ def process_file(json_path, image_root, output_vis_dir, dry_run=True, min_split_
             final_records.append(record)
             continue
 
-        if _should_split(record, bbox, min_split_width):
+        if _should_split(record, bbox, min_split_width, min_split_width_unit_ratio):
             x1, y1, x2, y2 = bbox
 
             # Extract crop
@@ -240,8 +264,20 @@ def main():
     parser.add_argument(
         "--min-split-width",
         type=int,
-        default=12,
-        help="Minimum bbox width in px to try splitting (default: 12)",
+        default=None,
+        help=(
+            "Minimum bbox width in px to try splitting. "
+            "If omitted, use a scale-aware threshold estimated from bbox height."
+        ),
+    )
+    parser.add_argument(
+        "--min-split-width-unit-ratio",
+        type=float,
+        default=1.0,
+        help=(
+            "Scale-aware split gate ratio against estimated unit_size "
+            "(used when --min-split-width is omitted). Default: 1.0"
+        ),
     )
     args = parser.parse_args()
 
@@ -267,6 +303,7 @@ def main():
             args.output_vis,
             dry_run=not args.apply,
             min_split_width=args.min_split_width,
+            min_split_width_unit_ratio=args.min_split_width_unit_ratio,
         )
         total_modified += count
 

--- a/tools/verification/gt_preparation/README.md
+++ b/tools/verification/gt_preparation/README.md
@@ -26,7 +26,7 @@ Use this flow for `evaluation2` GT rebuild / continuation:
 1. `tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py`
 2. `tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py`
 3. `tools/gt_relabel_gui/prepare_rebuild_eval2.py`
-4. `tools/gt_relabel_gui/server.py --mode gt --config tools/gt_relabel_gui/evaluation2_config.json`
+4. `python3 tools/gt_relabel_gui/server.py --mode gt --config tools/gt_relabel_gui/evaluation2_config.json`
 
 Authoritative outputs are written to:
 - `data/evaluation2/annotations/<work>/page_xxx/raw_boxes.json`

--- a/tools/verification/gt_preparation/README.md
+++ b/tools/verification/gt_preparation/README.md
@@ -17,6 +17,40 @@ Purpose: Standard scripts for Ground Truth (GT) preparation and candidate filter
 - `render_candidate_filter_overlay.py`
   - Creates visual overlays: gray=all, green=keep, red=drop.
 
+## GT rebuild tooling inventory (Issue #38)
+This section clarifies the current `evaluation2` GT rebuild workflow and marks
+older scripts that remain in the repository for historical/manual use cases.
+
+### Canonical workflow (current)
+Use this flow for `evaluation2` GT rebuild / continuation:
+1. `tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py`
+2. `tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py`
+3. `tools/gt_relabel_gui/prepare_rebuild_eval2.py`
+4. `tools/gt_relabel_gui/server.py --mode gt --config tools/gt_relabel_gui/evaluation2_config.json`
+
+Authoritative outputs are written to:
+- `data/evaluation2/annotations/<work>/page_xxx/raw_boxes.json`
+- `data/evaluation2/annotations/<work>/page_xxx/boxes_sorted.json`
+
+### Tool status matrix (evaluation2 GT rebuild)
+- `tools/gt_relabel_gui/prepare_rebuild_eval2.py`: `CURRENT`
+  - Builds `evaluation2_config.json` and per-page `boxes_provisional.json` from the latest adopted filtered seeds (currently v13-first fallback chain).
+- `tools/check_gt_config.py`: `AUXILIARY`
+  - Quick config/JSON existence check. Useful for diagnostics, but not part of the canonical rebuild path.
+- `tools/cnn_classifier/create_comprehensive_gt_config.py`: `LEGACY`
+  - Older `hybrid_generalization`-based config generation path.
+- `tools/cnn_classifier/create_gt_gui_config.py`: `LEGACY`
+  - Older `annotations_provisional`-based GUI config generator.
+- `tools/populate_missing_gt.py`: `LEGACY`
+  - Older helper for filling empty `editable` JSONs from `logs/hybrid_generalization`.
+- `tools/populate_provisional_gt.py`: `LEGACY`
+  - Older helper for overwriting provisional GT from CNN-filtered outputs.
+
+Policy for legacy scripts:
+- Keep for reproducibility / archaeology.
+- Do not use them for the current `evaluation2` GT rebuild unless you are intentionally reproducing the old workflow.
+- If in doubt, start from the Canonical workflow above.
+
 ## Canonical inputs/outputs for current run (v5)
 - Inventory: `logs/issue36_prep/20260208_bench_inventory.json`
 - Exclusions: `logs/issue36_prep/excluded_pages_for_gt_prep.json`


### PR DESCRIPTION
## Related Issue
- Closes #38
- Related #16

## What (What was implemented)
- `tools/verification/gt_preparation/README.md` に `evaluation2` GT再構築ツールの棚卸し表を追加
  - `CURRENT / AUXILIARY / LEGACY` の分類を明記
  - 現行の正規フロー（generate/apply -> prepare_rebuild_eval2 -> gt_relabel_gui）を明示
- `prepare_rebuild_eval2.py` に「現行入口」であることのコメントを追加
- 旧運用ツールに `LEGACY` 明示と現行導線の警告を追加
  - `tools/cnn_classifier/create_comprehensive_gt_config.py`
  - `tools/cnn_classifier/create_gt_gui_config.py`
  - `tools/populate_missing_gt.py`
  - `tools/populate_provisional_gt.py`
- `tools/check_gt_config.py` を `AUXILIARY`（補助チェック）として位置づけ、現行導線メッセージを追加

## Why (Why this change is needed)
- `evaluation2` GT 再構築で使用するツールが複数あり、現行フローと旧フローの区別が付きにくかったため。
- #16 の実作業で確立した手順を、再利用しやすい形で明示し、誤実行を減らすため。

## Scope (In / Out)
**In:**
- ツール役割の棚卸し（現行/補助/legacy分類）
- 正規フローの明示
- 旧ツールへの legacy 表示/導線警告（軽量）

**Out:**
- ツールの物理移動（`tools/legacy/...` への移設）
- 旧ツールの機能改修/統合
- GTデータ内容の変更
- barline検出アルゴリズムの改善

## How to test

### AI-side checks (performed by author / AI)
- `python3 tools/check_gt_config.py` 実行（AUXメッセージ + config診断動作確認）
- `python3 tools/cnn_classifier/create_gt_gui_config.py --help` 実行
- `python3 tools/cnn_classifier/create_comprehensive_gt_config.py --help` 実行
- 構文チェック（書き込み不要）: `ast.parse` で変更した6スクリプトを検証
- `make format` : pass
- `make lint` : pass

### Human-side checks (to be performed locally)
- `tools/verification/gt_preparation/README.md` の棚卸し表を確認し、現行/legacyの区別が明確か確認
- `python3 tools/populate_missing_gt.py` / `python3 tools/populate_provisional_gt.py` 実行時に legacy 警告が表示されることを確認（必要な場合のみ）

## Notes / Implementation details
- #38 の「legacy側に誤実行防止のガード」は、まず最小実装としてコメント + 実行時警告で対応
- 物理移動（`tools/legacy/...`）は今回は行っていないが、運用上の迷いを減らす要件は満たす構成
- #16 側ではすでに `prepare_rebuild_eval2.py` + `gt_relabel_gui` ベースで GT再構築を完了済み

## Screenshots / Logs (optional)
- なし（ドキュメント/軽量メッセージ中心の変更）

## Checklist
- [x] 対象 Issue の Goal / Acceptance Criteria をすべて満たしている
- [x] Issue に書かれていない機能を先取りしていない
- [x] 入出力仕様（パス・ファイル名）が Issue と一致している
- [x] エラー時のログが分かりやすい
- [x] 依存追加が最小限である
- [x] README / ドキュメント更新の要否を確認した
