### PR TITLE
tools: add Issue 120 canonical full68 intermediate evaluator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 .PHONY: help lint format
 
+ISSUE120_RESULTS_DIR ?= data/evaluation2/golden_baseline_eval2_bc23deb
+ISSUE120_GT_ROOT ?= data/evaluation2/annotations
+ISSUE120_OUTPUT_DIR ?= logs/issue120_e2e_recovery/latest_full_report
+ISSUE120_SCORE_THRESHOLD ?= 0.1
+ISSUE120_XDIST_THRESHOLD ?= 12.0
+ISSUE120_MEASURE_SUMMARY ?=
+
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
@@ -67,6 +74,21 @@ run-pipeline: ## Run the pipeline with a custom config (usage: make run-pipeline
 		/opt/venv_pipeline/bin/python src/pipeline/main.py --config "$(CONFIG)" --skip-existing > "$$LOG_FILE" 2>&1 || \
 		(EXIT_CODE=$$?; echo "Pipeline failed with exit code $$EXIT_CODE. See $$LOG_FILE"; exit $$EXIT_CODE); \
 	echo "Pipeline execution finished successfully. See $$LOG_FILE"
+
+eval-issue120-full: ## Evaluate Issue #120 canonical full-68 detector intermediates without running the pipeline
+	@mkdir -p "$(ISSUE120_OUTPUT_DIR)"
+	@MEASURE_ARG=""; \
+	if [ -n "$(ISSUE120_MEASURE_SUMMARY)" ]; then \
+		MEASURE_ARG="--measure-summary-json $(ISSUE120_MEASURE_SUMMARY)"; \
+	fi; \
+	PYTHONPATH=. python3 tools/issue120/eval_full68_from_intermediates.py \
+		--results-dir "$(ISSUE120_RESULTS_DIR)" \
+		--gt-root "$(ISSUE120_GT_ROOT)" \
+		--output-dir "$(ISSUE120_OUTPUT_DIR)" \
+		--score-threshold "$(ISSUE120_SCORE_THRESHOLD)" \
+		--xdist-threshold "$(ISSUE120_XDIST_THRESHOLD)" \
+		$$MEASURE_ARG
+
 repo-tree: ## Generate a repository directory overview
 	tree -L 3 -I "artifacts|logs|temp|datasets|.git|__pycache__|.venv*" > artifacts/repo_tree.txt
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ ISSUE120_OUTPUT_DIR ?= logs/issue120_e2e_recovery/latest_full_report
 ISSUE120_SCORE_THRESHOLD ?= 0.1
 ISSUE120_XDIST_THRESHOLD ?= 12.0
 ISSUE120_MEASURE_SUMMARY ?=
+ISSUE120_PROVENANCE_JSON ?=
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -78,8 +79,12 @@ run-pipeline: ## Run the pipeline with a custom config (usage: make run-pipeline
 eval-issue120-full: ## Evaluate Issue #120 canonical full-68 detector intermediates without running the pipeline
 	@mkdir -p "$(ISSUE120_OUTPUT_DIR)"
 	@MEASURE_ARG=""; \
+	PROVENANCE_ARG=""; \
 	if [ -n "$(ISSUE120_MEASURE_SUMMARY)" ]; then \
 		MEASURE_ARG="--measure-summary-json $(ISSUE120_MEASURE_SUMMARY)"; \
+	fi; \
+	if [ -n "$(ISSUE120_PROVENANCE_JSON)" ]; then \
+		PROVENANCE_ARG="--provenance-json $(ISSUE120_PROVENANCE_JSON)"; \
 	fi; \
 	PYTHONPATH=. python3 tools/issue120/eval_full68_from_intermediates.py \
 		--results-dir "$(ISSUE120_RESULTS_DIR)" \
@@ -87,7 +92,11 @@ eval-issue120-full: ## Evaluate Issue #120 canonical full-68 detector intermedia
 		--output-dir "$(ISSUE120_OUTPUT_DIR)" \
 		--score-threshold "$(ISSUE120_SCORE_THRESHOLD)" \
 		--xdist-threshold "$(ISSUE120_XDIST_THRESHOLD)" \
-		$$MEASURE_ARG
+		$$MEASURE_ARG && \
+	PYTHONPATH=. python3 tools/issue120/attach_eval_provenance.py \
+		--output-dir "$(ISSUE120_OUTPUT_DIR)" \
+		--results-dir "$(ISSUE120_RESULTS_DIR)" \
+		$$PROVENANCE_ARG
 
 repo-tree: ## Generate a repository directory overview
 	tree -L 3 -I "artifacts|logs|temp|datasets|.git|__pycache__|.venv*" > artifacts/repo_tree.txt

--- a/docs/ISSUE120_EVALUATION_CONTRACT.md
+++ b/docs/ISSUE120_EVALUATION_CONTRACT.md
@@ -20,6 +20,8 @@ ISSUE120_GT_ROOT=data/evaluation2/annotations
 ISSUE120_OUTPUT_DIR=logs/issue120_e2e_recovery/latest_full_report
 ISSUE120_SCORE_THRESHOLD=0.1
 ISSUE120_XDIST_THRESHOLD=12.0
