### PR TITLE
refactor: cleanup external dependencies and package structure

### DIFF
--- a/Dockerfile.sr_eval
+++ b/Dockerfile.sr_eval
@@ -35,9 +35,9 @@ ENV PATH="/opt/venv_sr/bin:$PATH"
 RUN /opt/venv_sr/bin/python -m ensurepip --upgrade && \
     /opt/venv_sr/bin/python -m pip install --no-cache-dir --upgrade pip setuptools wheel
 
-# Install dependencies (realesrgan requirements + ultralytics)
+# Install dependencies (realesrgan + ultralytics)
 # Note: uv will resolve compatible versions.
-RUN uv pip install -r external/realesrgan/requirements.txt ultralytics
+RUN uv pip install -e ./external/realesrgan ultralytics
 
 # Apply basicsr patch for torchvision compatibility
 # The path inside the venv depends on the Python version. For Python 3.11, it's lib/python3.11/site-packages
@@ -45,7 +45,7 @@ RUN uv pip install -r external/realesrgan/requirements.txt ultralytics
 RUN sed -i 's/from torchvision.transforms.functional_tensor import rgb_to_grayscale/from torchvision.transforms.functional import rgb_to_grayscale/g' /opt/venv_sr/lib/python3.11/site-packages/basicsr/data/degradations.py
 
 # Install homr (and its runtime deps) and pymupdf into the same venv so SR and homr execution share one environment.
-RUN uv pip install ./external/homr pymupdf
+RUN uv pip install -e ./external/homr pymupdf
 
 # Prefer GPU onnxruntime for performance parity with `homr_eval_gpu`.
 RUN /opt/venv_sr/bin/python -m pip uninstall -y onnxruntime && \

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean-artifacts: ## Remove all logs from the artifacts directory
 run-smoke-sr: ## Run smoke test inside sr_eval_gpu container (requires running container)
 	@mkdir -p artifacts
 	@echo "Running smoke test..."
-	@docker exec -w /workspace -e PYTHONPATH=/workspace:/workspace/external/homr sr_eval_gpu \
+	@docker exec -w /workspace -e PYTHONPATH=/workspace sr_eval_gpu \
 		/opt/venv_sr/bin/python src/pipeline/main.py --config "configs/smoke_test.yaml" > artifacts/smoke_test.log 2>&1 || \
 		(EXIT_CODE=$$?; echo "Smoke test failed with exit code $$EXIT_CODE. See artifacts/smoke_test.log"; exit $$EXIT_CODE)
 	@echo "Smoke test complete successfully. See artifacts/smoke_test.log"
@@ -26,7 +26,7 @@ run-pipeline: ## Run the pipeline with a custom config (usage: make run-pipeline
 	@mkdir -p artifacts
 	@LOG_FILE="artifacts/$$(basename "$(CONFIG)" .yaml)_$$(date +%Y%m%d_%H%M%S).log"; \
 	echo "Running pipeline with $(CONFIG). Logging to $$LOG_FILE..."; \
-	docker exec -w /workspace -e PYTHONPATH=/workspace:/workspace/external/homr sr_eval_gpu \
+	docker exec -w /workspace -e PYTHONPATH=/workspace sr_eval_gpu \
 		/opt/venv_sr/bin/python src/pipeline/main.py --config "$(CONFIG)" --skip-existing > "$$LOG_FILE" 2>&1 || \
 		(EXIT_CODE=$$?; echo "Pipeline failed with exit code $$EXIT_CODE. See $$LOG_FILE"; exit $$EXIT_CODE); \
 	echo "Pipeline execution finished successfully. See $$LOG_FILE"

--- a/src/common/preprocessing.py
+++ b/src/common/preprocessing.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from typing import Any, Optional
 
 import cv2
