### PR TITLE
docs/tools: audit Issue 120 historical best and reconstruction path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ ISSUE120_BANDS_FROM ?=
 ISSUE120_STAGE_B_SCORING_DIR ?= logs/issue120_e2e_recovery/stage_b_candidate_scoring
 ISSUE120_STAGE_B_EVAL_DIR ?= logs/issue120_e2e_recovery/stage_b_candidate_scoring_eval
 ISSUE120_CLEAN_OUTPUT ?= 0
+ISSUE120_DOCKER_IMAGE ?= pdfscore_pipeline_gpu
+ISSUE120_DOCKER_PYTHON ?= /opt/venv_pipeline/bin/python
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -105,7 +107,24 @@ eval-issue120-full: ## Evaluate Issue #120 canonical full-68 detector intermedia
 		--results-dir "$(ISSUE120_RESULTS_DIR)" \
 		$$PROVENANCE_ARG
 
-verify-issue120-stage-b: ## Re-score Issue #120 candidates, then evaluate with the canonical full-68 evaluator
+verify-issue120-stage-b: ## Re-score Issue #120 candidates in Docker, then evaluate with the canonical full-68 evaluator
+	@CLEAN_ARG=""; \
+	BANDS_ARG=""; \
+	if [ "$(ISSUE120_CLEAN_OUTPUT)" = "1" ]; then CLEAN_ARG="--clean-output"; fi; \
+	if [ -n "$(ISSUE120_BANDS_FROM)" ]; then BANDS_ARG="--bands-from $(ISSUE120_BANDS_FROM)"; fi; \
+	docker run --rm --gpus all -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace $(ISSUE120_DOCKER_IMAGE) \
+		$(ISSUE120_DOCKER_PYTHON) tools/issue120/score_candidates_then_eval_full68.py \
+		--candidates-dir "$(ISSUE120_CANDIDATES_DIR)" \
+		--image-root "$(ISSUE120_IMAGE_ROOT)" \
+		--gt-root "$(ISSUE120_GT_ROOT)" \
+		--model-path "$(ISSUE120_MODEL_PATH)" \
+		--scoring-output-dir "$(ISSUE120_STAGE_B_SCORING_DIR)" \
+		--eval-output-dir "$(ISSUE120_STAGE_B_EVAL_DIR)" \
+		--score-threshold "$(ISSUE120_SCORE_THRESHOLD)" \
+		--xdist-threshold "$(ISSUE120_XDIST_THRESHOLD)" \
+		$$BANDS_ARG $$CLEAN_ARG
+
+verify-issue120-stage-b-native: ## Re-score Issue #120 candidates using the current host Python environment
 	@CLEAN_ARG=""; \
 	BANDS_ARG=""; \
 	if [ "$(ISSUE120_CLEAN_OUTPUT)" = "1" ]; then CLEAN_ARG="--clean-output"; fi; \

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ ISSUE120_MODEL_PATH ?= logs/cnn_barline_classification/issue44_iter7_final_rescu
 ISSUE120_BANDS_FROM ?=
 ISSUE120_STAGE_B_SCORING_DIR ?= logs/issue120_e2e_recovery/stage_b_candidate_scoring
 ISSUE120_STAGE_B_EVAL_DIR ?= logs/issue120_e2e_recovery/stage_b_candidate_scoring_eval
+ISSUE120_STAGE_B_SCORER ?= pipeline
 ISSUE120_CLEAN_OUTPUT ?= 0
 ISSUE120_DOCKER_IMAGE ?= pdfscore_pipeline_gpu
 ISSUE120_DOCKER_PYTHON ?= /opt/venv_pipeline/bin/python
@@ -114,6 +115,7 @@ verify-issue120-stage-b: ## Re-score Issue #120 candidates in Docker, then evalu
 	if [ -n "$(ISSUE120_BANDS_FROM)" ]; then BANDS_ARG="--bands-from $(ISSUE120_BANDS_FROM)"; fi; \
 	docker run --rm --gpus all -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace $(ISSUE120_DOCKER_IMAGE) \
 		$(ISSUE120_DOCKER_PYTHON) tools/issue120/score_candidates_then_eval_full68.py \
+		--scorer "$(ISSUE120_STAGE_B_SCORER)" \
 		--candidates-dir "$(ISSUE120_CANDIDATES_DIR)" \
 		--image-root "$(ISSUE120_IMAGE_ROOT)" \
 		--gt-root "$(ISSUE120_GT_ROOT)" \
@@ -130,6 +132,7 @@ verify-issue120-stage-b-native: ## Re-score Issue #120 candidates using the curr
 	if [ "$(ISSUE120_CLEAN_OUTPUT)" = "1" ]; then CLEAN_ARG="--clean-output"; fi; \
 	if [ -n "$(ISSUE120_BANDS_FROM)" ]; then BANDS_ARG="--bands-from $(ISSUE120_BANDS_FROM)"; fi; \
 	PYTHONPATH=. python3 tools/issue120/score_candidates_then_eval_full68.py \
+		--scorer "$(ISSUE120_STAGE_B_SCORER)" \
 		--candidates-dir "$(ISSUE120_CANDIDATES_DIR)" \
 		--image-root "$(ISSUE120_IMAGE_ROOT)" \
 		--gt-root "$(ISSUE120_GT_ROOT)" \

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,13 @@ ISSUE120_SCORE_THRESHOLD ?= 0.1
 ISSUE120_XDIST_THRESHOLD ?= 12.0
 ISSUE120_MEASURE_SUMMARY ?=
 ISSUE120_PROVENANCE_JSON ?=
+ISSUE120_CANDIDATES_DIR ?= data/evaluation2/golden_baseline_eval2_bc23deb
+ISSUE120_IMAGE_ROOT ?= data/evaluation2/images
+ISSUE120_MODEL_PATH ?= logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth
+ISSUE120_BANDS_FROM ?=
+ISSUE120_STAGE_B_SCORING_DIR ?= logs/issue120_e2e_recovery/stage_b_candidate_scoring
+ISSUE120_STAGE_B_EVAL_DIR ?= logs/issue120_e2e_recovery/stage_b_candidate_scoring_eval
+ISSUE120_CLEAN_OUTPUT ?= 0
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -97,6 +104,22 @@ eval-issue120-full: ## Evaluate Issue #120 canonical full-68 detector intermedia
 		--output-dir "$(ISSUE120_OUTPUT_DIR)" \
 		--results-dir "$(ISSUE120_RESULTS_DIR)" \
 		$$PROVENANCE_ARG
+
+verify-issue120-stage-b: ## Re-score Issue #120 candidates, then evaluate with the canonical full-68 evaluator
+	@CLEAN_ARG=""; \
+	BANDS_ARG=""; \
+	if [ "$(ISSUE120_CLEAN_OUTPUT)" = "1" ]; then CLEAN_ARG="--clean-output"; fi; \
+	if [ -n "$(ISSUE120_BANDS_FROM)" ]; then BANDS_ARG="--bands-from $(ISSUE120_BANDS_FROM)"; fi; \
+	PYTHONPATH=. python3 tools/issue120/score_candidates_then_eval_full68.py \
+		--candidates-dir "$(ISSUE120_CANDIDATES_DIR)" \
+		--image-root "$(ISSUE120_IMAGE_ROOT)" \
+		--gt-root "$(ISSUE120_GT_ROOT)" \
+		--model-path "$(ISSUE120_MODEL_PATH)" \
+		--scoring-output-dir "$(ISSUE120_STAGE_B_SCORING_DIR)" \
+		--eval-output-dir "$(ISSUE120_STAGE_B_EVAL_DIR)" \
+		--score-threshold "$(ISSUE120_SCORE_THRESHOLD)" \
+		--xdist-threshold "$(ISSUE120_XDIST_THRESHOLD)" \
+		$$BANDS_ARG $$CLEAN_ARG
 
 repo-tree: ## Generate a repository directory overview
 	tree -L 3 -I "artifacts|logs|temp|datasets|.git|__pycache__|.venv*" > artifacts/repo_tree.txt