+ISSUE120_MEASURE_SUMMARY=
+ISSUE120_PROVENANCE_JSON=
 ```
 
 Equivalent direct command:
@@ -31,6 +33,10 @@ PYTHONPATH=. python3 tools/issue120/eval_full68_from_intermediates.py \
   --output-dir logs/issue120_e2e_recovery/latest_full_report \
   --score-threshold 0.1 \
   --xdist-threshold 12.0
+
+PYTHONPATH=. python3 tools/issue120/attach_eval_provenance.py \
+  --output-dir logs/issue120_e2e_recovery/latest_full_report \
+  --results-dir data/evaluation2/golden_baseline_eval2_bc23deb
 ```
 
 ## Evaluated page set
@@ -41,7 +47,7 @@ Use `--allow-partial` only for debugging. Partial results are not canonical.
 
 ## Input contract
 
-The evaluator consumes existing intermediate files.
+The evaluator consumes existing detector intermediate files.
 
 Required per page:
 
@@ -54,6 +60,8 @@ Optional per page:
 ```text
 pipeline2_no_peak_candidates.json
 ```
+
+These files correspond to a detector-stage boundary after candidate generation and CNN scoring. They are not raw OMR, HOMR, OMR-DLN, SR, or hybrid-consensus outputs.
 
 When candidates are available, the evaluator also reports approximate `FN_det` / `FN_cnn` split:
 
@@ -82,6 +90,7 @@ missing_pages.json             # only when required inputs are missing
 detector_metrics.json
 detector_page_metrics.csv
 evaluation_contract.json