@@ -130,20 +129,14 @@ def apply_advanced_sr(
         Upscaled image (if upsampler was provided) OR Tuple[Upscaled image, upsampler].
         For backward compatibility, it returns just the image if upsampler was provided.
     """
-    # Add the cloned repo to the path to ensure local source is used
     realesrgan_path = os.path.abspath(os.path.join(__file__, "../../..", "external", "realesrgan"))
-    if realesrgan_path not in sys.path:
-        sys.path.insert(0, realesrgan_path)
-
     try:
         import torch
         from basicsr.archs.rrdbnet_arch import RRDBNet
         from realesrgan import RealESRGANer
     except ImportError as e:
-        print(f"Error importing Real-ESRGAN dependencies from local source: {e}")
-        print(
-            "Please ensure you have cloned the repository to 'external/realesrgan' and installed its requirements."
-        )
+        print(f"Error importing Real-ESRGAN dependencies: {e}")
+        print("Please ensure you have installed the realesrgan package.")
         return image, upsampler
 
     # Check device

--- a/src/homr_eval_scripts/homr_evaluator.py
+++ b/src/homr_eval_scripts/homr_evaluator.py
@@ -43,10 +43,6 @@ if str(SRC_ROOT) in sys.path:
     sys.path.remove(str(SRC_ROOT))
 sys.path.insert(0, str(SRC_ROOT))
 
-if str(HOMR_REPO) in sys.path:
-    sys.path.remove(str(HOMR_REPO))
-sys.path.insert(0, str(HOMR_REPO))
-
 import logging
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -450,7 +446,9 @@ def sanitise_images(images: Iterable[str]) -> List[Path]:
 def autocrop_bounds(image: np.ndarray) -> Tuple[Tuple[int, int, int, int], bool]:
     gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
     hist = cv2.calcHist([image], [0], None, [256], [0, 256])
-    dominant_color_gray_scale = int(max(enumerate(hist), key=lambda x: float(x[1]))[0])
+    dominant_color_gray_scale = int(
+        max(enumerate(hist), key=lambda x: float(x[1].item() if hasattr(x[1], "item") else x[1]))[0]
+    )
     threshold_value = max(dominant_color_gray_scale - 30, 0)
     thresh = cv2.threshold(gray, threshold_value, 255, cv2.THRESH_BINARY)[1]
 

--- a/src/pipeline/detection.py
+++ b/src/pipeline/detection.py
@@ -149,7 +149,9 @@ def _run_hybrid_detection_in_process(
     env = os.environ.copy()
     current_pythonpath = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = (
-        f"{PROJECT_ROOT}:{current_pythonpath}" if current_pythonpath else str(PROJECT_ROOT)
+        f"{PROJECT_ROOT}{os.pathsep}{current_pythonpath}"
+        if current_pythonpath
+        else str(PROJECT_ROOT)
     )
 
     baseline_output = hybrid_output_dir / "baseline"

--- a/src/pipeline/detection.py
+++ b/src/pipeline/detection.py
@@ -144,11 +144,12 @@ def _run_hybrid_detection_in_process(
                 python_cmd = [os.environ.get("PIPELINE_PYTHON", sys.executable)]
                 break
 
-    # homr_evaluator requires PYTHONPATH to include src and external/homr
+    # homr_evaluator requires PYTHONPATH to include src
     # We pass it via environment variables in subprocess.run
     env = os.environ.copy()
-    env["PYTHONPATH"] = os.pathsep.join(
-        [str(PROJECT_ROOT), str(PROJECT_ROOT / "external" / "homr"), env.get("PYTHONPATH", "")]
+    current_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{PROJECT_ROOT}:{current_pythonpath}" if current_pythonpath else str(PROJECT_ROOT)
     )
 
     baseline_output = hybrid_output_dir / "baseline"

--- a/tools/add_measure_numbers.py
+++ b/tools/add_measure_numbers.py
@@ -90,7 +90,11 @@ def render_overlay(score: Score, image_path: Path, output_path: Path):
                     if getattr(bar, "is_ghost", False):
                         color = (255, 0, 255)  # Magenta for ghost
                     cv2.rectangle(
-                        overlay, (int(bar.bbox.x1), int(bar.bbox.y1)), (int(bar.bbox.x2), int(bar.bbox.y2)), color, 2
+                        overlay,
+                        (int(bar.bbox.x1), int(bar.bbox.y1)),
+                        (int(bar.bbox.x2), int(bar.bbox.y2)),
+                        color,
+                        2,
                     )
 
     cv2.imwrite(str(output_path), overlay)


### PR DESCRIPTION
## Related Issue
- Closes #26

## What (What was implemented)
- **動的なパス解決の排除**:
    - `src/pipeline/detection.py` および `src/homr_eval_scripts/homr_evaluator.py` から `external/homr` を `sys.path` や `PYTHONPATH` に手動で追加する処理を削除しました。
    - `src/common/preprocessing.py` から `external/realesrgan` への `sys.path.insert` を削除しました。
    - `Makefile` の `PYTHONPATH` 設定を `/workspace` のみに簡略化しました。
- **パッケージ管理の適正化**:
    - `Dockerfile.sr_eval` を更新し、`external/homr` および `external/realesrgan` を編集可能モード (`pip install -e`) でインストールするように変更しました。
- **互換性修正**:
    - `external/homr/homr/autocrop.py` および `src/homr_eval_scripts/homr_evaluator.py` において、NumPy 2.0 以降で発生していたスカラー変換の型エラーを修正しました。
    - `external/homr/pyproject.toml` で `opencv-python-headless` のバージョンを固定し、最新版での不具合を回避しました。

## Why (Why this change is needed)
- `sys.path` 操作による動的なパス解決は、IDEの補完や静的解析を妨げ、実行時の依存関係管理を不透明にするため。
- 今後のモデル永続化（Epic #13）に向けて、安定したインポート構造が必要なため。
- NumPy 2.0 環境下でのパイプライン実行エラーを解消するため。

## Scope (In / Out)
**In:**
- `src/pipeline/detection.py`
- `src/homr_eval_scripts/homr_evaluator.py`
- `src/common/preprocessing.py`
- `Makefile`
- `Dockerfile.sr_eval`
- `external/homr/pyproject.toml`
- `external/homr/homr/autocrop.py`

**Out:**
- `homr` リポジトリ自体の構造変更（サブモジュールとしての扱いを維持）。

## How to test

### AI-side checks (performed by author / AI)
- `make test`: 全テストパスを確認。
- `make run-smoke-sr`: `sr_eval_gpu` コンテナ内での実行を確認。
- `make run-pipeline CONFIG=configs/evaluation2_sr_x2.yaml`: PR #77 の成果である SR x2 モードでの動作と精度の維持（page_001 で 92 barlines 検出）を確認。
- `make run-pipeline CONFIG=configs/evaluation2_bypass_sr.yaml`: SR Bypass モードでの動作と精度の維持（page_001 で 82 barlines 検出）を確認。

### Human-side checks (to be performed locally)
- コンテナを再ビルド後、`make run-smoke-sr` が正常に終了することを確認してください。

## Notes / Implementation details
- パイプライン実行時に `src` を `PYTHONPATH` に含める必要があるため、`detection.py` での最小限の `PYTHONPATH` 設定は維持しています。

## Checklist
- [x] 対象 Issue の Goal / Acceptance Criteria をすべて満たしている
- [x] Issue に書かれていない機能を先取りしていない
- [x] 入出力仕様（パス・ファイル名）が Issue と一致している
- [x] エラー時のログが分かりやすい
- [x] 依存追加が最小限である
- [x] README / ドキュメント更新の要否を確認した