--- a/docs/ISSUE120_HISTORICAL_BEST_AUDIT.md
+++ b/docs/ISSUE120_HISTORICAL_BEST_AUDIT.md
@@ -1,0 +1,325 @@
+# Issue 120 Historical Best Accuracy Audit
+
+## Purpose
+
+This document is the working audit for #136. Its goal is to separate three different claims that were previously mixed together:
+
+1. saved intermediate evaluation reproduces `TP=3580 / FP=0 / FN=1`;
+2. the current downstream detector stages can regenerate those intermediates;
+3. the current full pipeline can regenerate the same detector result end-to-end.
+
+Only item 1 is currently verified by the canonical #134 evaluator. Items 2 and 3 remain open.
+
+## Current verified fact
+
+After #134, the following command evaluates saved post-CNN-scoring detector intermediates:
+
+```bash
+make eval-issue120-full
+```
+
+Local result reported for `data/evaluation2/golden_baseline_eval2_bc23deb`:
+
+```text
+Pages: 68/68
+Detector: GT=3581 Pred=3597 TP=3580 FP=0 FN=1 FN_det=0 FN_cnn=1 Precision=1.000000 Recall=0.999721
+```
+
+Precise interpretation:
+
+> The saved post-CNN-scoring detector intermediates under `data/evaluation2/golden_baseline_eval2_bc23deb` reproduce `TP=3580 / FP=0 / FN=1` under the canonical 68-page evaluator.
+
+This is not full-pipeline reproduction.
+
+## Branch and PR evidence inventory
+
+### Clean starting point
+
+- Commit: `90a278c668e148a68d5a8c3c19c067bb5ff29649`
+- Role: original clean rebuild base for Issue #120.
+- Meaning: useful as a historical source branch base, but not itself the current verified best.
+
+### PR #127: Golden Baseline introduction
+
+- PR: #127 `test: Phase 1.1 - 前提バグ修正とGolden Baseline検証の追加 (Epic #120)`
+- Base: `rebuild/issue120` at `90a278c668e148a68d5a8c3c19c067bb5ff29649`
+- Merge commit: `7d3fbf89dcd52b22b3919d36a30b2d46959fdd84`
+- Claimed result: `TP=3580, FP=0, FN=1` over 68 pages.
+- Added artifact tree: `data/evaluation2/golden_baseline_eval2_bc23deb/`.
+- Added verifier: `tools/repro_accuracy/verify_golden_baseline.py`.
+- Important limitation: this PR introduced saved scored/candidate outputs as a Golden Baseline. It does not by itself prove that the current full pipeline can regenerate those outputs.
+
+### PR #128: in-process / batch infrastructure
+
+- PR: #128 `feat: Phase 1.2 - In-process実行化とBatch Orchestrator等の基盤統合 (Epic #120)`
+- Merge commit: `b89ad515d065fc98f21c674092bb02a784277292`
+- Claimed result: `tools/repro_accuracy/verify_golden_baseline.py` still reports `TP=3580, FP=0, FN=1`.
+- Interpretation: preservation of the saved Golden Baseline evaluator, not necessarily full regeneration.
+
+### PR #129: native filtering and box tightening
+
+- PR: #129 `feat: Phase 3 - ネイティブフィルタリングとBox Tightening (Epic #120)`
+- Merge commit: `db422aed34ae846d6aa288a89ad78e7075b1aaad`
+- Claimed result: `tools/repro_accuracy/verify_golden_baseline.py` still reports `TP=3580, FP=0, FN=1`.
+- Interpretation: likely still verifier-based unless separate run artifacts are found.
+
+### PR #130 / #131: tall band / rounding fix
+
+- PR #130 was later superseded by #131.
+- PR #131 merge commit: `25548b29bb5d706b7c0bcb9f4d5881e892cc1a9b`.
+- Claimed result: `evaluate_full_rescue_v1.py` with native inference and cache disabled maintained `TP=3580, FP=0, FN=1`.
+- Current finding: `evaluate_full_rescue_v1.py` is not present at `rebuild/issue120` under `tools/repro_accuracy/`. This claim needs source recovery from past commit/log/artifact before it can be treated as reproducible.
+
+### PR #132: refactor step
+
+- PR: #132 `Refactor: Step 5 (Phase 2) - Pipeline and Utility Refactoring`
+- Merge commit: `fa0bb34c2d103f796228039740ae0412df47298b`
+- Claimed result: `evaluate_full_rescue_v1.py` with native inference maintained `TP=3580, FP=0, FN=1`.
+- Current finding: same as #131. The script and exact generated output tree must be recovered or reconstructed.
+
+### PR #139: canonical intermediate evaluator
+
+- PR: #139 `tools: add Issue 120 canonical full68 intermediate evaluator`
+- Merge commit: `0febdf8da383c26367b20d75ca98f4554190f2c9`
+- Verified result: saved post-CNN-scoring intermediates reproduce `TP=3580, FP=0, FN=1`.
+- Scope: evaluation only; no proof of upstream regeneration.
+
+## Artifact and script evidence
+
+### `data/evaluation2/golden_baseline_eval2_bc23deb/`
+
+This directory contains saved detector intermediates, including per-page:
+
+```text
+pipeline2_no_peak_candidates.json
+pipeline2_no_peak_filtered_cnn.json
+pipeline2_no_peak_scored.json
+```
+
+It also contains:
+
+```text
+eval_config.yaml
+global_summary.csv
+```
+
+`eval_config.yaml` records:
+
+```text
+eval_rule: center_anchor
+gt_root: data/evaluation2/annotations
+output_csv: logs/issue53_full_eval_rescue_v1/global_summary.csv
+scored_glob: '*_scored.json'
+scored_root: logs/issue53_full_eval_rescue_v1
+threshold: 0.1
+vov_threshold: 0.5
+xdist_threshold: 12.0
+```
+
+Interpretation:
+
+- The checked-in Golden Baseline tree appears to have been extracted from `logs/issue53_full_eval_rescue_v1`.
+- The matching thresholds match #134's canonical detector evaluator.
+- The original source log tree `logs/issue53_full_eval_rescue_v1` is not assumed to be available from a fresh checkout.
+
+### `tools/repro_accuracy/verify_golden_baseline.py`
+
+Role:
+
+- Evaluates saved scored JSON files from `data/evaluation2/golden_baseline_eval2_bc23deb`.
+- Uses `score >= 0.1`, `center_anchor`, `vov_threshold=0.5`, `xdist_threshold=12.0`.
+- Expects `TP=3580`, `FP=0`, `FN=1`.
+
+Limitations:
+
+- It glob-searches scored files rather than validating the canonical 68-page manifest.
+- It does not explain how the scored files were generated.
+- It does not regenerate candidates or CNN scores.
+
+Status:
+
+- Superseded as canonical evaluator by `make eval-issue120-full`, but still useful as historical evidence.
+
+### `tools/repro_accuracy/reproduce_clean_seed_v12.py`
+
+Role:
+
+- Attempts to regenerate clean seeds from previous hybrid outputs.
+- Uses `logs/issue36_prep/20260208_bench_inventory.json`.
+- Uses `logs/hybrid_generalization/verify_fixed_v10` with fixed score-to-run timestamp mappings:
+  - `Shostakovich-Festival_Overture_Va`: `20260324_121505`
+  - `Shostakovich-Sym5-Va`: `20260330_034727`
+  - `Sibelius-Violin_Concerto-Viola`: `20260330_042631`
+  - `Va_Prokofiev_Symphony1`: `20260330_044952`
+  - `Va__Prokofiev_Symphony5`: `20260330_095914`
+- Combines baseline, SR, and OMR/SR detector outputs.
+- Runs probe scan and candidate filters.
+- Writes final candidates to `logs/repro_v12_recovery_final/probe_candidates_filtered_v12`.
+
+Limitations:
+
+- Depends on log trees that are not source inputs in Git.
+- Does not itself prove that those upstream logs can be regenerated by the current pipeline.
+- Uses custom seed logic that must be compared against current production pipeline behavior before being considered a clean transplant target.
+
+Status:
+
+- Key candidate for reproducing the seed/candidate stage, but currently not a canonical full regeneration path.
+
+### `tools/repro_accuracy/verify_repro_batch_final.py`
+
+Role:
+
+- Uses candidates from `logs/repro_v12_recovery_final/probe_candidates_filtered_v12`.
+- Copies candidates into a verification output root.
+- Runs `run_cnn_scoring_batch` with model:
+  `logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth`.
+- Evaluates scored outputs.
+
+Important discrepancy:
+
+- It evaluates with `xdist_threshold=30.0`.
+- The canonical #134 evaluator and Golden Baseline config use `xdist_threshold=12.0`.
+
+Status:
+
+- Useful to test candidate -> CNN scoring regeneration, but it must be adjusted or paired with `make eval-issue120-full` to report canonical metrics.
+
+### `evaluate_full_rescue_v1.py`
+
+Status:
+
+- PR #130, #131, and #132 refer to it as the native inference script used to maintain `TP=3580, FP=0, FN=1`.
+- It is not currently present in `tools/repro_accuracy/` on `rebuild/issue120`.
+- The exact script must be recovered from a historical branch/commit or artifact before those PR claims can be upgraded from historical claim to reproducible evidence.
+
+## Current conclusion
+
+The detector-level Golden Baseline has one verified level and two unresolved upstream levels.
+
+### Verified
+
+Saved post-CNN-scoring intermediates under `data/evaluation2/golden_baseline_eval2_bc23deb` evaluate to:
+
+```text
+TP=3580 / FP=0 / FN=1
+```
+
+using the canonical 68-page evaluator from #134.
+
+### Not yet verified
+
+The current repository has not yet proven that it can regenerate those intermediates from:
+
+```text
+HOMR / OMR / SR / SR-side HOMR / OMR-DLN
+  -> hybrid consensus / seed preparation
+  -> probe scan candidates
+  -> CNN scoring
+```
+
+### Therefore
+
+The clean transplant target should not yet be described as "full pipeline reaches TP=3580 / FP=0 / FN=1".
+
+Current safer wording:
+
+> Detector-level target: saved post-CNN-scoring Golden Baseline intermediates reproduce `TP=3580 / FP=0 / FN=1`; #136 must still determine which upstream generation path can regenerate them.
+
+## Proposed staged verification plan
+
+### Stage A: saved scored intermediates
+
+Command:
+
+```bash
+make eval-issue120-full \
+  ISSUE120_RESULTS_DIR=data/evaluation2/golden_baseline_eval2_bc23deb
+```
+
+Expected:
+
+```text
+TP=3580 / FP=0 / FN=1
+```
+
+Status: verified locally after #134.
+
+### Stage B: saved candidates -> CNN scoring -> canonical evaluation
+
+Goal:
+
+- Use checked-in `pipeline2_no_peak_candidates.json` or regenerated candidates.
+- Run only CNN scoring.
+- Evaluate output with #134 canonical evaluator.
+
+Required change:
+
+- Either add a small wrapper around `run_cnn_scoring_batch`, or adapt `verify_repro_batch_final.py` so the final evaluation is performed by `make eval-issue120-full` with `xdist_threshold=12.0`.
+
+Acceptance:
+
+- Same canonical 68-page page set.
+- Same metric contract as #134.
+- If this fails, the problem is in CNN scoring, candidate layout, model path, or thresholding.
+
+### Stage C: hybrid/probe seed regeneration -> CNN scoring -> canonical evaluation
+
+Goal:
+
+- Run `reproduce_clean_seed_v12.py` or a cleaned successor.
+- Then run Stage B.
+
+Known dependencies:
+
+```text
+logs/issue36_prep/20260208_bench_inventory.json
+logs/hybrid_generalization/verify_fixed_v10/<timestamped runs>
+logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth
+```
+
+Acceptance:
+
+- Regenerated candidates must produce canonical detector metrics.
+- Missing upstream log dependencies must be reported explicitly, not silently skipped.
+
+### Stage D: slow upstream regeneration
+
+Goal:
+
+- Regenerate the baseline HOMR/OMR, SR, and SR-side HOMR/OMR outputs used by Stage C.
+
+This is expected to be the expensive stage and should be run locally, not as a default PR check.
+
+Acceptance:
+
+- The regenerated upstream outputs can feed Stage C.
+- If Stage C differs, compare upstream detection JSONs before modifying detector logic.
+
+### Stage E: full pipeline 68-page run
+
+Goal:
+
+- Confirm that the current pipeline can regenerate the detector result end-to-end.
+
+Acceptance:
+
+- Full pipeline output, after canonical evaluation, matches the selected gate or produces a documented delta.
+
+## Recommended immediate #136 next steps
+
+1. Recover or locate `evaluate_full_rescue_v1.py` from historical commits/artifacts.
+2. Decide whether `verify_repro_batch_final.py` should be replaced by a canonical Stage B wrapper.
+3. Check whether the model path `logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth` is available locally and how it should be referenced.
+4. Run Stage B locally using checked-in Golden Baseline candidates.
+5. Record whether candidate -> CNN scoring can reproduce the #134 result under `xdist_threshold=12.0`.
+
+## Decision status
+
+No clean transplant target is final yet.
+
+Interim target:
+
+- keep `TP=3580 / FP=0 / FN=1` as the detector-level historical target;
+- treat `data/evaluation2/golden_baseline_eval2_bc23deb` as a verified saved-intermediate benchmark;
+- do not claim full-pipeline reproduction until Stage C/D/E are verified.

--- a/docs/ISSUE120_HISTORICAL_BEST_AUDIT.md
+++ b/docs/ISSUE120_HISTORICAL_BEST_AUDIT.md
@@ -39,6 +39,36 @@ This is not full-pipeline reproduction.
 - Role: original clean rebuild base for Issue #120.
 - Meaning: useful as a historical source branch base, but not itself the current verified best.
 
+### PR #57: Issue #44 final baseline
+
+- PR: #57 `feat(cnn): finalize baseline retraining and improve staff clustering logic (#44)`
+- Head branch: `task/cnn-barline-classifier-retrain-eval2-gt`
+- Head commit: `b58b988979573e651c5a2f57270ebc1c830135b4`
+- Merge commit: `87fb6d0a47294d7879500285a62e519373498b65`
+- Claimed result: `evaluate_full_rescue_v1.py` produced final detector result with `FP=0`, `FN=1`.
+- Important recovered file:
+  - `experiments/issue53_probe_rescue/evaluate_full_rescue_v1.py`
+
+Recovered script behavior:
+
+```text
+bands_from = logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12
+output_root = logs/issue53_full_eval_rescue_v1
+model_path = logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth
+```
+
+It runs:
+
+1. `run_probe_scan_batch` over all `data/evaluation2/images/page_*.png` with gap/x-peak/rightmost/divisi rescue.
+2. `tools.cnn_classifier.score_candidates_batch.run_scoring_batch` with threshold `0.1`, crop recentering, and staff-aware filtering.
+3. `tools/re_evaluate_global.py` using `center_anchor`, `vov_threshold=0.5`, `xdist_threshold=12.0`.
+
+Interpretation:
+
+- This is the likely historical source for `logs/issue53_full_eval_rescue_v1`.
+- The checked-in `data/evaluation2/golden_baseline_eval2_bc23deb/eval_config.yaml` points to `logs/issue53_full_eval_rescue_v1` and uses the same canonical evaluation thresholds.
+- This script is experimental and references pre-refactor module paths (`src.pipeline.probe_scan`, `tools.cnn_classifier.score_candidates_batch`). It is evidence, not a drop-in current pipeline command.
+
 ### PR #127: Golden Baseline introduction
 
 - PR: #127 `test: Phase 1.1 - 前提バグ修正とGolden Baseline検証の追加 (Epic #120)`
@@ -68,14 +98,14 @@ This is not full-pipeline reproduction.
 - PR #130 was later superseded by #131.
 - PR #131 merge commit: `25548b29bb5d706b7c0bcb9f4d5881e892cc1a9b`.
 - Claimed result: `evaluate_full_rescue_v1.py` with native inference and cache disabled maintained `TP=3580, FP=0, FN=1`.
-- Current finding: `evaluate_full_rescue_v1.py` is not present at `rebuild/issue120` under `tools/repro_accuracy/`. This claim needs source recovery from past commit/log/artifact before it can be treated as reproducible.
+- Current finding: the script name appears to refer back to the experimental Issue #53/Issue #44 script under `experiments/issue53_probe_rescue/`, not to a current `tools/repro_accuracy/` script. The exact command/run artifact used for #131 still needs local confirmation.
 
 ### PR #132: refactor step
 
 - PR: #132 `Refactor: Step 5 (Phase 2) - Pipeline and Utility Refactoring`
 - Merge commit: `fa0bb34c2d103f796228039740ae0412df47298b`
 - Claimed result: `evaluate_full_rescue_v1.py` with native inference maintained `TP=3580, FP=0, FN=1`.
-- Current finding: same as #131. The script and exact generated output tree must be recovered or reconstructed.
+- Current finding: same as #131. The historical script has been located under PR #57, but the exact #132 execution path remains to be reproduced or confirmed from local logs.
 
 ### PR #139: canonical intermediate evaluator
 
@@ -140,6 +170,29 @@ Status:
 
 - Superseded as canonical evaluator by `make eval-issue120-full`, but still useful as historical evidence.
 
+### `experiments/issue53_probe_rescue/evaluate_full_rescue_v1.py`
+
+Recovered from PR #57 head commit `b58b988979573e651c5a2f57270ebc1c830135b4`.
+
+Role:
+
+- Historical experiment script that likely generated `logs/issue53_full_eval_rescue_v1`.
+- Starts from `logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12` as `bands_from`.
+- Runs probe scan with rescue options.
+- Runs CNN scoring with `issue44_iter7_final_rescue_v1/cnn_classifier_best.pth`.
+- Evaluates with `xdist_threshold=12.0`.
+
+Limitations:
+
+- Uses old module paths and pre-#120 APIs.
+- Assumes local log/model artifacts.
+- Does not run the current full pipeline.
+
+Status:
+
+- Important historical source evidence.
+- Should not be restored as-is into current workflow; instead, its stages should be represented by Stage B/C/D commands.
+
 ### `tools/repro_accuracy/reproduce_clean_seed_v12.py`
 
 Role:
@@ -183,15 +236,47 @@ Important discrepancy:
 
 Status:
 
-- Useful to test candidate -> CNN scoring regeneration, but it must be adjusted or paired with `make eval-issue120-full` to report canonical metrics.
+- Superseded for canonical Stage B verification by `tools/issue120/score_candidates_then_eval_full68.py`.
+- Candidate for removal or archival after Stage B is validated, because overlapping scripts are a source of confusion.
 
-### `evaluate_full_rescue_v1.py`
+### `tools/issue120/score_candidates_then_eval_full68.py`
 
-Status:
+Role:
 
-- PR #130, #131, and #132 refer to it as the native inference script used to maintain `TP=3580, FP=0, FN=1`.
-- It is not currently present in `tools/repro_accuracy/` on `rebuild/issue120`.
-- The exact script must be recovered from a historical branch/commit or artifact before those PR claims can be upgraded from historical claim to reproducible evidence.
+- New Stage B wrapper for #136.
+- Copies canonical candidate files into a fresh scoring output tree.
+- Runs current `src.pipeline.steps.cnn_scoring.run_cnn_scoring_batch`.
+- Evaluates newly scored outputs using the #134 canonical full-68 evaluator.
+- Writes provenance that marks the result as `stage_b_candidate_to_cnn_scoring`.
+
+Default command:
+
+```bash
+make verify-issue120-stage-b ISSUE120_CLEAN_OUTPUT=1
+```
+
+Optional command with historical staff-band source:
+
+```bash
+make verify-issue120-stage-b \
+  ISSUE120_CLEAN_OUTPUT=1 \
+  ISSUE120_BANDS_FROM=logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12
+```
+
+Expected local prerequisites:
+
+```text
+data/evaluation2/golden_baseline_eval2_bc23deb/**/pipeline2_no_peak_candidates.json
+data/evaluation2/images/**/page_*.png
+data/evaluation2/annotations/**/boxes_sorted.json
+logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth
+```
+
+Interpretation:
+
+- If this reproduces `TP=3580 / FP=0 / FN=1`, then the saved candidates plus current CNN scoring path are compatible with the golden detector target.
+- If this fails, the mismatch is in model availability/content, CNN scoring implementation, crop recentering/staff filtering, candidate layout, or evaluation defaults.
+- It still does not prove seed/candidate regeneration.
 
 ## Current conclusion
 
@@ -253,22 +338,34 @@ Goal:
 - Run only CNN scoring.
 - Evaluate output with #134 canonical evaluator.
 
-Required change:
+Command:
 
-- Either add a small wrapper around `run_cnn_scoring_batch`, or adapt `verify_repro_batch_final.py` so the final evaluation is performed by `make eval-issue120-full` with `xdist_threshold=12.0`.
+```bash
+make verify-issue120-stage-b ISSUE120_CLEAN_OUTPUT=1
+```
+
+If local staff-band artifacts are available, also run:
+
+```bash
+make verify-issue120-stage-b \
+  ISSUE120_CLEAN_OUTPUT=1 \
+  ISSUE120_BANDS_FROM=logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12
+```
 
 Acceptance:
 
 - Same canonical 68-page page set.
 - Same metric contract as #134.
-- If this fails, the problem is in CNN scoring, candidate layout, model path, or thresholding.
+- If this fails, the problem is in CNN scoring, candidate layout, model path, staff-band source, or thresholding.
+
+Status: wrapper added; local execution still required.
 
 ### Stage C: hybrid/probe seed regeneration -> CNN scoring -> canonical evaluation
 
 Goal:
 
 - Run `reproduce_clean_seed_v12.py` or a cleaned successor.
-- Then run Stage B.
+- Then run Stage B with `ISSUE120_CANDIDATES_DIR` pointing at regenerated candidates.
 
 Known dependencies:
 
@@ -308,11 +405,12 @@ Acceptance:
 
 ## Recommended immediate #136 next steps
 
-1. Recover or locate `evaluate_full_rescue_v1.py` from historical commits/artifacts.
-2. Decide whether `verify_repro_batch_final.py` should be replaced by a canonical Stage B wrapper.
-3. Check whether the model path `logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth` is available locally and how it should be referenced.
-4. Run Stage B locally using checked-in Golden Baseline candidates.
-5. Record whether candidate -> CNN scoring can reproduce the #134 result under `xdist_threshold=12.0`.
+1. Run Stage B locally without `ISSUE120_BANDS_FROM`.
+2. Run Stage B locally with historical `ISSUE120_BANDS_FROM` if that artifact exists.
+3. Compare both outputs against the Stage A result.
+4. If Stage B passes, archive or delete `verify_repro_batch_final.py` in a later cleanup PR to reduce script overlap.
+5. If Stage B fails, inspect `logs/issue120_e2e_recovery/stage_b_candidate_scoring_eval/detector_page_metrics.csv` and compare with Stage A page metrics.
+6. Then proceed to Stage C using `reproduce_clean_seed_v12.py` or a cleaned successor.
 
 ## Decision status
 

--- a/docs/ISSUE120_NMS_POLICY.md
+++ b/docs/ISSUE120_NMS_POLICY.md
@@ -1,0 +1,117 @@
+# Issue 120 CNN Scoring NMS Policy
+
+## Purpose
+
+This document records what the CNN scoring NMS step means, why it exists, what Stage B proved, and how Issue #120 should handle it going forward.
+
+## What NMS means here
+
+NMS means non-maximum suppression.
+
+In `src.pipeline.steps.cnn_scoring`, NMS is applied after CNN scoring and thresholding. It takes candidates whose CNN score is above the threshold and suppresses boxes that appear to represent the same barline as a higher-scoring box.
+
+The current implementation uses two suppression tests:
+
+1. IoU overlap between two boxes.
+2. Horizontal center distance when vertical overlap is high.
+
+Suppressed boxes have their score set to `0.0`, so they no longer appear in `pipeline2_no_peak_filtered_cnn.json` and no longer count as predictions under the canonical evaluator.
+
+## Intended role of NMS
+
+NMS is intended to reduce duplicate detections.
+
+Without NMS, a detector can emit multiple nearby boxes around the same visual barline. Those duplicates may become false positives under a one-to-one matching evaluator or may cause downstream measure-count instability.
+
+Therefore, NMS is not inherently wrong. It can be useful as a precision and stability mechanism.
+
+## What Stage B proved
+
+Stage B isolates this layer:
+
+```text
+saved candidates
+  -> CNN scoring / scoring-side filtering
+  -> canonical full-68 detector evaluation
+```
+
+The saved Golden Baseline candidates are sufficient to reproduce the historical detector target through the legacy scorer:
+
+```text
+Stage A saved scored:           Pred=3597 TP=3580 FP=0 FN=1
+Stage B legacy scorer:          Pred=3597 TP=3580 FP=0 FN=1
+```
+
+The current pipeline scorer with NMS enabled fails:
+
+```text
+Stage B pipeline scorer + NMS:  Pred=3507 TP=3507 FP=0 FN=74
+```
+
+The current pipeline scorer with NMS disabled reproduces the historical detector target:
+
+```text
+Stage B pipeline scorer no NMS: Pred=3597 TP=3580 FP=0 FN=1
+```
+
+## Interpretation
+
+The Stage B regression is caused by the current pipeline scorer's NMS step.
+
+This does not prove that NMS should be globally removed. It proves only that the current NMS rule is not compatible with the Issue #120 historical detector target on the canonical 68-page saved candidates.
+
+The current NMS rule suppresses true-positive candidates that the historical scorer retained. Because the false-positive count is already `0` in the historical target, this specific NMS application removes recall without improving precision for this benchmark.
+
+## Policy
+
+### Default behavior
+
+Keep NMS enabled by default in the general pipeline until a broader accuracy comparison proves that changing the default is safe.
+
+### Issue #120 reconstruction behavior
+
+Issue #120 canonical reconstruction may disable CNN scoring NMS explicitly.
+
+This must be explicit in config, command, or provenance. A result produced with NMS disabled must not be described as using default pipeline scoring.
+
+### Required recording
+
+Any Issue #120 metric report must record:
+
+```text
+cnn_apply_nms: true|false
+```
+
+or equivalent provenance field.
+
+### Forbidden shortcut
+
+Do not silently remove or weaken NMS globally just to recover the historical target.
+
+### Future repair
+
+After Stage C/D/E determine the candidate-generation path, NMS can be repaired or tuned under #137. Candidate approaches include:
+
+- disable NMS only for Issue #120 canonical reconstruction;
+- make NMS thresholds configurable;
+- replace the current X-distance suppression with a more conservative rule;
+- apply NMS only where it improves downstream measure-count metrics;
+- compare detector metrics and measure-count metrics before accepting any new default.
+
+## Current decision
+
+For #136:
+
+```text
+cnn_apply_nms=false
+```
+
+is the canonical Stage B setting for reproducing the historical detector target from saved candidates using the current pipeline scorer.
+
+For general pipeline operation:
+
+```text
+cnn_apply_nms=true
+```
+
+remains the default until #137 or a later PR changes it with evidence.