+intermediate_provenance.json
 ```
 
 `evaluation_contract.json` is the canonical machine-readable summary for this entrypoint.
@@ -112,6 +121,45 @@ score_threshold=0.1
 
 These defaults intentionally match the previous `verify_golden_baseline.py` contract rather than later ad-hoc restore scripts.
 
+## Provenance contract
+
+The default provenance block records that this is a post-CNN-scoring detector-intermediate evaluation.
+
+Expected upstream stages before this intermediate include:
+
+1. initial OMR/HOMR pass;
+2. optional SR image generation;
+3. OMR/HOMR pass on the SR image;
+4. optional OMR-DLN or other detector outputs used by the run;
+5. hybrid consensus / seed preparation;
+6. probe scan candidate generation;
+7. CNN scoring of candidates.
+
+The evaluator does not prove that those upstream stages were regenerated from the current code. It proves only that the saved post-CNN-scoring intermediates evaluate to the reported detector metrics under the canonical 68-page manifest and matching rule.
+
+To attach a verified local provenance record:
+
+```bash
+make eval-issue120-full \
+  ISSUE120_RESULTS_DIR=logs/path/to/intermediates \
+  ISSUE120_PROVENANCE_JSON=logs/path/to/provenance.json
+```
+
+Recommended provenance JSON fields:
+
+```json
+{
+  "schema_version": "issue120.intermediate_provenance.v1",
+  "status": "verified_local_run",
+  "results_dir": "logs/path/to/intermediates",
+  "evaluated_stage": "post_cnn_scoring_detector_intermediate",
+  "generation_commit": "<commit sha>",
+  "generation_command": "<command or script used to create intermediates>",
+  "source_artifact": "<artifact path or external reference>",
+  "notes": []
+}
+```
+
 ## Measure-count metrics
 
 This PR does not implement full downstream numbering evaluation. If a downstream measure-count run has already produced a summary JSON, attach it with:
@@ -128,13 +176,27 @@ Until a canonical measure-count evaluator exists, detector metrics and measure-c
 
 Full pipeline execution for 68 pages may take tens of minutes or hours and can produce large logs. It is intentionally not part of `make eval-issue120-full`.
 
+The slow stages are expected to be the initial OMR/HOMR processing, SR processing, and the second OMR/HOMR pass over SR output. Hybrid consensus, probe scan, and CNN scoring are comparatively cheaper and can be rerun more often once the slow upstream outputs are available.
+
 Recommended local workflow:
 
-1. Run or recover the intermediate generation workflow locally.
-2. Place or point `ISSUE120_RESULTS_DIR` at the resulting intermediate tree.
-3. Run `make eval-issue120-full ISSUE120_RESULTS_DIR=<path>`.
-4. Commit only source/tool/doc changes, not the generated output tree.
+1. Run or recover the slow upstream OMR/SR/HOMR outputs locally.
+2. Generate or recover the post-CNN-scoring intermediate tree.
+3. Point `ISSUE120_RESULTS_DIR` at that tree.
+4. Run `make eval-issue120-full ISSUE120_RESULTS_DIR=<path>`.
+5. Commit only source/tool/doc changes, not the generated output tree.
 
 ## Historical-best verification
 
-`TP=3580 / FP=0 / FN=1` remains a historical target until reproduced by this command or by a later documented canonical command. A document claim alone is not sufficient.
+The local run below reproduces the detector-intermediate historical target from saved intermediates:
+
+```text
+Pages: 68/68
+Detector: GT=3581 Pred=3597 TP=3580 FP=0 FN=1 FN_det=0 FN_cnn=1 Precision=1.000000 Recall=0.999721
+```
+
+This should be described precisely as:
+
+> The saved post-CNN-scoring detector intermediates under `data/evaluation2/golden_baseline_eval2_bc23deb` reproduce `TP=3580 / FP=0 / FN=1` under the canonical 68-page evaluator.
+
+It should not be described as full pipeline reproduction unless the upstream OMR/SR/HOMR/hybrid/probe/CNN generation path is also regenerated or otherwise proven.

--- a/docs/ISSUE120_EVALUATION_CONTRACT.md
+++ b/docs/ISSUE120_EVALUATION_CONTRACT.md
@@ -1,0 +1,140 @@
+# Issue 120 Evaluation Contract
+
+## Purpose
+
+This document defines the canonical Issue #120 evaluation entrypoint introduced for #134.
+
+The entrypoint intentionally evaluates saved intermediate outputs. It does not run the full pipeline. This prevents long, noisy full-pipeline runs from being confused with lightweight evaluation and makes it explicit when a result is based on a previously generated intermediate tree.
+
+## Canonical command
+
+```bash
+make eval-issue120-full
+```
+
+Default inputs:
+
+```text
+ISSUE120_RESULTS_DIR=data/evaluation2/golden_baseline_eval2_bc23deb
+ISSUE120_GT_ROOT=data/evaluation2/annotations
+ISSUE120_OUTPUT_DIR=logs/issue120_e2e_recovery/latest_full_report
+ISSUE120_SCORE_THRESHOLD=0.1
+ISSUE120_XDIST_THRESHOLD=12.0
+```
+
+Equivalent direct command:
+
+```bash
+PYTHONPATH=. python3 tools/issue120/eval_full68_from_intermediates.py \
+  --results-dir data/evaluation2/golden_baseline_eval2_bc23deb \
+  --gt-root data/evaluation2/annotations \
+  --output-dir logs/issue120_e2e_recovery/latest_full_report \
+  --score-threshold 0.1 \
+  --xdist-threshold 12.0
+```
+
+## Evaluated page set
+
+The command validates the canonical 68-page `evaluation2` subset used by Issue #120. Partial inputs fail by default.
+
+Use `--allow-partial` only for debugging. Partial results are not canonical.
+
+## Input contract
+
+The evaluator consumes existing intermediate files.
+
+Required per page:
+
+```text
+pipeline2_no_peak_scored.json
+```
+
+Optional per page:
+
+```text
+pipeline2_no_peak_candidates.json
+```
+
+When candidates are available, the evaluator also reports approximate `FN_det` / `FN_cnn` split:
+
+- `FN_det`: no matching candidate exists for the missed GT.
+- `FN_cnn`: a matching candidate exists, but the scored prediction did not pass the score threshold.
+
+Accepted result layouts:
+
+```text
+<results-dir>/eval2_<score>_<page>/pipeline2_no_peak_scored.json
+<results-dir>/<score>/<page>/pipeline2_no_peak_scored.json
+<results-dir>/<score>/eval2_<score>_<page>/pipeline2_no_peak_scored.json
+```
+
+The same layouts are used for `pipeline2_no_peak_candidates.json`.
+
+## Output contract
+
+The command writes outputs under `ISSUE120_OUTPUT_DIR`, which must remain ignored by Git.
+
+Generated files:
+
+```text
+manifest.json
+missing_pages.json             # only when required inputs are missing
+detector_metrics.json
+detector_page_metrics.csv
+evaluation_contract.json
+```
+
+`evaluation_contract.json` is the canonical machine-readable summary for this entrypoint.
+
+## Detector metrics
+
+The evaluator reports:
+
+- `TP`
+- `FP`
+- `FN`
+- `FN_det`
+- `FN_cnn`
+- `GT`
+- predicted boxes after threshold
+- candidate count, if candidates are present
+- precision
+- recall
+
+Matching rule defaults:
+
+```text
+rule_name=center_anchor
+vov_threshold=0.5
+xdist_threshold=12.0
+score_threshold=0.1
+```
+
+These defaults intentionally match the previous `verify_golden_baseline.py` contract rather than later ad-hoc restore scripts.
+
+## Measure-count metrics
+
+This PR does not implement full downstream numbering evaluation. If a downstream measure-count run has already produced a summary JSON, attach it with:
+
+```bash
+make eval-issue120-full ISSUE120_MEASURE_SUMMARY=path/to/measure_summary.json
+```
+
+The measure summary is copied into `evaluation_contract.json` under `measure_count_summary`.
+
+Until a canonical measure-count evaluator exists, detector metrics and measure-count metrics must be treated separately.
+
+## Long-running pipeline runs
+
+Full pipeline execution for 68 pages may take tens of minutes or hours and can produce large logs. It is intentionally not part of `make eval-issue120-full`.
+
+Recommended local workflow:
+
+1. Run or recover the intermediate generation workflow locally.
+2. Place or point `ISSUE120_RESULTS_DIR` at the resulting intermediate tree.
+3. Run `make eval-issue120-full ISSUE120_RESULTS_DIR=<path>`.
+4. Commit only source/tool/doc changes, not the generated output tree.
+
+## Historical-best verification
+
+`TP=3580 / FP=0 / FN=1` remains a historical target until reproduced by this command or by a later documented canonical command. A document claim alone is not sufficient.

--- a/tools/issue120/attach_eval_provenance.py
+++ b/tools/issue120/attach_eval_provenance.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Attach intermediate provenance metadata to an Issue #120 evaluation contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def default_provenance(results_dir: str) -> dict[str, Any]:
+    return {
+        "schema_version": "issue120.intermediate_provenance.v1",
+        "status": "default_unverified",
+        "results_dir": results_dir,
+        "evaluated_stage": "post_cnn_scoring_detector_intermediate",
+        "evaluated_files": {
+            "scored": "pipeline2_no_peak_scored.json",
+            "candidates": "pipeline2_no_peak_candidates.json",
+        },
+        "pipeline_stage_boundary": {
+            "included_before_this_intermediate": [
+                "initial OMR/HOMR pass",
+                "optional SR image generation",
+                "OMR/HOMR pass on SR image",
+                "optional OMR-DLN or other detector outputs used by the run",
+                "hybrid consensus / seed preparation",
+                "probe scan candidate generation",
+                "CNN scoring of candidates",
+            ],
+            "not_validated_by_this_evaluation": [
+                "whether the upstream OMR/HOMR/SR intermediates were regenerated from the current code",
+                "whether the seed-generation script matches the current production pipeline",
+                "downstream measure numbering quality unless a measure summary is attached",
+            ],
+        },
+        "generation_command": None,
+        "generation_commit": None,
+        "source_artifact": None,
+        "notes": [
+            "This provenance block was auto-generated because no --provenance-json was supplied.",
+            "Treat detector metrics as a validation of the saved post-CNN scoring intermediates, not as full pipeline reproduction.",
+        ],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory containing evaluation_contract.json.",
+    )
+    parser.add_argument(
+        "--results-dir",
+        required=True,
+        help="Intermediate result root used by the evaluator.",
+    )
+    parser.add_argument(
+        "--provenance-json",
+        type=Path,
+        default=None,
+        help="Optional provenance JSON supplied by the local experiment run.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    output_dir = Path(args.output_dir)
+    contract_path = output_dir / "evaluation_contract.json"
+    if not contract_path.exists():
+        raise SystemExit(f"evaluation_contract.json not found: {contract_path}")
+
+    contract = load_json(contract_path)
+    if args.provenance_json is not None:
+        if not args.provenance_json.exists():
+            raise SystemExit(f"provenance JSON not found: {args.provenance_json}")
+        provenance = load_json(args.provenance_json)
+    else:
+        provenance = default_provenance(args.results_dir)
+
+    contract["intermediate_provenance"] = provenance
+    write_json(contract_path, contract)
+    write_json(output_dir / "intermediate_provenance.json", provenance)
+    print(f"Attached intermediate provenance: {contract_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/issue120/eval_full68_from_intermediates.py
+++ b/tools/issue120/eval_full68_from_intermediates.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""Evaluate Issue #120 full-68 detector outputs from saved intermediates.
+
+This tool intentionally does not run the full pipeline.  It evaluates an existing
+intermediate result tree, validates that all canonical 68 pages are present, and
+writes normalized metrics under an ignored output directory.
+
+Default input layout matches the historical golden baseline tree:
+
+    data/evaluation2/golden_baseline_eval2_bc23deb/
+      eval2_<score>_<page>/pipeline2_no_peak_scored.json
+      eval2_<score>_<page>/pipeline2_no_peak_candidates.json
+
+Alternative common layouts are also accepted:
+
+    <results-dir>/<score>/<page>/pipeline2_no_peak_scored.json
+    <results-dir>/<score>/<page>/<scored-file>
+    <results-dir>/eval2_<score>_<page>/<scored-file>
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.common.barline_evaluation import (  # noqa: E402
+    center_distance_x,
+    greedy_barline_match,
+    is_barline_match,
+)
+
+# Canonical Issue #120 evaluation2 page set: 68 pages.
+# This is the same page selection used by the previous full-restore config generator.
+SCORES: dict[str, list[str]] = {
+    "Shostakovich-Festival_Overture_Va": [
+        "page_001",
+        "page_002",
+        "page_003",
+        "page_004",
+        "page_005",
+        "page_006",
+        "page_007",
+        "page_008",
+        "page_009",
+    ],
+    "Shostakovich-Sym5-Va": [
+        "page_002",
+        "page_003",
+        "page_004",
+        "page_005",
+        "page_006",
+        "page_007",
+        "page_008",
+        "page_009",
+        "page_010",
+        "page_011",
+        "page_012",
+        "page_013",
+        "page_014",
+        "page_015",
+        "page_016",
+        "page_018",
+        "page_019",
+        "page_020",
+        "page_021",
+        "page_022",
+        "page_024",
+        "page_025",
+    ],
+    "Sibelius-Violin_Concerto-Viola": [
+        "page_001",
+        "page_002",
+        "page_003",
+        "page_004",
+        "page_005",
+        "page_006",
+        "page_007",
+        "page_008",
+        "page_009",
+        "page_010",
+    ],
+    "Va_Prokofiev_Symphony1": [
+        "page_001",
+        "page_002",
+        "page_003",
+        "page_004",
+        "page_005",
+        "page_006",
+    ],
+    "Va__Prokofiev_Symphony5": [
+        "page_001",
+        "page_002",
+        "page_003",
+        "page_004",
+        "page_005",
+        "page_007",
+        "page_008",
+        "page_009",
+        "page_010",
+        "page_011",
+        "page_013",
+        "page_014",
+        "page_015",
+        "page_016",
+        "page_017",
+        "page_018",
+        "page_019",
+        "page_020",
+        "page_021",
+        "page_022",
+        "page_023",
+    ],
+}
+
+
+@dataclass(frozen=True)
+class PageRecord:
+    score: str
+    page: str
+
+
+@dataclass
+class PageMetric:
+    score: str
+    page: str
+    gt: int
+    pred: int
+    candidate_count: int | None
+    tp: int
+    fp: int
+    fn: int
+    fn_det: int | None
+    fn_cnn: int | None
+    precision: float | None
+    recall: float | None
+    scored_path: str
+    candidates_path: str | None
+    gt_path: str
+
+
+@dataclass
+class DetectorSummary:
+    page_count: int
+    expected_page_count: int
+    gt: int
+    pred: int
+    candidate_count: int | None
+    tp: int
+    fp: int
+    fn: int
+    fn_det: int | None
+    fn_cnn: int | None
+    precision: float | None
+    recall: float | None
+
+
+@dataclass
+class EvaluationContract:
+    schema_version: str
+    mode: str
+    results_dir: str
+    gt_root: str
+    output_dir: str
+    expected_pages: int
+    evaluated_pages: int
+    missing_pages: list[dict[str, str]]
+    score_threshold: float
+    rule_name: str
+    vov_threshold: float
+    xdist_threshold: float
+    detector_summary: DetectorSummary
+    measure_count_summary: dict[str, Any]
+
+
+def iter_manifest() -> list[PageRecord]:
+    return [PageRecord(score, page) for score, pages in SCORES.items() for page in pages]
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def normalize_box(box: Sequence[Any]) -> tuple[int, int, int, int]:
+    if len(box) < 4:
+        raise ValueError(f"Invalid box: {box!r}")
+    return tuple(int(round(float(v))) for v in box[:4])  # type: ignore[return-value]
+
+
+def boxes_from_gt(payload: Any) -> list[tuple[int, int, int, int]]:
+    boxes: list[tuple[int, int, int, int]] = []
+    if not isinstance(payload, list):
+        raise ValueError("GT payload must be a list")
+    for item in payload:
+        if isinstance(item, list):
+            boxes.append(normalize_box(item))
+        elif isinstance(item, dict):
+            if "barline_location" in item:
+                boxes.append(normalize_box(item["barline_location"]))
+            elif "box" in item:
+                boxes.append(normalize_box(item["box"]))
+            elif "bbox" in item:
+                boxes.append(normalize_box(item["bbox"]))
+    return boxes
+
+
+def boxes_from_scored(payload: Any, *, score_threshold: float) -> list[tuple[int, int, int, int]]:
+    boxes: list[tuple[int, int, int, int]] = []
+    if not isinstance(payload, list):
+        raise ValueError("Scored payload must be a list")
+    for item in payload:
+        if isinstance(item, dict):
+            if float(item.get("score", 0.0)) >= score_threshold and "bbox" in item:
+                boxes.append(normalize_box(item["bbox"]))
+        elif isinstance(item, list):
+            # Filtered-CNN JSONs are sometimes plain box lists.  Treat them as already filtered.
+            boxes.append(normalize_box(item))
+    return boxes
+
+
+def boxes_from_candidates(payload: Any) -> list[tuple[int, int, int, int]]:
+    boxes: list[tuple[int, int, int, int]] = []
+    if not isinstance(payload, list):
+        raise ValueError("Candidates payload must be a list")
+    for item in payload:
+        if isinstance(item, dict) and "bbox" in item:
+            boxes.append(normalize_box(item["bbox"]))
+        elif isinstance(item, list):
+            boxes.append(normalize_box(item))
+    return boxes
+
+
+def find_page_file(
+    root: Path,
+    record: PageRecord,
+    filename: str,
+) -> Path | None:
+    candidates = [
+        root / f"eval2_{record.score}_{record.page}" / filename,
+        root / record.score / record.page / filename,
+        root / record.score / f"eval2_{record.score}_{record.page}" / filename,
+    ]
+    for path in candidates:
+        if path.exists():
+            return path
+    return None
+
+
+def has_candidate_for_gt(
+    candidates: Iterable[tuple[int, int, int, int]],
+    gt: tuple[int, int, int, int],
+    *,
+    rule_name: str,
+    vov_threshold: float,
+    xdist_threshold: float,
+) -> bool:
+    return any(
+        is_barline_match(
+            cand,
+            gt,
+            rule_name=rule_name,
+            vov_threshold=vov_threshold,
+            xdist_threshold=xdist_threshold,
+        )
+        for cand in candidates
+    )
+
+
+def safe_div(num: int, den: int) -> float | None:
+    if den == 0:
+        return None
+    return num / den
+
+
+def read_measure_summary(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {
+            "status": "not_provided",
+            "note": "Detector intermediate evaluation completed. Provide --measure-summary-json after a numbering run to attach downstream measure-count metrics.",
+            "pred_measures": None,
+            "gt_measures": None,
+            "net_delta": None,
+            "abs_delta_sum": None,
+            "delta_pages": None,
+            "precision": None,
+            "recall": None,
+        }
+    if not path.exists():
+        raise FileNotFoundError(f"Measure summary not found: {path}")
+    payload = load_json(path)
+    if not isinstance(payload, dict):
+        raise ValueError("Measure summary JSON must be an object")
+    return {"status": "provided", "path": str(path), **payload}
+
+
+def evaluate(args: argparse.Namespace) -> EvaluationContract:
+    manifest = iter_manifest()
+    results_dir = Path(args.results_dir)
+    gt_root = Path(args.gt_root)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    page_metrics: list[PageMetric] = []
+    missing_pages: list[dict[str, str]] = []
+
+    for record in manifest:
+        gt_path = gt_root / record.score / record.page / "boxes_sorted.json"
+        scored_path = find_page_file(results_dir, record, args.scored_file)
+        candidates_path = find_page_file(results_dir, record, args.candidates_file)
+
+        missing_reasons: list[str] = []
+        if not gt_path.exists():
+            missing_reasons.append(f"missing_gt:{gt_path}")
+        if scored_path is None:
+            missing_reasons.append(f"missing_scored:{args.scored_file}")
+
+        if missing_reasons:
+            missing_pages.append(
+                {"score": record.score, "page": record.page, "reason": ";".join(missing_reasons)}
+            )
+            continue
+
+        assert scored_path is not None
+        gts = boxes_from_gt(load_json(gt_path))
+        preds = boxes_from_scored(load_json(scored_path), score_threshold=args.score_threshold)
+
+        match_result = greedy_barline_match(
+            preds,
+            gts,
+            rule_name=args.rule_name,
+            vov_threshold=args.vov_threshold,
+            xdist_threshold=args.xdist_threshold,
+        )
+
+        candidate_boxes: list[tuple[int, int, int, int]] | None = None
+        fn_det: int | None = None
+        fn_cnn: int | None = None
+        if candidates_path is not None and candidates_path.exists():
+            candidate_boxes = boxes_from_candidates(load_json(candidates_path))
+            fn_det = 0
+            fn_cnn = 0
+            for gt_index in match_result.false_negative_indices:
+                gt = gts[gt_index]
+                if has_candidate_for_gt(
+                    candidate_boxes,
+                    gt,
+                    rule_name=args.rule_name,
+                    vov_threshold=args.vov_threshold,
+                    xdist_threshold=args.xdist_threshold,
+                ):
+                    fn_cnn += 1
+                else:
+                    fn_det += 1
+
+        tp = len(match_result.matches)
+        fp = len(match_result.false_positive_indices)
+        fn = len(match_result.false_negative_indices)
+        page_metrics.append(
+            PageMetric(
+                score=record.score,
+                page=record.page,
+                gt=len(gts),
+                pred=len(preds),
+                candidate_count=len(candidate_boxes) if candidate_boxes is not None else None,
+                tp=tp,
+                fp=fp,
+                fn=fn,
+                fn_det=fn_det,
+                fn_cnn=fn_cnn,
+                precision=safe_div(tp, tp + fp),
+                recall=safe_div(tp, tp + fn),
+                scored_path=str(scored_path),
+                candidates_path=str(candidates_path) if candidates_path else None,
+                gt_path=str(gt_path),
+            )
+        )
+
+    if missing_pages and not args.allow_partial:
+        (output_dir / "missing_pages.json").write_text(
+            json.dumps(missing_pages, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        raise SystemExit(
+            f"Missing {len(missing_pages)} of {len(manifest)} canonical pages. See {output_dir / 'missing_pages.json'}"
+        )
+
+    total_gt = sum(m.gt for m in page_metrics)
+    total_pred = sum(m.pred for m in page_metrics)
+    total_candidates: int | None = None
+    if all(m.candidate_count is not None for m in page_metrics):
+        total_candidates = sum(int(m.candidate_count or 0) for m in page_metrics)
+    total_tp = sum(m.tp for m in page_metrics)
+    total_fp = sum(m.fp for m in page_metrics)
+    total_fn = sum(m.fn for m in page_metrics)
+    total_fn_det: int | None = None
+    total_fn_cnn: int | None = None
+    if all(m.fn_det is not None and m.fn_cnn is not None for m in page_metrics):
+        total_fn_det = sum(int(m.fn_det or 0) for m in page_metrics)
+        total_fn_cnn = sum(int(m.fn_cnn or 0) for m in page_metrics)
+
+    detector_summary = DetectorSummary(
+        page_count=len(page_metrics),
+        expected_page_count=len(manifest),
+        gt=total_gt,
+        pred=total_pred,
+        candidate_count=total_candidates,
+        tp=total_tp,
+        fp=total_fp,
+        fn=total_fn,
+        fn_det=total_fn_det,
+        fn_cnn=total_fn_cnn,
+        precision=safe_div(total_tp, total_tp + total_fp),
+        recall=safe_div(total_tp, total_tp + total_fn),
+    )
+
+    contract = EvaluationContract(
+        schema_version="issue120.full68.v1",
+        mode="intermediate_detector_eval",
+        results_dir=str(results_dir),
+        gt_root=str(gt_root),
+        output_dir=str(output_dir),
+        expected_pages=len(manifest),
+        evaluated_pages=len(page_metrics),
+        missing_pages=missing_pages,
+        score_threshold=args.score_threshold,
+        rule_name=args.rule_name,
+        vov_threshold=args.vov_threshold,
+        xdist_threshold=args.xdist_threshold,
+        detector_summary=detector_summary,
+        measure_count_summary=read_measure_summary(args.measure_summary_json),
+    )
+
+    write_outputs(output_dir, manifest, page_metrics, contract)
+    return contract
+
+
+def write_outputs(
+    output_dir: Path,
+    manifest: list[PageRecord],
+    page_metrics: list[PageMetric],
+    contract: EvaluationContract,
+) -> None:
+    (output_dir / "manifest.json").write_text(
+        json.dumps([asdict(item) for item in manifest], indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    (output_dir / "detector_metrics.json").write_text(
+        json.dumps(asdict(contract.detector_summary), indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    (output_dir / "evaluation_contract.json").write_text(
+        json.dumps(asdict(contract), indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    with (output_dir / "detector_page_metrics.csv").open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(asdict(page_metrics[0]).keys()) if page_metrics else [])
+        if page_metrics:
+            writer.writeheader()
+            for row in page_metrics:
+                writer.writerow(asdict(row))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--results-dir",
+        default="data/evaluation2/golden_baseline_eval2_bc23deb",
+        help="Root directory containing saved scored/candidate intermediates.",
+    )
+    parser.add_argument(
+        "--gt-root",
+        default="data/evaluation2/annotations",
+        help="Root directory containing evaluation2 GT annotations.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="logs/issue120_e2e_recovery/latest_full_report",
+        help="Ignored output directory for normalized metrics.",
+    )
+    parser.add_argument("--scored-file", default="pipeline2_no_peak_scored.json")
+    parser.add_argument("--candidates-file", default="pipeline2_no_peak_candidates.json")
+    parser.add_argument("--score-threshold", type=float, default=0.1)
+    parser.add_argument("--rule-name", default="center_anchor", choices=["center_anchor", "baseline_iou"])
+    parser.add_argument("--vov-threshold", type=float, default=0.5)
+    parser.add_argument("--xdist-threshold", type=float, default=12.0)
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Write partial metrics instead of failing when canonical pages are missing.",
+    )
+    parser.add_argument(
+        "--measure-summary-json",
+        type=Path,
+        default=None,
+        help="Optional downstream measure-count summary JSON to attach to the contract.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    contract = evaluate(args)
+    summary = contract.detector_summary
+    print("Issue #120 full-68 intermediate evaluation")
+    print(f"Pages: {summary.page_count}/{summary.expected_page_count}")
+    print(
+        "Detector: "
+        f"GT={summary.gt} Pred={summary.pred} TP={summary.tp} FP={summary.fp} FN={summary.fn} "
+        f"FN_det={summary.fn_det} FN_cnn={summary.fn_cnn} "
+        f"Precision={summary.precision:.6f if summary.precision is not None else 'n/a'} "
+        f"Recall={summary.recall:.6f if summary.recall is not None else 'n/a'}"
+    )
+    print(f"Wrote: {contract.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/issue120/eval_full68_from_intermediates.py
+++ b/tools/issue120/eval_full68_from_intermediates.py
@@ -333,7 +333,6 @@ def evaluate(args: argparse.Namespace) -> EvaluationContract:
             )
             continue
 
-        assert scored_path is not None
         gts = boxes_from_gt(load_json(gt_path))
         preds = boxes_from_scored(load_json(scored_path), score_threshold=args.score_threshold)
 
@@ -464,9 +463,9 @@ def write_outputs(
         json.dumps(asdict(contract), indent=2, ensure_ascii=False),
         encoding="utf-8",
     )
+    if not page_metrics:
+        return
     with (output_dir / "detector_page_metrics.csv").open("w", newline="", encoding="utf-8") as f:
-        if not page_metrics:
-            return
         writer = csv.DictWriter(f, fieldnames=list(asdict(page_metrics[0]).keys()))
         writer.writeheader()
         for row in page_metrics:

--- a/tools/issue120/eval_full68_from_intermediates.py
+++ b/tools/issue120/eval_full68_from_intermediates.py
@@ -32,7 +32,6 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from src.common.barline_evaluation import (  # noqa: E402
-    center_distance_x,
     greedy_barline_match,
     is_barline_match,
 )
@@ -221,7 +220,7 @@ def boxes_from_scored(payload: Any, *, score_threshold: float) -> list[tuple[int
             if float(item.get("score", 0.0)) >= score_threshold and "bbox" in item:
                 boxes.append(normalize_box(item["bbox"]))
         elif isinstance(item, list):
-            # Filtered-CNN JSONs are sometimes plain box lists.  Treat them as already filtered.
+            # Filtered-CNN JSONs are sometimes plain box lists. Treat them as already filtered.
             boxes.append(normalize_box(item))
     return boxes
 
@@ -278,6 +277,12 @@ def safe_div(num: int, den: int) -> float | None:
     if den == 0:
         return None
     return num / den
+
+
+def format_metric(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.6f}"
 
 
 def read_measure_summary(path: Path | None) -> dict[str, Any]:
@@ -460,11 +465,12 @@ def write_outputs(
         encoding="utf-8",
     )
     with (output_dir / "detector_page_metrics.csv").open("w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=list(asdict(page_metrics[0]).keys()) if page_metrics else [])
-        if page_metrics:
-            writer.writeheader()
-            for row in page_metrics:
-                writer.writerow(asdict(row))
+        if not page_metrics:
+            return
+        writer = csv.DictWriter(f, fieldnames=list(asdict(page_metrics[0]).keys()))
+        writer.writeheader()
+        for row in page_metrics:
+            writer.writerow(asdict(row))
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -514,8 +520,8 @@ def main() -> None:
         "Detector: "
         f"GT={summary.gt} Pred={summary.pred} TP={summary.tp} FP={summary.fp} FN={summary.fn} "
         f"FN_det={summary.fn_det} FN_cnn={summary.fn_cnn} "
-        f"Precision={summary.precision:.6f if summary.precision is not None else 'n/a'} "
-        f"Recall={summary.recall:.6f if summary.recall is not None else 'n/a'}"
+        f"Precision={format_metric(summary.precision)} "
+        f"Recall={format_metric(summary.recall)}"
     )
     print(f"Wrote: {contract.output_dir}")
 


### PR DESCRIPTION
## Related Issue
- Closes #134
- Parent: #120

## What
Adds a canonical Issue #120 full-68 evaluation entrypoint for saved detector intermediates.

This PR intentionally evaluates post-CNN-scoring detector intermediate files. It does **not** run the full pipeline and does **not** claim full-pipeline reproduction.

## Why
Issue #120 historically mixed several result types:

- full pipeline attempts;
- partial-page checks;
- saved intermediate evaluations;
- handoff documents with conflicting metric claims.

The best-known detector result, `TP=3580 / FP=0 / FN=1`, was reproduced from saved intermediates. This PR makes that workflow explicit, checks the canonical 68-page manifest, and writes normalized evidence files under ignored logs.

## Changes
- Add `tools/issue120/eval_full68_from_intermediates.py`.
  - Validates the canonical 68-page evaluation2 subset.
  - Fails by default if required pages are missing.
  - Evaluates `pipeline2_no_peak_scored.json` with the canonical detector matching defaults.
  - Optionally reads `pipeline2_no_peak_candidates.json` to report approximate `FN_det` / `FN_cnn` split.
  - Writes normalized outputs under `logs/issue120_e2e_recovery/latest_full_report/` by default.
- Add `tools/issue120/attach_eval_provenance.py`.
  - Attaches intermediate provenance to `evaluation_contract.json`.
  - Marks the evaluated stage as `post_cnn_scoring_detector_intermediate` unless a local provenance JSON is supplied.
- Add `make eval-issue120-full`.
- Add `docs/ISSUE120_EVALUATION_CONTRACT.md`.

## Local verification
The following command was run locally:

```bash
make eval-issue120-full
```

Observed result:

```text
Issue #120 full-68 intermediate evaluation
Pages: 68/68
Detector: GT=3581 Pred=3597 TP=3580 FP=0 FN=1 FN_det=0 FN_cnn=1 Precision=1.000000 Recall=0.999721
Wrote: logs/issue120_e2e_recovery/latest_full_report
```

Precise interpretation:

> The saved post-CNN-scoring detector intermediates under `data/evaluation2/golden_baseline_eval2_bc23deb` reproduce `TP=3580 / FP=0 / FN=1` under the canonical 68-page evaluator.

This should **not** be interpreted as proof that the current full pipeline regenerates those intermediates.

## Scope
In:
- Evaluation tooling.
- Makefile entrypoint.
- Evaluation contract documentation.
- Provenance attachment for intermediate results.

Out:
- No detector, CNN, HOMR, OMR-DLN, SR, numbering, or pipeline logic changes.
- No full 68-page pipeline execution.
- No generated logs or result JSONs committed.

## Follow-up
#136 should determine how the evaluated intermediates were generated and whether the upstream path can be reproduced:

```text
initial HOMR/OMR
  -> SR
  -> SR-side HOMR/OMR
  -> OMR-DLN / other detector outputs if used
  -> hybrid consensus / seed preparation
  -> probe scan candidates
  -> CNN scoring
  -> eval_full68_from_intermediates.py
```

The slow stages are expected to be initial HOMR/OMR, SR, and SR-side HOMR/OMR. Hybrid consensus, probe scan, and CNN scoring should be treated as comparatively cheaper downstream regeneration stages.