### PR TITLE
[Fix] PR #102 のレビュー指摘対応と整合性チェックの強化

### DIFF
--- a/tools/check_repo_consistency.py
+++ b/tools/check_repo_consistency.py
@@ -11,12 +11,7 @@ import yaml
 # --- Configuration ---
 MANIFEST_PATH = Path("docs/MANIFEST.md")
 # Scan these directories for untracked (orphan) files
-CORE_DIRS = [
-    "configs",
-    "src/pipeline",
-    "src/measure_numbering",
-    "tools"
-]
+CORE_DIRS = ["configs", "src/pipeline", "src/measure_numbering", "tools"]
 
 
 def get_git_timestamp(path: Path) -> int:
@@ -37,15 +32,13 @@ def extract_paths_from_manifest(manifest_path: Path) -> list[str]:
     # A simpler regex to find any non-whitespace string in backticks, then filter.
     # This is more robust than a complex regex trying to validate paths.
     matches = re.findall(r"`([^`\s]+)`", content)
-    paths = set()
-    for p in matches:
-        if "(Container)" in p:
-            continue
-        # Basic cleaning: remove trailing punctuation if any
-        p = p.strip(".,;:()")
-        # Heuristic to filter out non-path-like strings (e.g. single words without extension)
-        if "/" in p or "." in p:
-            paths.add(p)
+
+    # Filter out container placeholders and clean paths.
+    path_candidates = (p.strip(".,;:()") for p in matches if "(Container)" not in p)
+
+    # Heuristic to filter out non-path-like strings (e.g. single words without extension).
+    paths = {p for p in path_candidates if "/" in p or "." in p}
+
     return sorted(list(paths))
 
 
@@ -56,11 +49,11 @@ def check_consistency(stale_days: int):
     paths = extract_paths_from_manifest(MANIFEST_PATH)
     if not paths:
         print(f"[WARN] No paths extracted from {MANIFEST_PATH} or file missing.")
-    
+
     for p_str in paths:
         p = Path(p_str)
         is_ignored = any(part in ["datasets", "logs", "external", "models"] for part in p.parts)
-        
+
         if p.exists():
             print(f"[OK]       {p_str}")
         else:
@@ -102,35 +95,39 @@ def check_consistency(stale_days: int):
     print("\n--- 4. Orphan Asset Check (Untracked Mainline Candidates) ---")
     norm_tracked = {str(Path(p)) for p in paths}
     found_any_orphan = False
-    
+
     for core_dir in CORE_DIRS:
         d = Path(core_dir)
         if not d.exists():
             continue
-        
+
         # Collect all files recursively
         for f in d.rglob("*"):
             if f.is_dir() or "__pycache__" in str(f) or f.name == "__init__.py":
                 continue
-            
+
             f_str = str(f)
             if f_str not in norm_tracked:
                 ts = get_git_timestamp(f)
                 dt = datetime.fromtimestamp(ts).date() if ts else "No history"
                 print(f"[UNTRACKED] {f_str:40} (Last updated: {dt})")
                 found_any_orphan = True
-    
+
     if not found_any_orphan:
         print("[OK] All assets in core directories are tracked in MANIFEST.md.")
     else:
-        print("\nNote: [UNTRACKED] files are either legacy, experimental, or missing in MANIFEST.md.")
+        print(
+            "\nNote: [UNTRACKED] files are either legacy, experimental, or missing in MANIFEST.md."
+        )
 
     return all_ok
 
 
 def main():
     parser = argparse.ArgumentParser(description="Check repository consistency.")
-    parser.add_argument("--stale-days", type=int, default=30, help="Days until a document is considered stale.")
+    parser.add_argument(
+        "--stale-days", type=int, default=30, help="Days until a document is considered stale."
+    )
     args = parser.parse_args()
 
     success = check_consistency(args.stale_days)

--- a/tools/check_repo_consistency.py
+++ b/tools/check_repo_consistency.py
@@ -34,17 +34,18 @@ def extract_paths_from_manifest(manifest_path: Path) -> list[str]:
     if not manifest_path.exists():
         return []
     content = manifest_path.read_text()
-    # Simple regex to find paths like src/xxx or configs/xxx.yaml
-    matches = re.findall(r"`([^` ]+/[^` ]+|[^` ]+\.[a-z0-9]+)`|`([^` ]+\.py)`|`([^` ]+\.yaml)`", content)
+    # A simpler regex to find any non-whitespace string in backticks, then filter.
+    # This is more robust than a complex regex trying to validate paths.
+    matches = re.findall(r"`([^`\s]+)`", content)
     paths = set()
-    for match in matches:
-        for p in match:
-            if p:
-                if "(Container)" in p:
-                    continue
-                # Basic cleaning: remove trailing punctuation if any
-                p = p.strip(".,;:()")
-                paths.add(p)
+    for p in matches:
+        if "(Container)" in p:
+            continue
+        # Basic cleaning: remove trailing punctuation if any
+        p = p.strip(".,;:()")
+        # Heuristic to filter out non-path-like strings (e.g. single words without extension)
+        if "/" in p or "." in p:
+            paths.add(p)
     return sorted(list(paths))
 
 


### PR DESCRIPTION
## Related Issue
- Follow-up for #95 (PR #102)

## What (What was implemented)
- `tools/check_repo_consistency.py` の `extract_paths_from_manifest` 関数をリファクタリング。
    - PR #102 のレビュー指摘に基づき、正規表現を簡素化し、Python 側でのフィルタリングに責務を分離。
- `MANIFEST.md` に追跡対象（正本）として、主要なパイプラインモジュールとユーティリティ設定を追加。
- 整合性チェックに「Orphan Asset Check」を追加し、マニフェスト未登録のファイルを可視化。

## Why (Why this change is needed)
- レビューでの指摘（メンテナンス性の向上）に対応するため。
- 新しい正本を作成した際に古いファイルが残っている場合に検知できるようにし、リポジトリの健全性をより高めるため。

## How to test
- `make check-consistency` を実行し、マニフェスト記載資産の存在確認と、未登録資産のリストアップが正常に行われることを確認。

## Checklist
- [x] PR #102 のレビュー指摘に対応した
- [x] `make check-consistency` がパスすることを確認した
- [x] `make lint` をクリアした