--- a/docs/ISSUE120_ROADMAP.md
+++ b/docs/ISSUE120_ROADMAP.md
@@ -1,0 +1,299 @@
+# Issue 120 Roadmap
+
+## Purpose
+
+This roadmap reflects the Issue #120 restart after #133, #134, and #136 work.
+
+The current strategy is to separate five layers that were previously mixed together:
+
+```text
+Stage A: saved scored intermediates
+Stage B: saved candidates -> scoring -> canonical evaluation
+Stage C: regenerated candidates -> scoring -> canonical evaluation
+Stage D: regenerated slow upstream HOMR/OMR/SR artifacts -> Stage C
+Stage E: full 68-page pipeline validation
+```
+
+## Current completed foundation
+
+### #133: restart plan
+
+Status: completed.
+
+Result:
+
+- `rebuild/issue120` is the audit/integration target.
+- `fix/probe_seeds` is frozen as an experimental/evidence branch.
+- Issue #120 remains the parent Epic.
+- Work is split into staged audit/cleanup/repair issues.
+
+### #134: canonical full-68 intermediate evaluator
+
+Status: completed.
+
+Result:
+
+```bash
+make eval-issue120-full
+```
+
+This evaluates saved post-CNN-scoring detector intermediates and validates the canonical 68-page set.
+
+Verified detector result from saved Golden Baseline scored outputs:
+
+```text
+Pages: 68/68
+Detector: GT=3581 Pred=3597 TP=3580 FP=0 FN=1 FN_det=0 FN_cnn=1
+```
+
+Important boundary:
+
+- This is not full-pipeline reproduction.
+- It verifies saved post-CNN-scoring intermediates only.
+
+## #136: historical best and clean detector-level transplant target
+
+Status: in PR / review.
+
+Branch:
+
+```text
+audit/issue120-best-accuracy
+```
+
+PR base:
+
+```text
+rebuild/issue120
+```
+
+### Stage A result
+
+Saved scored Golden Baseline intermediates reproduce the detector target:
+
+```text
+TP=3580 / FP=0 / FN=1
+```
+
+### Stage B result
+
+Saved Golden Baseline candidates can reproduce the detector target through current pipeline CNN scoring if NMS is disabled:
+
+```text
+Stage B saved candidates + pipeline scorer + NMS enabled:
+  Pred=3507 TP=3507 FP=0 FN=74
+
+Stage B saved candidates + legacy scorer:
+  Pred=3597 TP=3580 FP=0 FN=1
+
+Stage B saved candidates + pipeline scorer + NMS disabled:
+  Pred=3597 TP=3580 FP=0 FN=1
+```
+
+Conclusion:
+
+- candidate files, model artifact, images, GT, and CNN inference are sufficient;
+- the Stage B regression is caused by current pipeline CNN scoring NMS;
+- NMS remains enabled by default globally, but Issue #120 canonical reconstruction must explicitly record `cnn_apply_nms=false`.
+
+### Stage C result
+
+The first attempted Stage C path was not correct:
+
+```text
+reproduce_clean_seed_v12.py:
+  baseline candidates: 29443
+  regenerated candidates: 180
+  empty pages: 40
+```
+
+This script is treated as a residual/rescue/filtered-subset experiment, not the canonical full candidate regeneration path.
+
+The #57 / Issue53 probe rescue path is the current clean detector-level candidate regeneration path:
+
+```text
+Issue53 probe rescue path:
+  baseline candidates: 29443
+  regenerated candidates: 29772
+  empty pages: 0
+  detector result: TP=3580 FP=0 FN=1
+```
+
+Current clean detector-level reconstruction target:
+
+```text
+#57 / Issue53 probe rescue candidate generation
+  -> current pipeline CNN scoring
+  -> cnn_apply_nms=false
+  -> #134 canonical full-68 evaluator
+  -> TP=3580 FP=0 FN=1
+```
+
+Remaining limitation:
+
+- This still depends on the historical `bands_from` artifact:
+
+```text
+logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12
+```
+
+It is not yet full slow-upstream pipeline reproduction.
+
+## Open / next issues
+
+### #135: generated artifact cleanup and retention policy
+
+Status: open.
+
+Purpose:
+
+- Clean tracked generated outputs and define what stays in Git.
+- Keep scripts/docs/configs; move or ignore bulky generated logs/JSON/CSV/PNG artifacts.
+
+Recommended timing:
+
+- Can proceed after #136 PR is merged.
+- Should not remove evidence needed for #140/#141 until references/provenance are documented.
+
+### #137: accuracy repair after audit
+
+Status: open.
+
+Purpose:
+
+- Resume targeted accuracy work only after audit and canonical evaluation gates are established.
+
+Updated dependency:
+
+- Depends on #136.
+- Should incorporate #142 for NMS policy before changing scoring behavior.
+- Should not mix Stage D/E full-upstream validation with algorithm changes.
+
+### #140: Stage D upstream artifact regeneration
+
+Status: open.
+
+Branch policy:
+
+```text
+base: rebuild/issue120
+branch: audit/issue120-stage-d-upstream-regen
+PR base: rebuild/issue120
+```
+
+Purpose:
+
+Verify whether the slow upstream artifacts used by Stage C can be regenerated:
+
+```text
+HOMR / OMR / SR / SR-side HOMR / OMR-DLN or equivalent
+  -> bands_from-like artifact
+  -> Issue53 probe rescue Stage C
+  -> canonical evaluator
+```
+
+Primary input currently requiring provenance:
+
+```text
+logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12
+```
+
+Acceptance:
+
+- regenerated upstream artifacts can feed Stage C and preserve the detector target; or
+- failure boundary is documented with follow-up issues.
+
+### #141: Stage E full 68-page pipeline validation
+
+Status: open.
+
+Branch policy:
+
+```text
+base: rebuild/issue120
+branch: audit/issue120-stage-e-full-pipeline
+PR base: rebuild/issue120
+```
+
+Purpose:
+
+Run or document the full 68-page pipeline result after Stage D clarifies upstream artifact regeneration.
+
+Acceptance:
+
+- complete 68-page output;
+- #134 canonical detector evaluation;
+- downstream measure-count metrics recorded separately;
+- generated artifacts remain under ignored paths.
+
+### #142: CNN scoring NMS repair/tuning
+
+Status: open.
+
+Branch policy:
+
+```text
+base: rebuild/issue120
+branch: fix/issue120-cnn-nms-policy
+PR base: rebuild/issue120
+```
+
+Purpose:
+
+Decide whether NMS should be kept, tuned, made conditional, or disabled in specific reconstruction modes.
+
+Current policy:
+
+```text
+default general pipeline: cnn_apply_nms=true
+Issue120 reconstruction: cnn_apply_nms=false, explicitly recorded
+```
+
+Acceptance:
+
+- no silent global NMS weakening;
+- any default change requires detector and measure-count evidence.
+
+## Recommended order from here
+
+```text
+1. Merge #136 PR.
+2. Use #136 result as the detector-level clean transplant target.
+3. Run #135 cleanup, preserving only source/docs/scripts and documented fixtures.
+4. Work #140 to verify or bound slow upstream artifact regeneration.
+5. Work #142 to decide NMS behavior before broad accuracy repair.
+6. Work #141 full 68-page pipeline validation after #140 boundary is known.
+7. Work #137 targeted accuracy repair using the canonical gates.
+```
+
+## Current canonical detector target
+
+Until changed by a later audited issue:
+
+```text
+TP=3580 / FP=0 / FN=1
+```
+
+Canonical reconstruction mode:
+
+```yaml
+detection:
+  cnn_apply_nms: false
+```
+
+Canonical evaluator:
+
+```bash
+make eval-issue120-full
+```
+
+Issue53-derived Stage C verifier:
+
+```bash
+docker run --rm --gpus all \
+  -v "$PWD":/workspace \
+  -w /workspace \
+  -e PYTHONPATH=/workspace \
+  pdfscore_pipeline_gpu \
+  /opt/venv_pipeline/bin/python tools/issue120/run_issue53_probe_rescue_then_eval.py
+```

--- a/docs/ISSUE120_STAGE_B_SCORING_DRIFT.md
+++ b/docs/ISSUE120_STAGE_B_SCORING_DRIFT.md
@@ -1,0 +1,170 @@
+# Issue 120 Stage B Scoring Drift Results
+
+## Purpose
+
+This document records the Stage B results for #136.
+
+Stage B starts from saved `pipeline2_no_peak_candidates.json` files, reruns CNN scoring, and then evaluates the newly scored outputs with the canonical #134 full-68 evaluator.
+
+This isolates the following layer:
+
+```text
+saved candidates
+  -> CNN scoring / scoring-side filtering
+  -> canonical full-68 detector evaluation
+```
+
+It does not regenerate candidates from HOMR/OMR/SR/hybrid/probe outputs.
+
+## Stage A reference
+
+The #134 evaluator verifies the saved post-CNN-scoring Golden Baseline intermediates:
+
+```text
+Pages: 68/68
+Detector: GT=3581 Pred=3597 TP=3580 FP=0 FN=1 FN_det=0 FN_cnn=1 Precision=1.000000 Recall=0.999721
+```
+
+This is the Stage A reference.
+
+## Stage B result: current pipeline scorer
+
+Command:
+
+```bash
+make verify-issue120-stage-b ISSUE120_CLEAN_OUTPUT=1
+```
+
+Result:
+
+```text
+Issue #120 full-68 intermediate evaluation
+Pages: 68/68
+Detector: GT=3581 Pred=3507 TP=3507 FP=0 FN=74 FN_det=0 FN_cnn=74 Precision=1.000000 Recall=0.979335
+Wrote: logs/issue120_e2e_recovery/stage_b_candidate_scoring_eval
+Attached intermediate provenance: logs/issue120_e2e_recovery/stage_b_candidate_scoring_eval/evaluation_contract.json
+Stage-B evaluation complete: logs/issue120_e2e_recovery/stage_b_candidate_scoring_eval
+```
+
+Command with historical bands source:
+
+```bash
+make verify-issue120-stage-b \
+  ISSUE120_CLEAN_OUTPUT=1 \
+  ISSUE120_BANDS_FROM=logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12
+```
+
+Result was identical:
+
+```text
+Pages: 68/68
+Detector: GT=3581 Pred=3507 TP=3507 FP=0 FN=74 FN_det=0 FN_cnn=74 Precision=1.000000 Recall=0.979335
+```
+
+Interpretation:
+
+- Saved candidates contain all GT-relevant candidates: `FN_det=0`.
+- The failure occurs after candidate generation: `FN_cnn=74`.
+- Historical bands source does not change the result, so this specific mismatch is not explained by missing `bands_from` alone.
+- The current `src.pipeline.steps.cnn_scoring.run_cnn_scoring_batch` path does not reproduce the saved Golden Baseline scored outputs from the saved Golden Baseline candidates.
+
+## Stage B result: legacy scorer
+
+Command:
+
+```bash
+make verify-issue120-stage-b \
+  ISSUE120_CLEAN_OUTPUT=1 \
+  ISSUE120_STAGE_B_SCORER=legacy
+```
+
+Result:
+
+```text
+Issue #120 full-68 intermediate evaluation
+Pages: 68/68
+Detector: GT=3581 Pred=3597 TP=3580 FP=0 FN=1 FN_det=0 FN_cnn=1 Precision=1.000000 Recall=0.999721
+Wrote: logs/issue120_e2e_recovery/stage_b_candidate_scoring_eval
+Attached intermediate provenance: logs/issue120_e2e_recovery/stage_b_candidate_scoring_eval/evaluation_contract.json
+Stage-B evaluation complete: logs/issue120_e2e_recovery/stage_b_candidate_scoring_eval
+```
+
+Command with historical bands source:
+
+```bash
+make verify-issue120-stage-b \
+  ISSUE120_CLEAN_OUTPUT=1 \
+  ISSUE120_STAGE_B_SCORER=legacy \
+  ISSUE120_BANDS_FROM=logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12
+```
+
+Result was identical:
+
+```text
+Pages: 68/68
+Detector: GT=3581 Pred=3597 TP=3580 FP=0 FN=1 FN_det=0 FN_cnn=1 Precision=1.000000 Recall=0.999721
+```
+
+Interpretation:
+
+- Saved candidates plus the legacy scoring implementation reproduce the Golden Baseline exactly.
+- This confirms the model artifact, image data, candidate files, threshold, and canonical evaluator are sufficient to recover `TP=3580 / FP=0 / FN=1`.
+- The regression is therefore not in saved candidates, not in GT, and not in the canonical evaluator.
+- The immediate drift is between legacy scoring and current pipeline scoring.
+
+## Current narrowed root cause
+
+The historical path uses:
+
+```text
+tools.cnn_classifier.score_candidates_batch.run_scoring_batch
+```
+
+The current pipeline path uses:
+
+```text
+src.pipeline.steps.cnn_scoring.run_cnn_scoring_batch
+```
+
+The latter produces 90 fewer predictions and 74 additional FN from the same saved candidates:
+
+```text
+Stage A / legacy Stage B: Pred=3597, TP=3580, FP=0, FN=1
+current pipeline Stage B: Pred=3507, TP=3507, FP=0, FN=74
+```
+
+Likely difference areas to audit next:
+
+1. NMS behavior in `src.pipeline.steps.cnn_scoring`.
+2. Staff-overlap filtering behavior and whether it mutates scores differently.
+3. Crop recentering parameter differences.
+4. Candidate object handling and threshold comparison differences.
+5. Any preprocessing difference between `tools.cnn_classifier.score_candidates_batch` and `src.pipeline.steps.cnn_scoring`.
+
+One notable code-level difference already observed:
+
+- `src.pipeline.steps.cnn_scoring` applies `apply_nms(candidate_objects_for_filter)`.
+- `tools.cnn_classifier.score_candidates_batch` does not appear to apply the same NMS step in its final filtered output path.
+
+This is a strong candidate for the 90-prediction drop, but it is not yet proven. The next step should compare page-level metrics and/or run an ablation with pipeline NMS disabled.
+
+## Decision
+
+Stage B is now partially verified:
+
+- `legacy` scorer: verified, reproduces Golden Baseline.
+- `pipeline` scorer: fails, produces `TP=3507 / FP=0 / FN=74`.
+
+Therefore the clean transplant target should be described as:
+
+> Saved Golden Baseline candidates can reproduce `TP=3580 / FP=0 / FN=1` through the historical legacy scorer, but the current pipeline scorer has drifted and currently fails Stage B.
+
+This should be fixed before treating the current full pipeline as a candidate for final Issue #120 accuracy work.
+
+## Recommended next steps
+
+1. Add a controlled ablation for current pipeline scorer with NMS disabled.
+2. Compare current pipeline scored output against legacy scored output page by page.
+3. If NMS is confirmed as the cause, make NMS optional or align it with legacy behavior for Issue #120 canonical mode.
+4. After pipeline scorer reproduces Stage B, proceed to Stage C: seed/candidate regeneration.
+5. Keep `verify_repro_batch_final.py` non-canonical and plan deletion/archive after the Stage B wrapper is accepted.

--- a/src/pipeline/detection/orchestrator.py
+++ b/src/pipeline/detection/orchestrator.py
@@ -175,6 +175,8 @@ class DetectorOrchestrator:
         if not cnn_model:
             raise ValueError("detection.cnn_model_path is required.")
 
+        cnn_apply_nms = bool(self.det_cfg.get("cnn_apply_nms", True))
+
         if not self.dry_run:
             effective_images, effective_sr_scale = self._get_effective_images_for_probe()
             effective_score_name = self._get_effective_score_name()
@@ -193,6 +195,7 @@ class DetectorOrchestrator:
                 input_image_scale=float(effective_sr_scale),
                 bands_from=self.hybrid_output_dir,
                 staff_vov_threshold=float(self.det_cfg.get("staff_vov_threshold", 0.5)),
+                apply_nms_enabled=cnn_apply_nms,
                 in_memory_images=self.in_memory_images,
             )
         cmd_score = [
@@ -203,6 +206,8 @@ class DetectorOrchestrator:
             str(self.probe_output_dir),
             "--threshold",
             str(self.det_cfg.get("cnn_threshold", 0.1)),
+            "--apply-nms",
+            str(cnn_apply_nms),
         ]
         return {"commands": [cmd_score]}
 

--- a/src/pipeline/steps/cnn_scoring.py
+++ b/src/pipeline/steps/cnn_scoring.py
@@ -224,6 +224,7 @@ def _score_directory(
     crop_recenter_on_bbox_ink: bool = False,
     crop_recenter_max_shift_unit_ratio: float = 0.35,
     input_image_scale: float = 1.0,
+    apply_nms_enabled: bool = True,
     in_memory_images: Dict[str, Any] | None = None,
 ) -> bool:
     candidates_path = run_dir / "pipeline2_no_peak_candidates.json"
