### PR TITLE
Issue #39: staff_mask由来のband細切れ化を五線帯統合で改善

### DIFF
--- a/src/pipeline/probe_detector/bands.py
+++ b/src/pipeline/probe_detector/bands.py
@@ -87,6 +87,8 @@ def staff_bands_from_mask(
     if len(segments) <= 1:
         return segments
 
+    h, w = mask.shape[:2]
+
     # Second pass: if the mask looks line-like (thin staff-line segments), merge
     # adjacent segments into full staff-region bands. This prevents severe
     # fragmentation when `staff_mask` is actually a line mask (e.g. debug_3_staff).
@@ -105,24 +107,63 @@ def staff_bands_from_mask(
     # Region masks already form thick bands. We only apply the merge heuristic
     # when the mask looks like a stack of many thin/medium line segments
     # (typical for debug_3_staff outputs), not pre-merged staff regions.
-    line_like = len(segments) >= 10 and med_h <= 12.0 and med_gap <= 20.0
+    # Resized debug staff masks can thicken line segments (e.g. ~15 px median)
+    # while still behaving as line-like masks.
+    line_like = len(segments) >= 5 and med_h <= 20.0 and med_gap <= 20.0
     if not line_like:
         return segments
 
     merge_gap = max(gap_tolerance + 1, int(round(med_gap * 1.8)))
+    # Segment metadata is used to drop non-staff horizontal fragments after merging.
+    seg_meta = []
+    for y1, y2 in segments:
+        band = mask[y1 : y2 + 1, :]
+        xs = np.where(band.sum(axis=0) > 0)[0]
+        if xs.size == 0:
+            x1 = x2 = 0
+            width = 0
+        else:
+            x1 = int(xs.min())
+            x2 = int(xs.max())
+            width = int(x2 - x1 + 1)
+        seg_meta.append({"y1": y1, "y2": y2, "x1": x1, "x2": x2, "w": width})
+
     merged: List[Tuple[int, int]] = []
-    start, end = segments[0]
-    for next_start, next_end in segments[1:]:
-        gap = next_start - end - 1
+    current_group = [seg_meta[0]]
+    for next_seg in seg_meta[1:]:
+        gap = next_seg["y1"] - current_group[-1]["y2"] - 1
         if gap <= merge_gap:
-            end = next_end
+            current_group.append(next_seg)
             continue
-        if end - start + 1 >= min_height:
-            merged.append((start, end))
-        start, end = next_start, next_end
-    if end - start + 1 >= min_height:
-        merged.append((start, end))
+
+        _append_if_staff_like(current_group, merged, min_height=min_height, image_w=w)
+        current_group = [next_seg]
+
+    _append_if_staff_like(current_group, merged, min_height=min_height, image_w=w)
     return merged
+
+
+def _append_if_staff_like(
+    group: List[dict[str, int]],
+    out: List[Tuple[int, int]],
+    *,
+    min_height: int,
+    image_w: int,
+) -> None:
+    if not group:
+        return
+    # Require multiple horizontally long lines to avoid treating random
+    # non-staff horizontal fragments as staff bands.
+    line_count = len(group)
+    long_line_thresh = max(40, int(round(image_w * 0.30)))
+    long_line_count = sum(1 for seg in group if seg["w"] >= long_line_thresh)
+    if line_count < 4 or long_line_count < 3:
+        return
+
+    y1 = int(group[0]["y1"])
+    y2 = int(group[-1]["y2"])
+    if y2 - y1 + 1 >= min_height:
+        out.append((y1, y2))
 
 
 def scan_staff_band_from_ink(

--- a/src/pipeline/probe_detector/bands.py
+++ b/src/pipeline/probe_detector/bands.py
@@ -68,7 +68,9 @@ def staff_bands_from_mask(
     rows = np.where(mask.sum(axis=1) > 0)[0]
     if rows.size == 0:
         return []
-    bands: List[Tuple[int, int]] = []
+
+    # First pass: keep the original row-segment extraction behavior.
+    segments: List[Tuple[int, int]] = []
     start = int(rows[0])
     prev = int(rows[0])
     for y in rows[1:]:
@@ -76,12 +78,51 @@ def staff_bands_from_mask(
             prev = int(y)
             continue
         if prev - start + 1 >= min_height:
-            bands.append((start, prev))
+            segments.append((start, prev))
         start = int(y)
         prev = int(y)
     if prev - start + 1 >= min_height:
-        bands.append((start, prev))
-    return bands
+        segments.append((start, prev))
+
+    if len(segments) <= 1:
+        return segments
+
+    # Second pass: if the mask looks line-like (thin staff-line segments), merge
+    # adjacent segments into full staff-region bands. This prevents severe
+    # fragmentation when `staff_mask` is actually a line mask (e.g. debug_3_staff).
+    heights = np.array([y2 - y1 + 1 for y1, y2 in segments], dtype=np.float32)
+    gaps = np.array(
+        [segments[i + 1][0] - segments[i][1] - 1 for i in range(len(segments) - 1)],
+        dtype=np.float32,
+    )
+    positive_gaps = gaps[gaps > 0]
+    if positive_gaps.size == 0:
+        return segments
+
+    med_h = float(np.median(heights))
+    med_gap = float(np.median(positive_gaps))
+
+    # Region masks already form thick bands. We only apply the merge heuristic
+    # when the mask looks like a stack of many thin/medium line segments
+    # (typical for debug_3_staff outputs), not pre-merged staff regions.
+    line_like = len(segments) >= 10 and med_h <= 12.0 and med_gap <= 20.0
+    if not line_like:
+        return segments
+
+    merge_gap = max(gap_tolerance + 1, int(round(med_gap * 1.8)))
+    merged: List[Tuple[int, int]] = []
+    start, end = segments[0]
+    for next_start, next_end in segments[1:]:
+        gap = next_start - end - 1
+        if gap <= merge_gap:
+            end = next_end
+            continue
+        if end - start + 1 >= min_height:
+            merged.append((start, end))
+        start, end = next_start, next_end
+    if end - start + 1 >= min_height:
+        merged.append((start, end))
+    return merged
 
 
 def scan_staff_band_from_ink(

--- a/src/pipeline/probe_detector/bands.py
+++ b/src/pipeline/probe_detector/bands.py
@@ -107,9 +107,13 @@ def staff_bands_from_mask(
     # Region masks already form thick bands. We only apply the merge heuristic
     # when the mask looks like a stack of many thin/medium line segments
     # (typical for debug_3_staff outputs), not pre-merged staff regions.
-    # Resized debug staff masks can thicken line segments (e.g. ~15 px median)
-    # while still behaving as line-like masks.
-    line_like = len(segments) >= 5 and med_h <= 20.0 and med_gap <= 20.0
+    #
+    # Use a staff-step proxy from the mask itself (median row gap) instead of
+    # fixed pixel thresholds so the heuristic scales with resolution.
+    staff_step_proxy = max(1.0, med_gap)
+    line_like = (
+        len(segments) >= 5 and med_h <= (3.0 * staff_step_proxy) and med_gap <= (0.05 * float(h))
+    )
     if not line_like:
         return segments
 
@@ -155,7 +159,7 @@ def _append_if_staff_like(
     # Require multiple horizontally long lines to avoid treating random
     # non-staff horizontal fragments as staff bands.
     line_count = len(group)
-    long_line_thresh = max(40, int(round(image_w * 0.30)))
+    long_line_thresh = int(round(image_w * 0.30))
     long_line_count = sum(1 for seg in group if seg["w"] >= long_line_thresh)
     if line_count < 4 or long_line_count < 3:
         return

--- a/tests/test_probe_bands.py
+++ b/tests/test_probe_bands.py
@@ -1,0 +1,33 @@
+import unittest
+
+import numpy as np
+
+from src.pipeline.probe_detector.bands import staff_bands_from_mask
+
+
+class TestStaffBandsFromMask(unittest.TestCase):
+    def test_line_like_staff_mask_segments_are_merged_into_staff_bands(self):
+        mask = np.zeros((200, 50), dtype=np.uint8)
+
+        # Two staves represented as five thin horizontal lines each.
+        for y in (10, 20, 30, 40, 50):
+            mask[y : y + 1, 5:45] = 1
+        for y in (110, 120, 130, 140, 150):
+            mask[y : y + 1, 5:45] = 1
+
+        bands = staff_bands_from_mask(mask)
+
+        self.assertEqual(bands, [(10, 50), (110, 150)])
+
+    def test_region_like_staff_mask_is_not_over_merged(self):
+        mask = np.zeros((220, 60), dtype=np.uint8)
+        mask[20:65, 5:55] = 1
+        mask[120:170, 5:55] = 1
+
+        bands = staff_bands_from_mask(mask)
+
+        self.assertEqual(bands, [(20, 64), (120, 169)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_probe_bands.py
+++ b/tests/test_probe_bands.py
@@ -28,6 +28,21 @@ class TestStaffBandsFromMask(unittest.TestCase):
 
         self.assertEqual(bands, [(20, 64), (120, 169)])
 
+    def test_line_like_short_nonstaff_fragments_are_filtered_out(self):
+        mask = np.zeros((220, 120), dtype=np.uint8)
+
+        # One staff-like group (5 long lines).
+        for y in (20, 30, 40, 50, 60):
+            mask[y : y + 1, 10:110] = 1
+
+        # Non-staff short horizontal fragments (should not become a staff band).
+        for y in (140, 150):
+            mask[y : y + 1, 15:35] = 1
+
+        bands = staff_bands_from_mask(mask)
+
+        self.assertEqual(bands, [(20, 60)])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/verification/gt_preparation/README.md
+++ b/tools/verification/gt_preparation/README.md
@@ -51,6 +51,47 @@ Policy for legacy scripts:
 - Do not use them for the current `evaluation2` GT rebuild unless you are intentionally reproducing the old workflow.
 - If in doubt, start from the Canonical workflow above.
 
+## staff_mask band normalization (Issue #39)
+Problem:
+- `band_source=staff_mask` could over-fragment `*_debug_3_staff.png` into many thin row segments
+  (line-mask-like behavior), causing page-dependent candidate instability.
+
+Implementation (src):
+- `src/pipeline/probe_detector/bands.py::staff_bands_from_mask`
+  - Keep original row-segment extraction as first pass.
+  - Detect line-like staff masks (many thin/medium segments).
+  - Merge nearby segments using a gap threshold derived from the median inter-segment gap,
+    producing staff-region bands instead of per-line fragments.
+- `band_source=row_stats` path is unchanged.
+
+Lightweight verification artifacts (2026-02-22):
+- Band overlay compare (legacy=red, new=green):
+  - `logs/issue39_staff_mask/band_overlay_compare_20260222/<score>/<page>/band_overlay_legacy_red_new_green.png`
+- Band count summary:
+  - `logs/issue39_staff_mask/band_overlay_compare_20260222/summary.json`
+- Probe subset compare (staff_mask before/after + row_stats regression check):
+  - `logs/issue39_staff_mask/20260222_staff_mask_probe_subset_compare.json`
+
+Representative band-count improvements (from `summary.json`):
+- `Va_Prokofiev_Symphony1/page_006`: `97 -> 15`
+- `Sibelius-Violin_Concerto-Viola/page_004`: `84 -> 20`
+- `Shostakovich-Sym5-Va/page_005`: `46 -> 9`
+- `Va_Prokofiev_Symphony1/page_001`: `77 -> 16`
+
+Verification notes:
+- `row_stats` regression spot-check (`Va_Prokofiev_Symphony1/page_006`) remained identical
+  in generated/final candidate counts.
+- Probe subset compare (`logs/issue39_staff_mask/20260222_staff_mask_probe_subset_compare.json`)
+  includes `suggest_candidate_drops` keep/drop counts:
+  - `Shostakovich-Sym5-Va/page_005` improved from
+    `generated/final/keep = 1730/30/30` to `218/225/185`
+    (legacy staff-band fragmentation was starving valid candidates after filtering).
+  - Some pages remain numerically unchanged with the tested v13-like probe config
+    (expected if later probe thresholds/rescues dominate candidate count).
+- `tests/test_probe_bands.py` covers:
+  - line-like mask -> merged staff bands
+  - region-like mask -> no over-merge
+
 ## Canonical inputs/outputs for current run (v5)
 - Inventory: `logs/issue36_prep/20260208_bench_inventory.json`
 - Exclusions: `logs/issue36_prep/excluded_pages_for_gt_prep.json`

--- a/tools/verification/gt_preparation/README.md
+++ b/tools/verification/gt_preparation/README.md
@@ -73,10 +73,10 @@ Lightweight verification artifacts (2026-02-22):
   - `logs/issue39_staff_mask/20260222_staff_mask_probe_subset_compare.json`
 
 Representative band-count improvements (from `summary.json`):
-- `Va_Prokofiev_Symphony1/page_006`: `97 -> 15`
-- `Sibelius-Violin_Concerto-Viola/page_004`: `84 -> 20`
-- `Shostakovich-Sym5-Va/page_005`: `46 -> 9`
-- `Va_Prokofiev_Symphony1/page_001`: `77 -> 16`
+- `Va_Prokofiev_Symphony1/page_006`: `97 -> 13`
+- `Sibelius-Violin_Concerto-Viola/page_004`: `84 -> 11`
+- `Shostakovich-Sym5-Va/page_005`: `46 -> 8`
+- `Va_Prokofiev_Symphony1/page_001`: `77 -> 12`
 
 Verification notes:
 - `row_stats` regression spot-check (`Va_Prokofiev_Symphony1/page_006`) remained identical
@@ -84,13 +84,14 @@ Verification notes:
 - Probe subset compare (`logs/issue39_staff_mask/20260222_staff_mask_probe_subset_compare.json`)
   includes `suggest_candidate_drops` keep/drop counts:
   - `Shostakovich-Sym5-Va/page_005` improved from
-    `generated/final/keep = 1730/30/30` to `218/225/185`
+    `generated/final/keep = 1730/30/30` to `195/225/178`
     (legacy staff-band fragmentation was starving valid candidates after filtering).
-  - Some pages remain numerically unchanged with the tested v13-like probe config
-    (expected if later probe thresholds/rescues dominate candidate count).
+  - Other representative pages also improved after the final staff-like filtering + resized-mask tolerance fix
+    (e.g. `Va_Prokofiev_Symphony1/page_006`: `legacy_keep=120 -> new_keep=251`).
 - `tests/test_probe_bands.py` covers:
   - line-like mask -> merged staff bands
   - region-like mask -> no over-merge
+  - short non-staff horizontal fragments -> filtered out
 
 ## Canonical inputs/outputs for current run (v5)
 - Inventory: `logs/issue36_prep/20260208_bench_inventory.json`


### PR DESCRIPTION
## Related Issue
- Closes #39

## What (What was implemented)
- `src/pipeline/probe_detector/bands.py` の `staff_bands_from_mask()` を2段階化
  - 1st pass: 従来どおり row segment を抽出
  - 2nd pass: line-like な `staff_mask`（`debug_3_staff` 相当）を検出した場合、隣接 segment を staff帯として統合
- `band_source=row_stats` 経路は変更なし（非破壊）
- `tests/test_probe_bands.py` を追加
  - line-like mask の統合
  - region-like mask の非過剰マージ
- `tools/verification/gt_preparation/README.md` に #39 の実装概要・検証ログ・代表結果を追記

## Why (Why this change is needed)
- `band_source=staff_mask` が `*_debug_3_staff.png`（線分マスク寄り）をそのまま band 化すると、五線ごとの細切れ segment になり、ページ依存の候補過多/過少を引き起こしていたため。

## Scope (In / Out)
**In:**
- `staff_mask` 起点 band 抽出の正規化（五線帯への統合）
- 代表ページでの before/after 比較（band数・probe subset・filter keep差分）
- `row_stats` 経路の非破壊確認（spot-check）
- README 更新

**Out:**
- CNN フィルタ閾値再設計
- `row_stats` 経路のロジック変更
- measure numbering / GTラベル仕様変更

## How to test

### AI-side checks (performed by author / AI)
- `. .venv_pdf/bin/activate && python3 -m unittest tests.test_probe_bands -v` : pass
- `make format` : pass
- `make lint` : pass
- 代表ページ band compare 生成:
  - `logs/issue39_staff_mask/band_overlay_compare_20260222/summary.json`
- 代表ページ probe subset compare + filter keep/drop compare:
  - `logs/issue39_staff_mask/20260222_staff_mask_probe_subset_compare.json`
- `row_stats` regression spot-check:
  - `Va_Prokofiev_Symphony1/page_006` で generated/final/keep が完全一致（README に記録）

### Human-side checks (to be performed locally)
- `logs/issue39_staff_mask/band_overlay_compare_20260222/*/*/band_overlay_legacy_red_new_green.png` を確認
  - legacy(赤) の細切れ band が new(緑) で staff帯に統合されていること
- `logs/issue39_staff_mask/20260222_staff_mask_probe_subset_compare.json` を確認
  - `Shostakovich-Sym5-Va/page_005` などで `keep` が改善していること
- 必要なら `generate_probe_candidates_from_inventory.py --band-source staff_mask` を代表ページで再実行して候補数の偏り改善を追加確認

## Notes / Implementation details
- line-like 判定は実測ベースの保守的ヒューリスティック（segment数・segment高さ中央値・gap中央値）
- merge gap は median inter-segment gap から動的に決定
- `staff_mask` が既に帯領域マスクの場合は merge をスキップする設計（過剰マージ回避）

## Screenshots / Logs (optional)
- `logs/issue39_staff_mask/band_overlay_compare_20260222/summary.json`
- `logs/issue39_staff_mask/20260222_staff_mask_probe_subset_compare.json`

## Checklist
- [x] 対象 Issue の Goal / Acceptance Criteria をすべて満たしている
- [x] Issue に書かれていない機能を先取りしていない
- [x] 入出力仕様（パス・ファイル名）が Issue と一致している
- [x] エラー時のログが分かりやすい
- [x] 依存追加が最小限である
- [x] README / ドキュメント更新の要否を確認した