@@ -350,7 +351,8 @@ def _score_directory(
                 if id(item) not in kept_indices:
                     item["score"] = 0.0
 
-    apply_nms(candidate_objects_for_filter)
+    if apply_nms_enabled:
+        apply_nms(candidate_objects_for_filter)
 
     filtered_boxes = [
         item["bbox"] for item in candidate_objects_for_filter if item["score"] >= threshold
@@ -378,6 +380,7 @@ def run_cnn_scoring_batch(
     crop_recenter_max_shift_unit_ratio: float = 0.35,
     input_image_scale: float = 1.0,
     candidate_rescale_factor: Optional[float] = None,
+    apply_nms_enabled: bool = True,
     in_memory_images: Dict[str, Any] | None = None,
 ) -> int:
     """Run CNN scoring for all probe output dirs with one model load."""
@@ -407,6 +410,7 @@ def run_cnn_scoring_batch(
             crop_recenter_on_bbox_ink=crop_recenter_on_bbox_ink,
             crop_recenter_max_shift_unit_ratio=crop_recenter_max_shift_unit_ratio,
             input_image_scale=input_image_scale,
+            apply_nms_enabled=apply_nms_enabled,
             in_memory_images=in_memory_images,
         ):
             processed += 1

--- a/tools/issue120/compare_candidate_coverage.py
+++ b/tools/issue120/compare_candidate_coverage.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Compare candidate coverage between two Issue #120 candidate trees."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.issue120.eval_full68_from_intermediates import find_page_file, iter_manifest  # noqa: E402
+
+
+def load_count(path: Path | None) -> int | None:
+    if path is None or not path.exists():
+        return None
+    with path.open("r", encoding="utf-8") as f:
+        payload: Any = json.load(f)
+    if not isinstance(payload, list):
+        return None
+    return len(payload)
+
+
+def safe_ratio(num: int | None, den: int | None) -> float | None:
+    if num is None or den is None or den == 0:
+        return None
+    return num / den
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline-dir",
+        type=Path,
+        default=Path("data/evaluation2/golden_baseline_eval2_bc23deb"),
+        help="Reference candidate tree.",
+    )
+    parser.add_argument(
+        "--candidate-dir",
+        type=Path,
+        default=Path("logs/repro_v12_recovery_final/probe_candidates_filtered_v12"),
+        help="Candidate tree to compare against baseline.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("logs/issue120_e2e_recovery/stage_c_seed_regen_eval"),
+    )
+    parser.add_argument("--candidate-file", default="pipeline2_no_peak_candidates.json")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = iter_manifest()
+
+    rows: list[dict[str, Any]] = []
+    baseline_total = 0
+    candidate_total = 0
+    missing_baseline = 0
+    missing_candidate = 0
+    empty_candidate_pages = 0
+
+    for record in manifest:
+        baseline_path = find_page_file(args.baseline_dir, record, args.candidate_file)
+        candidate_path = find_page_file(args.candidate_dir, record, args.candidate_file)
+        baseline_count = load_count(baseline_path)
+        candidate_count = load_count(candidate_path)
+
+        if baseline_count is None:
+            missing_baseline += 1
+        else:
+            baseline_total += baseline_count
+        if candidate_count is None:
+            missing_candidate += 1
+        else:
+            candidate_total += candidate_count
+            if candidate_count == 0:
+                empty_candidate_pages += 1
+
+        rows.append(
+            {
+                "score": record.score,
+                "page": record.page,
+                "baseline_count": baseline_count,
+                "candidate_count": candidate_count,
+                "delta": None
+                if baseline_count is None or candidate_count is None
+                else candidate_count - baseline_count,
+                "candidate_to_baseline_ratio": safe_ratio(candidate_count, baseline_count),
+                "baseline_path": str(baseline_path) if baseline_path else None,
+                "candidate_path": str(candidate_path) if candidate_path else None,
+            }
+        )
+
+    summary = {
+        "schema_version": "issue120.candidate_coverage_comparison.v1",
+        "baseline_dir": str(args.baseline_dir),
+        "candidate_dir": str(args.candidate_dir),
+        "expected_pages": len(manifest),
+        "baseline_total_candidates": baseline_total,
+        "candidate_total_candidates": candidate_total,
+        "total_delta": candidate_total - baseline_total,
+        "candidate_to_baseline_ratio": safe_ratio(candidate_total, baseline_total),
+        "missing_baseline_pages": missing_baseline,
+        "missing_candidate_pages": missing_candidate,
+        "empty_candidate_pages": empty_candidate_pages,
+        "worst_pages": sorted(
+            rows,
+            key=lambda r: (
+                r["candidate_to_baseline_ratio"]
+                if r["candidate_to_baseline_ratio"] is not None
+                else -1
+            ),
+        )[:20],
+    }
+
+    (args.output_dir / "candidate_coverage_comparison.json").write_text(
+        json.dumps({"summary": summary, "rows": rows}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    with (args.output_dir / "candidate_coverage_comparison.csv").open(
+        "w", newline="", encoding="utf-8"
+    ) as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print("Candidate coverage comparison")
+    print(f"Pages: {len(manifest)}")
+    print(f"Baseline candidates: {baseline_total}")
+    print(f"Compared candidates: {candidate_total}")
+    print(f"Ratio: {safe_ratio(candidate_total, baseline_total)}")
+    print(f"Empty compared pages: {empty_candidate_pages}")
+    print(f"Wrote: {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/issue120/run_issue53_probe_rescue_then_eval.py
+++ b/tools/issue120/run_issue53_probe_rescue_then_eval.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Regenerate the Issue #53/#57 probe-rescue candidate layer and evaluate it.
+
+This is the preferred Stage-C candidate-regeneration path for #136.  It mirrors
+the historical PR #57 experiment script:
+
+    experiments/issue53_probe_rescue/evaluate_full_rescue_v1.py
+
+but uses the current #134/#136 evaluation wrappers and records the result as a
+separate, explicit regeneration attempt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.issue120.compare_candidate_coverage import main as _unused_compare_main  # noqa: F401,E402
+from tools.issue120.eval_full68_from_intermediates import iter_manifest  # noqa: E402
+from src.pipeline.steps.probe_scan import run_probe_scan_batch  # noqa: E402
+
+
+DEFAULT_BANDS_FROM = Path("logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12")
+DEFAULT_MODEL = Path(
+    "logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth"
+)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def canonical_images(image_root: Path) -> list[Path]:
+    images: list[Path] = []
+    missing: list[str] = []
+    for record in iter_manifest():
+        path = image_root / record.score / f"{record.page}.png"
+        if path.exists():
+            images.append(path)
+        else:
+            missing.append(str(path))
+    if missing:
+        raise SystemExit("Missing canonical images:\n" + "\n".join(missing))
+    return images
+
+
+def run_probe_regeneration(args: argparse.Namespace) -> int:
+    detect_probe_kwargs = {
+        "scan_gap_rescue": True,
+        "scan_gap_threshold_ratio": 1.5,
+        "scan_gap_rescue_min_ratio": 0.3,
+        "scan_x_peak_rescue": True,
+        "scan_rightmost_rescue": True,
+        "divisi_rescue": True,
+        "scan_center_on_peak": True,
+        "max_per_band": 100,
+    }
+    images = canonical_images(args.image_root)
+    return run_probe_scan_batch(
+        images=images,
+        output_root=args.output_root,
+        bands_from=args.bands_from,
+        staff_mask_dir=None,
+        clef_mask_dir=None,
+        ink_threshold=180,
+        min_ratio=0.85,
+        min_height_ratio=0.012,
+        min_width_ratio=0.0001,
+        detect_probe_kwargs=detect_probe_kwargs,
+        skip_existing=False,
+        enable_heuristic_filters=False,
+        disable_seed_splitting=args.disable_seed_splitting,
+    )
+
+
+def run_command(cmd: list[str]) -> None:
+    print("+ " + " ".join(str(part) for part in cmd), flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def run_candidate_comparison(args: argparse.Namespace) -> None:
+    run_command(
+        [
+            sys.executable,
+            "tools/issue120/compare_candidate_coverage.py",
+            "--baseline-dir",
+            str(args.baseline_dir),
+            "--candidate-dir",
+            str(args.output_root),
+            "--output-dir",
+            str(args.eval_output_dir),
+        ]
+    )
+
+
+def run_stage_b_eval(args: argparse.Namespace) -> None:
+    cmd = [
+        sys.executable,
+        "tools/issue120/score_candidates_then_eval_full68.py",
+        "--scorer",
+        args.scorer,
+        "--clean-output",
+        "--candidates-dir",
+        str(args.output_root),
+        "--image-root",
+        str(args.image_root),
+        "--gt-root",
+        str(args.gt_root),
+        "--model-path",
+        str(args.model_path),
+        "--scoring-output-dir",
+        str(args.scoring_output_dir),
+        "--eval-output-dir",
+        str(args.eval_output_dir),
+        "--score-threshold",
+        str(args.score_threshold),
+        "--xdist-threshold",
+        str(args.xdist_threshold),
+    ]
+    if args.scorer == "pipeline" and not args.pipeline_nms:
+        cmd.append("--disable-pipeline-nms")
+    if args.bands_from:
+        cmd.extend(["--bands-from", str(args.bands_from)])
+    run_command(cmd)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image-root", type=Path, default=Path("data/evaluation2/images"))
+    parser.add_argument("--gt-root", type=Path, default=Path("data/evaluation2/annotations"))
+    parser.add_argument("--bands-from", type=Path, default=DEFAULT_BANDS_FROM)
+    parser.add_argument("--model-path", type=Path, default=DEFAULT_MODEL)
+    parser.add_argument("--baseline-dir", type=Path, default=Path("data/evaluation2/golden_baseline_eval2_bc23deb"))
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path("logs/issue120_e2e_recovery/stage_c_issue53_probe_rescue_candidates"),
+    )
+    parser.add_argument(
+        "--scoring-output-dir",
+        type=Path,
+        default=Path("logs/issue120_e2e_recovery/stage_c_issue53_probe_rescue_scoring"),
+    )
+    parser.add_argument(
+        "--eval-output-dir",
+        type=Path,
+        default=Path("logs/issue120_e2e_recovery/stage_c_issue53_probe_rescue_eval"),
+    )
+    parser.add_argument("--scorer", choices=["pipeline", "legacy"], default="pipeline")
+    parser.add_argument("--pipeline-nms", action="store_true", default=False)
+    parser.add_argument("--score-threshold", type=float, default=0.1)
+    parser.add_argument("--xdist-threshold", type=float, default=12.0)
+    parser.add_argument("--disable-seed-splitting", action="store_true")
+    parser.add_argument("--skip-probe-regeneration", action="store_true")
+    parser.add_argument("--coverage-only", action="store_true")
+    parser.add_argument("--no-clean-output", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    required = [args.image_root, args.gt_root, args.bands_from, args.model_path]
+    missing = [str(path) for path in required if not path.exists()]
+    if missing:
+        raise SystemExit("Missing required inputs:\n" + "\n".join(missing))
+
+    if not args.no_clean_output:
+        shutil.rmtree(args.output_root, ignore_errors=True)
+        shutil.rmtree(args.scoring_output_dir, ignore_errors=True)
+        shutil.rmtree(args.eval_output_dir, ignore_errors=True)
+
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    args.eval_output_dir.mkdir(parents=True, exist_ok=True)
+
+    provenance = {
+        "schema_version": "issue120.issue53_probe_rescue_regen.v1",
+        "historical_source": "PR #57 experiments/issue53_probe_rescue/evaluate_full_rescue_v1.py",
+        "output_root": str(args.output_root),
+        "bands_from": str(args.bands_from),
+        "model_path": str(args.model_path),
+        "probe_params": {
+            "ink_threshold": 180,
+            "min_ratio": 0.85,
+            "min_height_ratio": 0.012,
+            "scan_gap_threshold_ratio": 1.5,
+            "scan_gap_rescue_min_ratio": 0.3,
+            "max_per_band": 100,
+            "disable_seed_splitting": args.disable_seed_splitting,
+        },
+        "scorer": args.scorer,
+        "pipeline_nms": args.pipeline_nms,
+    }
+    write_json(args.eval_output_dir / "issue53_probe_rescue_regen_provenance.json", provenance)
+
+    if not args.skip_probe_regeneration:
+        processed = run_probe_regeneration(args)
+        print(f"Issue53-style probe regeneration processed pages: {processed}")
+
+    run_candidate_comparison(args)
+    if args.coverage_only:
+        return
+
+    run_stage_b_eval(args)
+    print(f"Issue53-style Stage-C evaluation complete: {args.eval_output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/issue120/run_issue53_probe_rescue_then_eval.py
+++ b/tools/issue120/run_issue53_probe_rescue_then_eval.py
@@ -23,7 +23,6 @@ from typing import Any
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from tools.issue120.compare_candidate_coverage import main as _unused_compare_main  # noqa: F401,E402
 from tools.issue120.eval_full68_from_intermediates import iter_manifest  # noqa: E402
 from src.pipeline.steps.probe_scan import run_probe_scan_batch  # noqa: E402
 

--- a/tools/issue120/run_stage_c_seed_regen_then_eval.py
+++ b/tools/issue120/run_stage_c_seed_regen_then_eval.py
@@ -6,8 +6,9 @@ This wrapper keeps Stage C explicit:
 1. validate the historical log/model dependencies used by
    tools/repro_accuracy/reproduce_clean_seed_v12.py;
 2. optionally run that seed/candidate regeneration script;
-3. run the Stage-B verifier on the regenerated candidates;
-4. evaluate with the canonical #134 full-68 evaluator.
+3. validate regenerated candidate coverage before scoring;
+4. run the Stage-B verifier on the regenerated candidates;
+5. evaluate with the canonical #134 full-68 evaluator.
 
 Stage C still does not regenerate the slow upstream HOMR/OMR/SR artifacts. It
 starts from existing historical logs under logs/hybrid_generalization and checks
@@ -19,10 +20,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
+
+from tools.issue120.eval_full68_from_intermediates import find_page_file, iter_manifest
 
 
 DEFAULT_INVENTORY = Path("logs/issue36_prep/20260208_bench_inventory.json")
@@ -40,6 +44,11 @@ SCORE_TO_RUN = {
     "Va_Prokofiev_Symphony1": "20260330_044952",
     "Va__Prokofiev_Symphony5": "20260330_095914",
 }
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def write_json(path: Path, payload: Any) -> None:
@@ -71,6 +80,74 @@ def validate_inputs(args: argparse.Namespace) -> list[str]:
 def run_command(cmd: list[str]) -> None:
     print("+ " + " ".join(str(part) for part in cmd), flush=True)
     subprocess.run(cmd, check=True)
+
+
+def validate_candidate_coverage(args: argparse.Namespace) -> dict[str, Any]:
+    manifest = iter_manifest()
+    missing_pages: list[dict[str, str]] = []
+    empty_pages: list[dict[str, str]] = []
+    page_counts: list[dict[str, Any]] = []
+    total_candidates = 0
+
+    for record in manifest:
+        path = find_page_file(
+            args.regenerated_candidates_dir,
+            record,
+            "pipeline2_no_peak_candidates.json",
+        )
+        if path is None:
+            missing_pages.append({"score": record.score, "page": record.page})
+            continue
+
+        payload = load_json(path)
+        count = len(payload) if isinstance(payload, list) else 0
+        total_candidates += count
+        item = {
+            "score": record.score,
+            "page": record.page,
+            "path": str(path),
+            "candidate_count": count,
+        }
+        page_counts.append(item)
+        if count == 0:
+            empty_pages.append(item)
+
+    report = {
+        "schema_version": "issue120.stage_c.candidate_coverage.v1",
+        "regenerated_candidates_dir": str(args.regenerated_candidates_dir),
+        "expected_pages": len(manifest),
+        "present_pages": len(page_counts),
+        "missing_pages": missing_pages,
+        "empty_pages": empty_pages,
+        "total_candidates": total_candidates,
+        "page_counts": page_counts,
+    }
+    write_json(args.stage_c_eval_dir / "stage_c_candidate_coverage.json", report)
+    return report
+
+
+def assert_candidate_coverage(args: argparse.Namespace, report: dict[str, Any]) -> None:
+    missing_count = len(report["missing_pages"])
+    present_pages = int(report["present_pages"])
+    total_candidates = int(report["total_candidates"])
+    expected_pages = int(report["expected_pages"])
+
+    if missing_count:
+        raise SystemExit(
+            f"Stage C candidate coverage failed: {missing_count} missing pages. "
+            f"See {args.stage_c_eval_dir / 'stage_c_candidate_coverage.json'}"
+        )
+    if present_pages != expected_pages:
+        raise SystemExit(
+            f"Stage C candidate coverage failed: {present_pages}/{expected_pages} pages present. "
+            f"See {args.stage_c_eval_dir / 'stage_c_candidate_coverage.json'}"
+        )
+    if total_candidates < args.min_total_candidates:
+        raise SystemExit(
+            f"Stage C candidate coverage failed: only {total_candidates} total candidates; "
+            f"minimum is {args.min_total_candidates}. "
+            f"See {args.stage_c_eval_dir / 'stage_c_candidate_coverage.json'}"
+        )
 
 
 def build_stage_b_cmd(args: argparse.Namespace) -> list[str]:
@@ -129,9 +206,25 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--xdist-threshold", type=float, default=12.0)
     parser.add_argument("--bands-from", type=Path, default=None)
     parser.add_argument(
+        "--min-total-candidates",
+        type=int,
+        default=3000,
+        help="Fail before scoring if regenerated candidates are implausibly sparse.",
+    )
+    parser.add_argument(
         "--skip-regeneration",
         action="store_true",
         help="Skip reproduce_clean_seed_v12.py and only evaluate existing regenerated candidates.",
+    )
+    parser.add_argument(
+        "--no-clean-regen-output",
+        action="store_true",
+        help="Do not delete the regeneration output directory before running regeneration.",
+    )
+    parser.add_argument(
+        "--coverage-only",
+        action="store_true",
+        help="Validate regenerated candidate coverage and stop before scoring.",
     )
     parser.add_argument(
         "--validate-only",
@@ -170,10 +263,24 @@ def main() -> None:
         return
 
     if not args.skip_regeneration:
+        if args.regen_output_dir.exists() and not args.no_clean_regen_output:
+            shutil.rmtree(args.regen_output_dir)
         run_command([sys.executable, "tools/repro_accuracy/reproduce_clean_seed_v12.py"])
 
     if not args.regenerated_candidates_dir.exists():
         raise SystemExit(f"Regenerated candidates not found: {args.regenerated_candidates_dir}")
+
+    coverage = validate_candidate_coverage(args)
+    print(
+        "Stage-C candidate coverage: "
+        f"pages={coverage['present_pages']}/{coverage['expected_pages']} "
+        f"total_candidates={coverage['total_candidates']} "
+        f"missing={len(coverage['missing_pages'])} "
+        f"empty={len(coverage['empty_pages'])}"
+    )
+    assert_candidate_coverage(args, coverage)
+    if args.coverage_only:
+        return
 
     run_command(build_stage_b_cmd(args))
     print(f"Stage-C evaluation complete: {args.stage_c_eval_dir}")

--- a/tools/issue120/run_stage_c_seed_regen_then_eval.py
+++ b/tools/issue120/run_stage_c_seed_regen_then_eval.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Stage-C verifier for Issue #120: seed/candidate regeneration -> scoring -> eval.
+
+This wrapper keeps Stage C explicit:
+
+1. validate the historical log/model dependencies used by
+   tools/repro_accuracy/reproduce_clean_seed_v12.py;
+2. optionally run that seed/candidate regeneration script;
+3. run the Stage-B verifier on the regenerated candidates;
+4. evaluate with the canonical #134 full-68 evaluator.
+
+Stage C still does not regenerate the slow upstream HOMR/OMR/SR artifacts. It
+starts from existing historical logs under logs/hybrid_generalization and checks
+whether the current seed/probe regeneration path can reproduce candidates that
+score to the historical detector target.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_INVENTORY = Path("logs/issue36_prep/20260208_bench_inventory.json")
+DEFAULT_RUN_ROOT = Path("logs/hybrid_generalization/verify_fixed_v10")
+DEFAULT_REGEN_OUTPUT = Path("logs/repro_v12_recovery_final")
+DEFAULT_REGEN_CANDIDATES = DEFAULT_REGEN_OUTPUT / "probe_candidates_filtered_v12"
+DEFAULT_MODEL = Path(
+    "logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth"
+)
+
+SCORE_TO_RUN = {
+    "Shostakovich-Festival_Overture_Va": "20260324_121505",
+    "Shostakovich-Sym5-Va": "20260330_034727",
+    "Sibelius-Violin_Concerto-Viola": "20260330_042631",
+    "Va_Prokofiev_Symphony1": "20260330_044952",
+    "Va__Prokofiev_Symphony5": "20260330_095914",
+}
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def validate_inputs(args: argparse.Namespace) -> list[str]:
+    missing: list[str] = []
+    required_paths = [
+        args.inventory_path,
+        args.run_root,
+        args.model_path,
+        args.image_root,
+        args.gt_root,
+    ]
+    for path in required_paths:
+        if not path.exists():
+            missing.append(str(path))
+
+    for score_name, run_id in SCORE_TO_RUN.items():
+        run_dir = args.run_root / run_id
+        if not run_dir.exists():
+            missing.append(f"{run_dir}  # {score_name}")
+
+    return missing
+
+
+def run_command(cmd: list[str]) -> None:
+    print("+ " + " ".join(str(part) for part in cmd), flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def build_stage_b_cmd(args: argparse.Namespace) -> list[str]:
+    cmd = [
+        sys.executable,
+        "tools/issue120/score_candidates_then_eval_full68.py",
+        "--scorer",
+        args.scorer,
+        "--clean-output",
+        "--candidates-dir",
+        str(args.regenerated_candidates_dir),
+        "--image-root",
+        str(args.image_root),
+        "--gt-root",
+        str(args.gt_root),
+        "--model-path",
+        str(args.model_path),
+        "--scoring-output-dir",
+        str(args.stage_c_scoring_dir),
+        "--eval-output-dir",
+        str(args.stage_c_eval_dir),
+        "--score-threshold",
+        str(args.score_threshold),
+        "--xdist-threshold",
+        str(args.xdist_threshold),
+    ]
+    if args.scorer == "pipeline" and not args.pipeline_nms:
+        cmd.append("--disable-pipeline-nms")
+    if args.bands_from:
+        cmd.extend(["--bands-from", str(args.bands_from)])
+    return cmd
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inventory-path", type=Path, default=DEFAULT_INVENTORY)
+    parser.add_argument("--run-root", type=Path, default=DEFAULT_RUN_ROOT)
+    parser.add_argument("--regen-output-dir", type=Path, default=DEFAULT_REGEN_OUTPUT)
+    parser.add_argument("--regenerated-candidates-dir", type=Path, default=DEFAULT_REGEN_CANDIDATES)
+    parser.add_argument("--image-root", type=Path, default=Path("data/evaluation2/images"))
+    parser.add_argument("--gt-root", type=Path, default=Path("data/evaluation2/annotations"))
+    parser.add_argument("--model-path", type=Path, default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--stage-c-scoring-dir",
+        type=Path,
+        default=Path("logs/issue120_e2e_recovery/stage_c_seed_regen_scoring"),
+    )
+    parser.add_argument(
+        "--stage-c-eval-dir",
+        type=Path,
+        default=Path("logs/issue120_e2e_recovery/stage_c_seed_regen_eval"),
+    )
+    parser.add_argument("--scorer", choices=["pipeline", "legacy"], default="pipeline")
+    parser.add_argument("--pipeline-nms", action="store_true", default=False)
+    parser.add_argument("--score-threshold", type=float, default=0.1)
+    parser.add_argument("--xdist-threshold", type=float, default=12.0)
+    parser.add_argument("--bands-from", type=Path, default=None)
+    parser.add_argument(
+        "--skip-regeneration",
+        action="store_true",
+        help="Skip reproduce_clean_seed_v12.py and only evaluate existing regenerated candidates.",
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Only validate required historical inputs; do not run regeneration or evaluation.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    missing = validate_inputs(args)
+    report = {
+        "schema_version": "issue120.stage_c.validation.v1",
+        "inventory_path": str(args.inventory_path),
+        "run_root": str(args.run_root),
+        "regen_output_dir": str(args.regen_output_dir),
+        "regenerated_candidates_dir": str(args.regenerated_candidates_dir),
+        "model_path": str(args.model_path),
+        "score_to_run": SCORE_TO_RUN,
+        "missing": missing,
+        "scorer": args.scorer,
+        "pipeline_nms": args.pipeline_nms,
+    }
+    write_json(args.stage_c_eval_dir / "stage_c_input_validation.json", report)
+
+    if missing:
+        print("Missing required Stage-C inputs:")
+        for item in missing:
+            print(f"  - {item}")
+        print(f"Validation report: {args.stage_c_eval_dir / 'stage_c_input_validation.json'}")
+        raise SystemExit(2)
+
+    print("Stage-C input validation passed.")
+    if args.validate_only:
+        return
+
+    if not args.skip_regeneration:
+        run_command([sys.executable, "tools/repro_accuracy/reproduce_clean_seed_v12.py"])
+
+    if not args.regenerated_candidates_dir.exists():
+        raise SystemExit(f"Regenerated candidates not found: {args.regenerated_candidates_dir}")
+
+    run_command(build_stage_b_cmd(args))
+    print(f"Stage-C evaluation complete: {args.stage_c_eval_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/issue120/run_stage_c_seed_regen_then_eval.py
+++ b/tools/issue120/run_stage_c_seed_regen_then_eval.py
@@ -59,20 +59,24 @@ def write_json(path: Path, payload: Any) -> None:
 def validate_inputs(args: argparse.Namespace) -> list[str]:
     missing: list[str] = []
     required_paths = [
-        args.inventory_path,
-        args.run_root,
         args.model_path,
         args.image_root,
         args.gt_root,
     ]
+    if args.skip_regeneration:
+        required_paths.append(args.regenerated_candidates_dir)
+    else:
+        required_paths.extend([args.inventory_path, args.run_root])
+
     for path in required_paths:
         if not path.exists():
             missing.append(str(path))
 
-    for score_name, run_id in SCORE_TO_RUN.items():
-        run_dir = args.run_root / run_id
-        if not run_dir.exists():
-            missing.append(f"{run_dir}  # {score_name}")
+    if not args.skip_regeneration and args.run_root.exists():
+        for score_name, run_id in SCORE_TO_RUN.items():
+            run_dir = args.run_root / run_id
+            if not run_dir.exists():
+                missing.append(f"{run_dir}  # {score_name}")
 
     return missing
 
@@ -80,6 +84,21 @@ def validate_inputs(args: argparse.Namespace) -> list[str]:
 def run_command(cmd: list[str]) -> None:
     print("+ " + " ".join(str(part) for part in cmd), flush=True)
     subprocess.run(cmd, check=True)
+
+
+def run_regeneration(args: argparse.Namespace) -> None:
+    run_command(
+        [
+            sys.executable,
+            "tools/repro_accuracy/reproduce_clean_seed_v12.py",
+            "--inventory-path",
+            str(args.inventory_path),
+            "--run-root",
+            str(args.run_root),
+            "--output-root",
+            str(args.regen_output_dir),
+        ]
+    )
 
 
 def validate_candidate_coverage(args: argparse.Namespace) -> dict[str, Any]:
@@ -128,9 +147,9 @@ def validate_candidate_coverage(args: argparse.Namespace) -> dict[str, Any]:
 
 def assert_candidate_coverage(args: argparse.Namespace, report: dict[str, Any]) -> None:
     missing_count = len(report["missing_pages"])
-    present_pages = int(report["present_pages"])
-    total_candidates = int(report["total_candidates"])
-    expected_pages = int(report["expected_pages"])
+    present_pages = report["present_pages"]
+    total_candidates = report["total_candidates"]
+    expected_pages = report["expected_pages"]
 
     if missing_count:
         raise SystemExit(
@@ -246,6 +265,7 @@ def main() -> None:
         "model_path": str(args.model_path),
         "score_to_run": SCORE_TO_RUN,
         "missing": missing,
+        "skip_regeneration": args.skip_regeneration,
         "scorer": args.scorer,
         "pipeline_nms": args.pipeline_nms,
     }
@@ -265,7 +285,7 @@ def main() -> None:
     if not args.skip_regeneration:
         if args.regen_output_dir.exists() and not args.no_clean_regen_output:
             shutil.rmtree(args.regen_output_dir)
-        run_command([sys.executable, "tools/repro_accuracy/reproduce_clean_seed_v12.py"])
+        run_regeneration(args)
 
     if not args.regenerated_candidates_dir.exists():
         raise SystemExit(f"Regenerated candidates not found: {args.regenerated_candidates_dir}")

--- a/tools/issue120/score_candidates_then_eval_full68.py
+++ b/tools/issue120/score_candidates_then_eval_full68.py
@@ -2,8 +2,8 @@
 """Stage-B verifier for Issue #120: candidates -> CNN scoring -> full68 eval.
 
 This tool copies canonical 68-page candidate intermediates into a fresh scoring
-work directory, runs the current in-process CNN scoring implementation, then
-invokes the #134 evaluator on the scored outputs.
+work directory, runs a selected CNN scoring implementation, then invokes the #134
+evaluator on the scored outputs.
 
 It intentionally starts from `pipeline2_no_peak_candidates.json`; it does not
 regenerate candidates from HOMR/OMR/SR/hybrid/probe sources.
@@ -25,6 +25,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 from src.pipeline.core.run_ids import build_probe_run_id_from_parts  # noqa: E402
 from src.pipeline.steps.cnn_scoring import run_cnn_scoring_batch  # noqa: E402
+from tools.cnn_classifier.score_candidates_batch import run_scoring_batch as run_legacy_scoring_batch  # noqa: E402
 from tools.issue120.eval_full68_from_intermediates import (  # noqa: E402
     PageRecord,
     find_page_file,
@@ -89,6 +90,7 @@ def build_provenance(args: argparse.Namespace, processed_pages: int) -> dict[str
         "schema_version": "issue120.intermediate_provenance.v1",
         "status": "stage_b_candidate_to_cnn_scoring",
         "evaluated_stage": "post_cnn_scoring_detector_intermediate",
+        "scorer": args.scorer,
         "candidate_source_dir": str(args.candidates_dir),
         "scoring_output_dir": str(args.scoring_output_dir),
         "model_path": str(args.model_path),
@@ -103,6 +105,8 @@ def build_provenance(args: argparse.Namespace, processed_pages: int) -> dict[str
         "notes": [
             "Stage B starts from existing candidates and reruns CNN scoring only.",
             "It does not regenerate candidates from HOMR/OMR/SR/hybrid/probe sources.",
+            "scorer=pipeline uses src.pipeline.steps.cnn_scoring.run_cnn_scoring_batch.",
+            "scorer=legacy uses tools.cnn_classifier.score_candidates_batch.run_scoring_batch, matching the historical Issue #53 script family more closely.",
         ],
     }
 
@@ -135,6 +139,36 @@ def run_eval(args: argparse.Namespace, provenance_path: Path) -> None:
             str(provenance_path),
         ],
         check=True,
+    )
+
+
+def run_selected_scorer(args: argparse.Namespace, images: list[Path]) -> int:
+    if args.scorer == "pipeline":
+        return run_cnn_scoring_batch(
+            probe_output_root=args.scoring_output_dir,
+            images=images,
+            model_path=args.model_path,
+            threshold=args.score_threshold,
+            batch_size=args.batch_size,
+            staff_mask_dir=args.staff_mask_dir,
+            bands_from=args.bands_from,
+            staff_vov_threshold=args.staff_vov_threshold,
+            crop_recenter_on_bbox_ink=args.crop_recenter_on_bbox_ink,
+            crop_recenter_max_shift_unit_ratio=args.crop_recenter_max_shift_unit_ratio,
+            input_image_scale=args.input_image_scale,
+        )
+
+    return run_legacy_scoring_batch(
+        logs=args.scoring_output_dir,
+        model=args.model_path,
+        threshold=args.score_threshold,
+        images_root=args.image_root,
+        overwrite=True,
+        crop_recenter_on_bbox_ink=args.crop_recenter_on_bbox_ink,
+        crop_recenter_max_shift_unit_ratio=args.crop_recenter_max_shift_unit_ratio,
+        bands_from=args.bands_from,
+        staff_mask_dir=args.staff_mask_dir,
+        staff_vov_threshold=args.staff_vov_threshold,
     )
 
 
@@ -178,6 +212,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--xdist-threshold", type=float, default=12.0)
     parser.add_argument("--staff-vov-threshold", type=float, default=0.5)
     parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--scorer", choices=["pipeline", "legacy"], default="pipeline")
     parser.add_argument("--crop-recenter-on-bbox-ink", action="store_true", default=True)
     parser.add_argument("--no-crop-recenter-on-bbox-ink", dest="crop_recenter_on_bbox_ink", action="store_false")
     parser.add_argument("--crop-recenter-max-shift-unit-ratio", type=float, default=0.35)
@@ -220,19 +255,7 @@ def main() -> None:
             manifest=manifest,
             candidates_file=args.candidates_file,
         )
-        processed_pages = run_cnn_scoring_batch(
-            probe_output_root=args.scoring_output_dir,
-            images=images,
-            model_path=args.model_path,
-            threshold=args.score_threshold,
-            batch_size=args.batch_size,
-            staff_mask_dir=args.staff_mask_dir,
-            bands_from=args.bands_from,
-            staff_vov_threshold=args.staff_vov_threshold,
-            crop_recenter_on_bbox_ink=args.crop_recenter_on_bbox_ink,
-            crop_recenter_max_shift_unit_ratio=args.crop_recenter_max_shift_unit_ratio,
-            input_image_scale=args.input_image_scale,
-        )
+        processed_pages = run_selected_scorer(args, images)
     else:
         processed_pages = 0
 

--- a/tools/issue120/score_candidates_then_eval_full68.py
+++ b/tools/issue120/score_candidates_then_eval_full68.py
@@ -91,6 +91,7 @@ def build_provenance(args: argparse.Namespace, processed_pages: int) -> dict[str
         "status": "stage_b_candidate_to_cnn_scoring",
         "evaluated_stage": "post_cnn_scoring_detector_intermediate",
         "scorer": args.scorer,
+        "pipeline_nms_enabled": args.pipeline_nms_enabled,
         "candidate_source_dir": str(args.candidates_dir),
         "scoring_output_dir": str(args.scoring_output_dir),
         "model_path": str(args.model_path),
@@ -107,6 +108,7 @@ def build_provenance(args: argparse.Namespace, processed_pages: int) -> dict[str
             "It does not regenerate candidates from HOMR/OMR/SR/hybrid/probe sources.",
             "scorer=pipeline uses src.pipeline.steps.cnn_scoring.run_cnn_scoring_batch.",
             "scorer=legacy uses tools.cnn_classifier.score_candidates_batch.run_scoring_batch, matching the historical Issue #53 script family more closely.",
+            "pipeline_nms_enabled only applies to scorer=pipeline.",
         ],
     }
 
@@ -156,6 +158,7 @@ def run_selected_scorer(args: argparse.Namespace, images: list[Path]) -> int:
             crop_recenter_on_bbox_ink=args.crop_recenter_on_bbox_ink,
             crop_recenter_max_shift_unit_ratio=args.crop_recenter_max_shift_unit_ratio,
             input_image_scale=args.input_image_scale,
+            apply_nms_enabled=args.pipeline_nms_enabled,
         )
 
     return run_legacy_scoring_batch(
@@ -213,6 +216,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--staff-vov-threshold", type=float, default=0.5)
     parser.add_argument("--batch-size", type=int, default=64)
     parser.add_argument("--scorer", choices=["pipeline", "legacy"], default="pipeline")
+    parser.add_argument("--pipeline-nms-enabled", action="store_true", default=True)
+    parser.add_argument("--disable-pipeline-nms", dest="pipeline_nms_enabled", action="store_false")
     parser.add_argument("--crop-recenter-on-bbox-ink", action="store_true", default=True)
     parser.add_argument("--no-crop-recenter-on-bbox-ink", dest="crop_recenter_on_bbox_ink", action="store_false")
     parser.add_argument("--crop-recenter-max-shift-unit-ratio", type=float, default=0.35)

--- a/tools/issue120/score_candidates_then_eval_full68.py
+++ b/tools/issue120/score_candidates_then_eval_full68.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Stage-B verifier for Issue #120: candidates -> CNN scoring -> full68 eval.
+
+This tool copies canonical 68-page candidate intermediates into a fresh scoring
+work directory, runs the current in-process CNN scoring implementation, then
+invokes the #134 evaluator on the scored outputs.
+
+It intentionally starts from `pipeline2_no_peak_candidates.json`; it does not
+regenerate candidates from HOMR/OMR/SR/hybrid/probe sources.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.pipeline.core.run_ids import build_probe_run_id_from_parts  # noqa: E402
+from src.pipeline.steps.cnn_scoring import run_cnn_scoring_batch  # noqa: E402
+from tools.issue120.eval_full68_from_intermediates import (  # noqa: E402
+    PageRecord,
+    find_page_file,
+    iter_manifest,
+)
+
+
+DEFAULT_MODEL = Path(
+    "logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth"
+)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def collect_images(image_root: Path, manifest: list[PageRecord]) -> list[Path]:
+    images: list[Path] = []
+    missing: list[str] = []
+    for record in manifest:
+        path = image_root / record.score / f"{record.page}.png"
+        if not path.exists():
+            missing.append(str(path))
+        else:
+            images.append(path)
+    if missing:
+        raise SystemExit("Missing canonical images:\n" + "\n".join(missing))
+    return images
+
+
+def copy_candidates(
+    *,
+    candidates_dir: Path,
+    scoring_root: Path,
+    manifest: list[PageRecord],
+    candidates_file: str,
+) -> list[dict[str, str]]:
+    copied: list[dict[str, str]] = []
+    missing: list[dict[str, str]] = []
+    for record in manifest:
+        src = find_page_file(candidates_dir, record, candidates_file)
+        if src is None:
+            missing.append(asdict(record))
+            continue
+        run_id = build_probe_run_id_from_parts(record.score, record.page)
+        dest_dir = scoring_root / run_id
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / "pipeline2_no_peak_candidates.json"
+        shutil.copy2(src, dest)
+        copied.append({"score": record.score, "page": record.page, "src": str(src), "dest": str(dest)})
+    if missing:
+        write_json(scoring_root / "missing_candidate_pages.json", missing)
+        raise SystemExit(
+            f"Missing {len(missing)} candidate files. See {scoring_root / 'missing_candidate_pages.json'}"
+        )
+    write_json(scoring_root / "copied_candidates.json", copied)
+    return copied
+
+
+def build_provenance(args: argparse.Namespace, processed_pages: int) -> dict[str, Any]:
+    return {
+        "schema_version": "issue120.intermediate_provenance.v1",
+        "status": "stage_b_candidate_to_cnn_scoring",
+        "evaluated_stage": "post_cnn_scoring_detector_intermediate",
+        "candidate_source_dir": str(args.candidates_dir),
+        "scoring_output_dir": str(args.scoring_output_dir),
+        "model_path": str(args.model_path),
+        "bands_from": str(args.bands_from) if args.bands_from else None,
+        "staff_mask_dir": str(args.staff_mask_dir) if args.staff_mask_dir else None,
+        "processed_pages": processed_pages,
+        "score_threshold": args.score_threshold,
+        "staff_vov_threshold": args.staff_vov_threshold,
+        "crop_recenter_on_bbox_ink": args.crop_recenter_on_bbox_ink,
+        "crop_recenter_max_shift_unit_ratio": args.crop_recenter_max_shift_unit_ratio,
+        "input_image_scale": args.input_image_scale,
+        "notes": [
+            "Stage B starts from existing candidates and reruns CNN scoring only.",
+            "It does not regenerate candidates from HOMR/OMR/SR/hybrid/probe sources.",
+        ],
+    }
+
+
+def run_eval(args: argparse.Namespace, provenance_path: Path) -> None:
+    cmd = [
+        sys.executable,
+        "tools/issue120/eval_full68_from_intermediates.py",
+        "--results-dir",
+        str(args.scoring_output_dir),
+        "--gt-root",
+        str(args.gt_root),
+        "--output-dir",
+        str(args.eval_output_dir),
+        "--score-threshold",
+        str(args.score_threshold),
+        "--xdist-threshold",
+        str(args.xdist_threshold),
+    ]
+    subprocess.run(cmd, check=True)
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/issue120/attach_eval_provenance.py",
+            "--output-dir",
+            str(args.eval_output_dir),
+            "--results-dir",
+            str(args.scoring_output_dir),
+            "--provenance-json",
+            str(provenance_path),
+        ],
+        check=True,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--candidates-dir",
+        type=Path,
+        default=Path("data/evaluation2/golden_baseline_eval2_bc23deb"),
+        help="Root containing canonical 68-page pipeline2_no_peak_candidates.json files.",
+    )
+    parser.add_argument(
+        "--image-root",
+        type=Path,
+        default=Path("data/evaluation2/images"),
+        help="Root containing evaluation2 page images.",
+    )
+    parser.add_argument(
+        "--gt-root",
+        type=Path,
+        default=Path("data/evaluation2/annotations"),
+        help="Root containing evaluation2 GT annotations.",
+    )
+    parser.add_argument(
+        "--scoring-output-dir",
+        type=Path,
+        default=Path("logs/issue120_e2e_recovery/stage_b_candidate_scoring"),
+        help="Work directory for copied candidates and newly scored outputs.",
+    )
+    parser.add_argument(
+        "--eval-output-dir",
+        type=Path,
+        default=Path("logs/issue120_e2e_recovery/stage_b_candidate_scoring_eval"),
+        help="Output directory for canonical full68 evaluation results.",
+    )
+    parser.add_argument("--candidates-file", default="pipeline2_no_peak_candidates.json")
+    parser.add_argument("--model-path", type=Path, default=DEFAULT_MODEL)
+    parser.add_argument("--bands-from", type=Path, default=None)
+    parser.add_argument("--staff-mask-dir", type=Path, default=None)
+    parser.add_argument("--score-threshold", type=float, default=0.1)
+    parser.add_argument("--xdist-threshold", type=float, default=12.0)
+    parser.add_argument("--staff-vov-threshold", type=float, default=0.5)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--crop-recenter-on-bbox-ink", action="store_true", default=True)
+    parser.add_argument("--no-crop-recenter-on-bbox-ink", dest="crop_recenter_on_bbox_ink", action="store_false")
+    parser.add_argument("--crop-recenter-max-shift-unit-ratio", type=float, default=0.35)
+    parser.add_argument("--input-image-scale", type=float, default=1.0)
+    parser.add_argument(
+        "--clean-output",
+        action="store_true",
+        help="Delete scoring/eval output directories before running.",
+    )
+    parser.add_argument(
+        "--skip-scoring",
+        action="store_true",
+        help="Only run canonical evaluation against an existing scoring output directory.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    manifest = iter_manifest()
+
+    if args.clean_output:
+        shutil.rmtree(args.scoring_output_dir, ignore_errors=True)
+        shutil.rmtree(args.eval_output_dir, ignore_errors=True)
+
+    args.scoring_output_dir.mkdir(parents=True, exist_ok=True)
+    args.eval_output_dir.mkdir(parents=True, exist_ok=True)
+
+    images = collect_images(args.image_root, manifest)
+
+    if not args.skip_scoring:
+        if not args.model_path.exists():
+            raise SystemExit(
+                f"Model not found: {args.model_path}\n"
+                "Provide --model-path or restore the expected CNN model artifact."
+            )
+        copy_candidates(
+            candidates_dir=args.candidates_dir,
+            scoring_root=args.scoring_output_dir,
+            manifest=manifest,
+            candidates_file=args.candidates_file,
+        )
+        processed_pages = run_cnn_scoring_batch(
+            probe_output_root=args.scoring_output_dir,
+            images=images,
+            model_path=args.model_path,
+            threshold=args.score_threshold,
+            batch_size=args.batch_size,
+            staff_mask_dir=args.staff_mask_dir,
+            bands_from=args.bands_from,
+            staff_vov_threshold=args.staff_vov_threshold,
+            crop_recenter_on_bbox_ink=args.crop_recenter_on_bbox_ink,
+            crop_recenter_max_shift_unit_ratio=args.crop_recenter_max_shift_unit_ratio,
+            input_image_scale=args.input_image_scale,
+        )
+    else:
+        processed_pages = 0
+
+    provenance = build_provenance(args, processed_pages)
+    provenance_path = args.eval_output_dir / "stage_b_provenance.json"
+    write_json(provenance_path, provenance)
+    run_eval(args, provenance_path)
+    print(f"Stage-B evaluation complete: {args.eval_output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/repro_accuracy/reproduce_clean_seed_v12.py
+++ b/tools/repro_accuracy/reproduce_clean_seed_v12.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import logging
 import sys
@@ -16,8 +17,8 @@ from src.pipeline.steps.probe_scan import run_probe_scan_batch
 logging.basicConfig(level=logging.INFO)
 
 # Constants for easy configuration
-INVENTORY_PATH = Path("logs/issue36_prep/20260208_bench_inventory.json")
-RUN_ROOT = Path("logs/hybrid_generalization/verify_fixed_v10")
+DEFAULT_INVENTORY_PATH = Path("logs/issue36_prep/20260208_bench_inventory.json")
+DEFAULT_RUN_ROOT = Path("logs/hybrid_generalization/verify_fixed_v10")
 
 # Mapping from score name to the specific timestamp subdirectory in verify_fixed_v10
 SCORE_TO_RUN = {
@@ -28,20 +29,32 @@ SCORE_TO_RUN = {
     "Va__Prokofiev_Symphony5": "20260330_095914",
 }
 
-OUTPUT_ROOT_TOP = Path("logs/repro_v12_recovery_final")
+DEFAULT_OUTPUT_ROOT_TOP = Path("logs/repro_v12_recovery_final")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inventory-path", type=Path, default=DEFAULT_INVENTORY_PATH)
+    parser.add_argument("--run-root", type=Path, default=DEFAULT_RUN_ROOT)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT_TOP)
+    return parser
 
 
 def main():
-    if not INVENTORY_PATH.exists():
-        print(f"Error: {INVENTORY_PATH} not found.")
+    args = build_parser().parse_args()
+    inventory_path = args.inventory_path
+    run_root = args.run_root
+    output_root_top = args.output_root
+
+    if not inventory_path.exists():
+        print(f"Error: {inventory_path} not found.")
         return
 
-    inv_data = json.loads(INVENTORY_PATH.read_text())
+    inv_data = json.loads(inventory_path.read_text())
     records = inv_data.get("records", [])
 
     print(f"Found {len(records)} pages in inventory.")
 
-    output_root_top = OUTPUT_ROOT_TOP
     output_root_top.mkdir(parents=True, exist_ok=True)
 
     processed_count = 0
@@ -55,7 +68,7 @@ def main():
             print(f"Warning: No run mapping for {score_name}. Skipping.")
             continue
 
-        hybrid_sub_root = RUN_ROOT / SCORE_TO_RUN[score_name]
+        hybrid_sub_root = run_root / SCORE_TO_RUN[score_name]
 
         # Use robust path lookup
         baseline_json = (


### PR DESCRIPTION
## Related Issue
- Closes #136
- Parent: #120
- Follow-ups: #140, #141, #142

## What
Documents and tools the Issue #120 historical-best audit.

This PR identifies the clean detector-level reconstruction target for the historical `TP=3580 / FP=0 / FN=1` result and separates it from full slow-upstream pipeline reproduction.

## Summary

### Stage A: saved scored intermediates
Already verified by #134:

```text
Saved scored Golden Baseline -> #134 evaluator
TP=3580 FP=0 FN=1
```

### Stage B: saved candidates -> scoring -> evaluation
This PR adds `tools/issue120/score_candidates_then_eval_full68.py`.

Findings:

```text
saved candidates + legacy scorer:
  Pred=3597 TP=3580 FP=0 FN=1

saved candidates + pipeline scorer + NMS enabled:
  Pred=3507 TP=3507 FP=0 FN=74

saved candidates + pipeline scorer + NMS disabled:
  Pred=3597 TP=3580 FP=0 FN=1
```

Conclusion:

- The saved candidates, model artifact, images, GT, and CNN inference are sufficient.
- The Stage B regression is caused by current pipeline CNN scoring NMS.
- NMS remains enabled by default globally.
- Issue #120 canonical reconstruction must explicitly record `cnn_apply_nms=false`.

### Stage C: regenerated candidates -> scoring -> evaluation
The previous `reproduce_clean_seed_v12.py` path was tested and found not to regenerate the full Golden Baseline candidate layer:

```text
baseline candidates: 29443
regenerated candidates: 180
empty pages: 40
```

A #57 / Issue53-derived path was recovered and implemented as:

```text
tools/issue120/run_issue53_probe_rescue_then_eval.py
```

Observed result:

```text
Issue53 probe rescue candidates: 29772
TP=3580 FP=0 FN=1
```

Current clean detector-level reconstruction target:

```text
#57 / Issue53 probe rescue candidate generation
  -> current pipeline CNN scoring
  -> cnn_apply_nms=false
  -> #134 canonical full-68 evaluator
  -> TP=3580 FP=0 FN=1
```

## Changes

Docs:
- `docs/ISSUE120_HISTORICAL_BEST_AUDIT.md`
- `docs/ISSUE120_STAGE_B_SCORING_DRIFT.md`
- `docs/ISSUE120_NMS_POLICY.md`
- `docs/ISSUE120_ROADMAP.md`

Tools:
- `tools/issue120/score_candidates_then_eval_full68.py`
- `tools/issue120/compare_candidate_coverage.py`
- `tools/issue120/run_stage_c_seed_regen_then_eval.py`
- `tools/issue120/run_issue53_probe_rescue_then_eval.py`

Pipeline config surface:
- `detection.cnn_apply_nms`, defaulting to `true`.
- Audit tools can disable NMS explicitly for Issue #120 reconstruction.

Makefile:
- Adds Stage B verifier convenience targets.

## Scope boundaries

This PR does not claim full slow-upstream pipeline reproduction.

Still open:
- #140: regenerate or bound slow upstream HOMR/OMR/SR artifacts.
- #141: full 68-page pipeline validation.
- #142: decide whether NMS should be tuned, conditional, or kept as-is.

## Local verification results

### Stage B, pipeline scorer with NMS disabled

```text
Pages: 68/68
Detector: GT=3581 Pred=3597 TP=3580 FP=0 FN=1 FN_det=0 FN_cnn=1 Precision=1.000000 Recall=0.999721
```

### Stage C, Issue53 probe rescue path

```text
Issue53-style probe regeneration processed pages: 68
Baseline candidates: 29443
Compared candidates: 29772
Ratio: 1.011174133070679
Empty compared pages: 0
Pages: 68/68
Detector: GT=3581 Pred=3600 TP=3580 FP=0 FN=1 FN_det=0 FN_cnn=1 Precision=1.000000 Recall=0.999721
```

## Review notes

The PR is intentionally audit-heavy. Generated outputs are not committed. The new scripts produce outputs under ignored `logs/` paths and record provenance/coverage/evaluation contracts.