### PR TITLE
Issue120: integrate Issue36 dense candidate validation route

### DIFF
--- a/docs/refactors/issue120/ISSUE120_ISSUE36_DENSE_VALIDATION.md
+++ b/docs/refactors/issue120/ISSUE120_ISSUE36_DENSE_VALIDATION.md
@@ -4,7 +4,7 @@
 
 Issue #149 integrates the recovered Issue #36 v12 dense candidate producer into the current Issue #120 validation workflow.
 
-The route is intentionally narrower than full Stage E pipeline validation:
+The accepted route is intentionally narrower than full Stage E pipeline validation:
 
 ```text
 Issue #36 v12 bench inventory
@@ -12,7 +12,9 @@ Issue #36 v12 bench inventory
   -> compare raw candidates with recovered historical root
   -> apply clef-mask-aware filter
   -> compare filtered candidates with recovered historical roots
-  -> current CNN scoring
+  -> use regenerated filtered root as Issue53 `bands_from`
+  -> regenerate Issue53 probe-rescue candidates
+  -> current CNN scoring with explicit NMS setting
   -> #134 full-68 detector evaluator
 ```
 
@@ -28,6 +30,24 @@ TP=3580 / FP=0 / FN=1
 
 Detector metrics and downstream measure-count metrics must remain separate.
 
+## Important route distinction
+
+The recovered Issue #36 filtered root is byte-identical to the historical dense `bands_from` / scoring-input root:
+
+```text
+logs/issue36_prep/probe_candidates_filtered_v12
+= logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12
+```
+
+It is not the final Issue #120 candidate root to score directly. Direct scoring is a useful diagnostic and has shown detector-side misses:
+
+```text
+Issue36 filtered root -> current CNN scoring -> evaluator
+observed: TP=3566 FP=0 FN=15 FN_det=12 FN_cnn=3
+```
+
+Therefore the #149 acceptance route uses the recovered filtered root as `bands_from` for the current Issue53 probe-rescue verifier, matching the clean reconstruction path established by #136/#143.
+
 ## Reproduction-sensitive generation setting
 
 The current `detect_probe_scan` default for `band_cluster_max_dist` no longer matches the historical `edf7bf6` Issue #36 v12 implementation. The Issue #36 route therefore pins:
@@ -38,19 +58,26 @@ band_cluster_max_dist=25.0
 
 This is route-local. It must not be interpreted as a general pipeline default change.
 
-## Main wrapper
+## Main wrappers
+
+Acceptance route:
+
+```text
+tools/issue120/run_issue36_dense_bands_then_issue53_eval.py
+```
+
+Diagnostic direct-score route:
 
 ```text
 tools/issue120/run_issue36_dense_candidates_then_eval.py
 ```
 
-The wrapper records route provenance under ignored `logs/` output, including:
+The acceptance wrapper records route provenance under ignored `logs/` output, including:
 
-- raw and filtered candidate root summaries;
+- raw and filtered Issue36 candidate root summaries;
 - raw / filtered / historical scoring-input candidate-root comparison summaries;
-- generation parameters;
-- filter parameters;
 - clef-mask filtering status and clef-mask resolution;
+- Issue53 probe-rescue provenance and candidate coverage summary;
 - CNN scorer and explicit `cnn_apply_nms` setting;
 - detector target and observed detector summary;
 - scope guards for #141 and #142.
@@ -67,12 +94,6 @@ The #149 target is kept in a small include file to avoid enlarging the root Make
 
 ```bash
 make -f Makefile -f tools/issue120/Makefile.issue36_dense.mk verify-issue120-issue36-dense
-```
-
-By default, the Make target requires historical candidate-root equality before scoring:
-
-```text
-ISSUE120_ISSUE36_DENSE_REQUIRE_CANDIDATES=1
 ```
 
 To make the run fail unless the detector target is exactly met:
@@ -99,7 +120,6 @@ ISSUE120_ISSUE36_DENSE_EXCLUDE
 ISSUE120_ISSUE36_DENSE_HISTORICAL_RAW
 ISSUE120_ISSUE36_DENSE_HISTORICAL_FILTERED
 ISSUE120_ISSUE36_DENSE_HISTORICAL_SCORING_INPUT
-ISSUE120_ISSUE36_DENSE_REQUIRE_CANDIDATES
 ISSUE120_ISSUE36_DENSE_REQUIRE_TARGET
 ```
 
@@ -111,7 +131,7 @@ docker run --rm --gpus all \
   -w /workspace \
   -e PYTHONPATH=/workspace \
   pdfscore_pipeline_gpu \
-  /opt/venv_pipeline/bin/python tools/issue120/run_issue36_dense_candidates_then_eval.py \
+  /opt/venv_pipeline/bin/python tools/issue120/run_issue36_dense_bands_then_issue53_eval.py \
     --inventory logs/issue36_prep/20260208_bench_inventory.json \
     --exclude logs/issue36_prep/excluded_pages_for_gt_prep.json \
     --historical-raw-candidates-root logs/issue36_prep/probe_candidates_from_bench_v12 \
@@ -122,7 +142,6 @@ docker run --rm --gpus all \
     --model-path logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth \
     --output-root logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation \
     --no-pipeline-nms \
-    --require-candidate-match \
     --require-detector-target
 ```
 
@@ -138,9 +157,11 @@ logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation/
   scoring_input_delta/
   probe_generation_summary_v12_current.json
   filter_apply_summary_v12_current.json
+  issue53_probe_rescue_candidates/
   scoring/
   eval/
   issue36_dense_candidate_route_provenance.json
+  issue36_dense_bands_issue53_route_provenance.json
 ```
 
 All of these outputs are generated artifacts and must not be committed.
@@ -172,11 +193,12 @@ python3 - <<'PY'
 import json
 from pathlib import Path
 root = Path('logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation')
-prov = json.loads((root / 'issue36_dense_candidate_route_provenance.json').read_text())
+prov = json.loads((root / 'issue36_dense_bands_issue53_route_provenance.json').read_text())
 print(prov['candidate_root_summary'])
-print(prov['candidate_root_comparisons'])
+print(prov['issue36_provenance']['candidate_root_comparisons'])
 print(prov['clef_mask_filtering']['resolution'])
 print(prov['clef_mask_filtering']['reason_counts'])
+print(prov['issue53_probe_rescue']['candidate_coverage_summary'])
 print(prov['cnn_scoring'])
 print(prov['detector_summary'])
 PY
@@ -199,6 +221,22 @@ Expected detector target:
 
 ```text
 TP=3580 / FP=0 / FN=1
+```
+
+## Diagnostic direct-score target
+
+To reproduce the known direct-score boundary:
+
+```bash
+make -f Makefile -f tools/issue120/Makefile.issue36_dense.mk \
+  verify-issue120-issue36-dense-direct-score
+```
+
+Expected diagnostic interpretation:
+
+```text
+candidate roots: exact match
+Issue36 filtered root direct scoring: not the acceptance route
 ```
 
 ## Scope boundaries

--- a/docs/refactors/issue120/ISSUE120_ISSUE36_DENSE_VALIDATION.md
+++ b/docs/refactors/issue120/ISSUE120_ISSUE36_DENSE_VALIDATION.md
@@ -9,7 +9,9 @@ The route is intentionally narrower than full Stage E pipeline validation:
 ```text
 Issue #36 v12 bench inventory
   -> generate dense raw candidates
+  -> compare raw candidates with recovered historical root
   -> apply clef-mask-aware filter
+  -> compare filtered candidates with recovered historical roots
   -> current CNN scoring
   -> #134 full-68 detector evaluator
 ```
@@ -26,6 +28,16 @@ TP=3580 / FP=0 / FN=1
 
 Detector metrics and downstream measure-count metrics must remain separate.
 
+## Reproduction-sensitive generation setting
+
+The current `detect_probe_scan` default for `band_cluster_max_dist` no longer matches the historical `edf7bf6` Issue #36 v12 implementation. The Issue #36 route therefore pins:
+
+```text
+band_cluster_max_dist=25.0
+```
+
+This is route-local. It must not be interpreted as a general pipeline default change.
+
 ## Main wrapper
 
 ```text
@@ -35,6 +47,7 @@ tools/issue120/run_issue36_dense_candidates_then_eval.py
 The wrapper records route provenance under ignored `logs/` output, including:
 
 - raw and filtered candidate root summaries;
+- raw / filtered / historical scoring-input candidate-root comparison summaries;
 - generation parameters;
 - filter parameters;
 - clef-mask filtering status and clef-mask resolution;
@@ -54,6 +67,12 @@ The #149 target is kept in a small include file to avoid enlarging the root Make
 
 ```bash
 make -f Makefile -f tools/issue120/Makefile.issue36_dense.mk verify-issue120-issue36-dense
+```
+
+By default, the Make target requires historical candidate-root equality before scoring:
+
+```text
+ISSUE120_ISSUE36_DENSE_REQUIRE_CANDIDATES=1
 ```
 
 To make the run fail unless the detector target is exactly met:
@@ -77,6 +96,10 @@ ISSUE120_XDIST_THRESHOLD
 ISSUE120_ISSUE36_DENSE_OUTPUT_ROOT
 ISSUE120_ISSUE36_DENSE_INVENTORY
 ISSUE120_ISSUE36_DENSE_EXCLUDE
+ISSUE120_ISSUE36_DENSE_HISTORICAL_RAW
+ISSUE120_ISSUE36_DENSE_HISTORICAL_FILTERED
+ISSUE120_ISSUE36_DENSE_HISTORICAL_SCORING_INPUT
+ISSUE120_ISSUE36_DENSE_REQUIRE_CANDIDATES
 ISSUE120_ISSUE36_DENSE_REQUIRE_TARGET
 ```
 
@@ -91,11 +114,15 @@ docker run --rm --gpus all \
   /opt/venv_pipeline/bin/python tools/issue120/run_issue36_dense_candidates_then_eval.py \
     --inventory logs/issue36_prep/20260208_bench_inventory.json \
     --exclude logs/issue36_prep/excluded_pages_for_gt_prep.json \
+    --historical-raw-candidates-root logs/issue36_prep/probe_candidates_from_bench_v12 \
+    --historical-filtered-candidates-root logs/issue36_prep/probe_candidates_filtered_v12 \
+    --historical-scoring-input-root logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12 \
     --image-root data/evaluation2/images \
     --gt-root data/evaluation2/annotations \
     --model-path logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth \
     --output-root logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation \
     --no-pipeline-nms \
+    --require-candidate-match \
     --require-detector-target
 ```
 
@@ -106,6 +133,9 @@ logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation/
   probe_candidates_from_bench_v12/
   probe_candidates_filtered_v12/
   filter_suggestions_v12/
+  raw_delta/
+  filtered_delta/
+  scoring_input_delta/
   probe_generation_summary_v12_current.json
   filter_apply_summary_v12_current.json
   scoring/
@@ -114,6 +144,24 @@ logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation/
 ```
 
 All of these outputs are generated artifacts and must not be committed.
+
+## Required candidate-root checks
+
+The route writes `filter_candidate_delta_summary.json` under each delta directory.
+
+Expected comparison properties:
+
+```text
+raw_delta.summary.mismatch_pages=0
+raw_delta.summary.total_extra_in_repro=0
+raw_delta.summary.total_missing_from_repro=0
+filtered_delta.summary.mismatch_pages=0
+filtered_delta.summary.total_extra_in_repro=0
+filtered_delta.summary.total_missing_from_repro=0
+scoring_input_delta.summary.mismatch_pages=0
+scoring_input_delta.summary.total_extra_in_repro=0
+scoring_input_delta.summary.total_missing_from_repro=0
+```
 
 ## Required provenance checks
 
@@ -126,6 +174,7 @@ from pathlib import Path
 root = Path('logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation')
 prov = json.loads((root / 'issue36_dense_candidate_route_provenance.json').read_text())
 print(prov['candidate_root_summary'])
+print(prov['candidate_root_comparisons'])
 print(prov['clef_mask_filtering']['resolution'])
 print(prov['clef_mask_filtering']['reason_counts'])
 print(prov['cnn_scoring'])

--- a/docs/refactors/issue120/ISSUE120_ISSUE36_DENSE_VALIDATION.md
+++ b/docs/refactors/issue120/ISSUE120_ISSUE36_DENSE_VALIDATION.md
@@ -1,0 +1,159 @@
+# Issue 120 / Issue 149: Issue36 Dense Candidate Validation Route
+
+## Purpose
+
+Issue #149 integrates the recovered Issue #36 v12 dense candidate producer into the current Issue #120 validation workflow.
+
+The route is intentionally narrower than full Stage E pipeline validation:
+
+```text
+Issue #36 v12 bench inventory
+  -> generate dense raw candidates
+  -> apply clef-mask-aware filter
+  -> current CNN scoring
+  -> #134 full-68 detector evaluator
+```
+
+It does not change general pipeline defaults. It does not run the full slow HOMR/SR/OMR pipeline.
+
+## Acceptance target
+
+Detector-level target:
+
+```text
+TP=3580 / FP=0 / FN=1
+```
+
+Detector metrics and downstream measure-count metrics must remain separate.
+
+## Main wrapper
+
+```text
+tools/issue120/run_issue36_dense_candidates_then_eval.py
+```
+
+The wrapper records route provenance under ignored `logs/` output, including:
+
+- raw and filtered candidate root summaries;
+- generation parameters;
+- filter parameters;
+- clef-mask filtering status and clef-mask resolution;
+- CNN scorer and explicit `cnn_apply_nms` setting;
+- detector target and observed detector summary;
+- scope guards for #141 and #142.
+
+Default output root:
+
+```text
+logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation
+```
+
+## Make target
+
+The #149 target is kept in a small include file to avoid enlarging the root Makefile while this route is under review:
+
+```bash
+make -f Makefile -f tools/issue120/Makefile.issue36_dense.mk verify-issue120-issue36-dense
+```
+
+To make the run fail unless the detector target is exactly met:
+
+```bash
+make -f Makefile -f tools/issue120/Makefile.issue36_dense.mk \
+  verify-issue120-issue36-dense \
+  ISSUE120_ISSUE36_DENSE_REQUIRE_TARGET=1
+```
+
+Useful variables:
+
+```text
+ISSUE120_DOCKER_IMAGE
+ISSUE120_DOCKER_PYTHON
+ISSUE120_IMAGE_ROOT
+ISSUE120_GT_ROOT
+ISSUE120_MODEL_PATH
+ISSUE120_SCORE_THRESHOLD
+ISSUE120_XDIST_THRESHOLD
+ISSUE120_ISSUE36_DENSE_OUTPUT_ROOT
+ISSUE120_ISSUE36_DENSE_INVENTORY
+ISSUE120_ISSUE36_DENSE_EXCLUDE
+ISSUE120_ISSUE36_DENSE_REQUIRE_TARGET
+```
+
+## Direct Docker command
+
+```bash
+docker run --rm --gpus all \
+  -v "$PWD":/workspace \
+  -w /workspace \
+  -e PYTHONPATH=/workspace \
+  pdfscore_pipeline_gpu \
+  /opt/venv_pipeline/bin/python tools/issue120/run_issue36_dense_candidates_then_eval.py \
+    --inventory logs/issue36_prep/20260208_bench_inventory.json \
+    --exclude logs/issue36_prep/excluded_pages_for_gt_prep.json \
+    --image-root data/evaluation2/images \
+    --gt-root data/evaluation2/annotations \
+    --model-path logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth \
+    --output-root logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation \
+    --no-pipeline-nms \
+    --require-detector-target
+```
+
+## Expected generated files
+
+```text
+logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation/
+  probe_candidates_from_bench_v12/
+  probe_candidates_filtered_v12/
+  filter_suggestions_v12/
+  probe_generation_summary_v12_current.json
+  filter_apply_summary_v12_current.json
+  scoring/
+  eval/
+  issue36_dense_candidate_route_provenance.json
+```
+
+All of these outputs are generated artifacts and must not be committed.
+
+## Required provenance checks
+
+After a successful run, check:
+
+```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+root = Path('logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation')
+prov = json.loads((root / 'issue36_dense_candidate_route_provenance.json').read_text())
+print(prov['candidate_root_summary'])
+print(prov['clef_mask_filtering']['resolution'])
+print(prov['clef_mask_filtering']['reason_counts'])
+print(prov['cnn_scoring'])
+print(prov['detector_summary'])
+PY
+```
+
+Expected recovered filter properties:
+
+```text
+filtered candidate files=68
+filtered candidate total=22565
+clef_mask_resolution.resolved_pages=68
+clef_mask_resolution.missing_pages=0
+reason_counts.left_margin_zone=3520
+reason_counts.clef_mask_overlap=4665
+reason_counts.no_staff_overlap=781
+cnn_apply_nms=false
+```
+
+Expected detector target:
+
+```text
+TP=3580 / FP=0 / FN=1
+```
+
+## Scope boundaries
+
+- NMS policy and any general default change remain owned by #142.
+- Full slow HOMR/SR/OMR pipeline validation remains owned by #141.
+- This route validates the recovered dense candidate producer and current scoring/evaluator path only.

--- a/tools/issue120/Makefile.issue36_dense.mk
+++ b/tools/issue120/Makefile.issue36_dense.mk
@@ -1,0 +1,29 @@
+# Issue #120 / #149 dense candidate producer validation targets.
+# Use with:
+#   make -f Makefile -f tools/issue120/Makefile.issue36_dense.mk verify-issue120-issue36-dense
+
+ISSUE120_ISSUE36_DENSE_OUTPUT_ROOT ?= logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation
+ISSUE120_ISSUE36_DENSE_INVENTORY ?= logs/issue36_prep/20260208_bench_inventory.json
+ISSUE120_ISSUE36_DENSE_EXCLUDE ?= logs/issue36_prep/excluded_pages_for_gt_prep.json
+ISSUE120_ISSUE36_DENSE_REQUIRE_TARGET ?= 0
+
+verify-issue120-issue36-dense: ## Regenerate Issue #36 v12 dense candidates, score, and evaluate Issue #120 detector metrics
+	@mkdir -p artifacts
+	@LOG_FILE="artifacts/issue120_issue36_dense_verify_$$(date +%Y%m%d_%H%M%S).log"; \
+	TARGET_ARG=""; \
+	if [ "$(ISSUE120_ISSUE36_DENSE_REQUIRE_TARGET)" = "1" ]; then TARGET_ARG="--require-detector-target"; fi; \
+	echo "Running Issue #120/#149 Issue36 dense candidate validation. Logging to $$LOG_FILE..."; \
+	docker run --rm --gpus all -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace $(ISSUE120_DOCKER_IMAGE) \
+		$(ISSUE120_DOCKER_PYTHON) tools/issue120/run_issue36_dense_candidates_then_eval.py \
+		--inventory "$(ISSUE120_ISSUE36_DENSE_INVENTORY)" \
+		--exclude "$(ISSUE120_ISSUE36_DENSE_EXCLUDE)" \
+		--image-root "$(ISSUE120_IMAGE_ROOT)" \
+		--gt-root "$(ISSUE120_GT_ROOT)" \
+		--model-path "$(ISSUE120_MODEL_PATH)" \
+		--output-root "$(ISSUE120_ISSUE36_DENSE_OUTPUT_ROOT)" \
+		--score-threshold "$(ISSUE120_SCORE_THRESHOLD)" \
+		--xdist-threshold "$(ISSUE120_XDIST_THRESHOLD)" \
+		--no-pipeline-nms \
+		$$TARGET_ARG > "$$LOG_FILE" 2>&1 || \
+		(EXIT_CODE=$$?; echo "Issue36 dense candidate validation failed with exit code $$EXIT_CODE. See $$LOG_FILE"; exit $$EXIT_CODE); \
+	echo "Issue36 dense candidate validation complete. See $$LOG_FILE"

--- a/tools/issue120/Makefile.issue36_dense.mk
+++ b/tools/issue120/Makefile.issue36_dense.mk
@@ -11,14 +11,36 @@ ISSUE120_ISSUE36_DENSE_HISTORICAL_SCORING_INPUT ?= logs/cnn_barline_classificati
 ISSUE120_ISSUE36_DENSE_REQUIRE_CANDIDATES ?= 1
 ISSUE120_ISSUE36_DENSE_REQUIRE_TARGET ?= 0
 
-verify-issue120-issue36-dense: ## Regenerate Issue #36 v12 dense candidates, compare roots, score, and evaluate detector metrics
+verify-issue120-issue36-dense: ## Acceptance route: regenerate Issue36 dense bands, run Issue53 probe-rescue, score, and evaluate detector metrics
 	@mkdir -p artifacts
 	@LOG_FILE="artifacts/issue120_issue36_dense_verify_$$(date +%Y%m%d_%H%M%S).log"; \
 	TARGET_ARG=""; \
-	CANDIDATE_ARG=""; \
 	if [ "$(ISSUE120_ISSUE36_DENSE_REQUIRE_TARGET)" = "1" ]; then TARGET_ARG="--require-detector-target"; fi; \
+	echo "Running Issue #120/#149 Issue36 dense bands -> Issue53 validation. Logging to $$LOG_FILE..."; \
+	docker run --rm --gpus all -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace $(ISSUE120_DOCKER_IMAGE) \
+		$(ISSUE120_DOCKER_PYTHON) tools/issue120/run_issue36_dense_bands_then_issue53_eval.py \
+		--inventory "$(ISSUE120_ISSUE36_DENSE_INVENTORY)" \
+		--exclude "$(ISSUE120_ISSUE36_DENSE_EXCLUDE)" \
+		--historical-raw-candidates-root "$(ISSUE120_ISSUE36_DENSE_HISTORICAL_RAW)" \
+		--historical-filtered-candidates-root "$(ISSUE120_ISSUE36_DENSE_HISTORICAL_FILTERED)" \
+		--historical-scoring-input-root "$(ISSUE120_ISSUE36_DENSE_HISTORICAL_SCORING_INPUT)" \
+		--image-root "$(ISSUE120_IMAGE_ROOT)" \
+		--gt-root "$(ISSUE120_GT_ROOT)" \
+		--model-path "$(ISSUE120_MODEL_PATH)" \
+		--output-root "$(ISSUE120_ISSUE36_DENSE_OUTPUT_ROOT)" \
+		--score-threshold "$(ISSUE120_SCORE_THRESHOLD)" \
+		--xdist-threshold "$(ISSUE120_XDIST_THRESHOLD)" \
+		--no-pipeline-nms \
+		$$TARGET_ARG > "$$LOG_FILE" 2>&1 || \
+		(EXIT_CODE=$$?; echo "Issue36 dense bands -> Issue53 validation failed with exit code $$EXIT_CODE. See $$LOG_FILE"; exit $$EXIT_CODE); \
+	echo "Issue36 dense bands -> Issue53 validation complete. See $$LOG_FILE"
+
+verify-issue120-issue36-dense-direct-score: ## Diagnostic only: score Issue36 filtered root directly and compare the expected failure boundary
+	@mkdir -p artifacts
+	@LOG_FILE="artifacts/issue120_issue36_dense_direct_score_$$(date +%Y%m%d_%H%M%S).log"; \
+	CANDIDATE_ARG=""; \
 	if [ "$(ISSUE120_ISSUE36_DENSE_REQUIRE_CANDIDATES)" = "1" ]; then CANDIDATE_ARG="--require-candidate-match"; fi; \
-	echo "Running Issue #120/#149 Issue36 dense candidate validation. Logging to $$LOG_FILE..."; \
+	echo "Running diagnostic direct scoring of Issue36 filtered root. Logging to $$LOG_FILE..."; \
 	docker run --rm --gpus all -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace $(ISSUE120_DOCKER_IMAGE) \
 		$(ISSUE120_DOCKER_PYTHON) tools/issue120/run_issue36_dense_candidates_then_eval.py \
 		--inventory "$(ISSUE120_ISSUE36_DENSE_INVENTORY)" \
@@ -33,6 +55,6 @@ verify-issue120-issue36-dense: ## Regenerate Issue #36 v12 dense candidates, com
 		--score-threshold "$(ISSUE120_SCORE_THRESHOLD)" \
 		--xdist-threshold "$(ISSUE120_XDIST_THRESHOLD)" \
 		--no-pipeline-nms \
-		$$CANDIDATE_ARG $$TARGET_ARG > "$$LOG_FILE" 2>&1 || \
-		(EXIT_CODE=$$?; echo "Issue36 dense candidate validation failed with exit code $$EXIT_CODE. See $$LOG_FILE"; exit $$EXIT_CODE); \
-	echo "Issue36 dense candidate validation complete. See $$LOG_FILE"
+		$$CANDIDATE_ARG > "$$LOG_FILE" 2>&1 || \
+		(EXIT_CODE=$$?; echo "Diagnostic direct scoring failed with exit code $$EXIT_CODE. See $$LOG_FILE"; exit $$EXIT_CODE); \
+	echo "Diagnostic direct scoring complete. See $$LOG_FILE"

--- a/tools/issue120/Makefile.issue36_dense.mk
+++ b/tools/issue120/Makefile.issue36_dense.mk
@@ -5,18 +5,27 @@
 ISSUE120_ISSUE36_DENSE_OUTPUT_ROOT ?= logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation
 ISSUE120_ISSUE36_DENSE_INVENTORY ?= logs/issue36_prep/20260208_bench_inventory.json
 ISSUE120_ISSUE36_DENSE_EXCLUDE ?= logs/issue36_prep/excluded_pages_for_gt_prep.json
+ISSUE120_ISSUE36_DENSE_HISTORICAL_RAW ?= logs/issue36_prep/probe_candidates_from_bench_v12
+ISSUE120_ISSUE36_DENSE_HISTORICAL_FILTERED ?= logs/issue36_prep/probe_candidates_filtered_v12
+ISSUE120_ISSUE36_DENSE_HISTORICAL_SCORING_INPUT ?= logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12
+ISSUE120_ISSUE36_DENSE_REQUIRE_CANDIDATES ?= 1
 ISSUE120_ISSUE36_DENSE_REQUIRE_TARGET ?= 0
 
-verify-issue120-issue36-dense: ## Regenerate Issue #36 v12 dense candidates, score, and evaluate Issue #120 detector metrics
+verify-issue120-issue36-dense: ## Regenerate Issue #36 v12 dense candidates, compare roots, score, and evaluate detector metrics
 	@mkdir -p artifacts
 	@LOG_FILE="artifacts/issue120_issue36_dense_verify_$$(date +%Y%m%d_%H%M%S).log"; \
 	TARGET_ARG=""; \
+	CANDIDATE_ARG=""; \
 	if [ "$(ISSUE120_ISSUE36_DENSE_REQUIRE_TARGET)" = "1" ]; then TARGET_ARG="--require-detector-target"; fi; \
+	if [ "$(ISSUE120_ISSUE36_DENSE_REQUIRE_CANDIDATES)" = "1" ]; then CANDIDATE_ARG="--require-candidate-match"; fi; \
 	echo "Running Issue #120/#149 Issue36 dense candidate validation. Logging to $$LOG_FILE..."; \
 	docker run --rm --gpus all -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace $(ISSUE120_DOCKER_IMAGE) \
 		$(ISSUE120_DOCKER_PYTHON) tools/issue120/run_issue36_dense_candidates_then_eval.py \
 		--inventory "$(ISSUE120_ISSUE36_DENSE_INVENTORY)" \
 		--exclude "$(ISSUE120_ISSUE36_DENSE_EXCLUDE)" \
+		--historical-raw-candidates-root "$(ISSUE120_ISSUE36_DENSE_HISTORICAL_RAW)" \
+		--historical-filtered-candidates-root "$(ISSUE120_ISSUE36_DENSE_HISTORICAL_FILTERED)" \
+		--historical-scoring-input-root "$(ISSUE120_ISSUE36_DENSE_HISTORICAL_SCORING_INPUT)" \
 		--image-root "$(ISSUE120_IMAGE_ROOT)" \
 		--gt-root "$(ISSUE120_GT_ROOT)" \
 		--model-path "$(ISSUE120_MODEL_PATH)" \
@@ -24,6 +33,6 @@ verify-issue120-issue36-dense: ## Regenerate Issue #36 v12 dense candidates, sco
 		--score-threshold "$(ISSUE120_SCORE_THRESHOLD)" \
 		--xdist-threshold "$(ISSUE120_XDIST_THRESHOLD)" \
 		--no-pipeline-nms \
-		$$TARGET_ARG > "$$LOG_FILE" 2>&1 || \
+		$$CANDIDATE_ARG $$TARGET_ARG > "$$LOG_FILE" 2>&1 || \
 		(EXIT_CODE=$$?; echo "Issue36 dense candidate validation failed with exit code $$EXIT_CODE. See $$LOG_FILE"; exit $$EXIT_CODE); \
 	echo "Issue36 dense candidate validation complete. See $$LOG_FILE"

--- a/tools/issue120/run_issue36_dense_bands_then_issue53_eval.py
+++ b/tools/issue120/run_issue36_dense_bands_then_issue53_eval.py
@@ -27,6 +27,8 @@ from typing import Any
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from tools.issue120.eval_full68_from_intermediates import iter_manifest  # noqa: E402
+
 DEFAULT_MODEL = Path(
     "logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth"
 )
@@ -56,6 +58,17 @@ def run_command(cmd: list[str]) -> None:
     subprocess.run(cmd, check=True)
 
 
+def require_under_logs(path: Path, *, label: str) -> None:
+    logs_root = PROJECT_ROOT.resolve() / "logs"
+    try:
+        path.resolve().relative_to(logs_root)
+    except ValueError as exc:
+        raise SystemExit(
+            f"Error: {label} must be under logs/ per repository log-management policy. "
+            f"Got: {path}"
+        ) from exc
+
+
 def candidate_root_summary(root: Path) -> dict[str, int | str | bool]:
     files = sorted(root.rglob("pipeline2_no_peak_candidates.json")) if root.exists() else []
     total = 0
@@ -63,7 +76,7 @@ def candidate_root_summary(root: Path) -> dict[str, int | str | bool]:
     for path in files:
         try:
             payload = load_json(path)
-        except Exception:  # noqa: BLE001
+        except (json.JSONDecodeError, OSError):
             unreadable += 1
             continue
         if isinstance(payload, list):
@@ -105,10 +118,12 @@ def validate_complete_contract(eval_output_dir: Path) -> None:
     expected = contract.get("expected_pages")
     evaluated = contract.get("evaluated_pages")
     missing = contract.get("missing_pages", [])
-    if expected != 68 or evaluated != 68 or missing:
+    expected_count = len(iter_manifest())
+    if expected != expected_count or evaluated != expected_count or missing:
         raise SystemExit(
             "Incomplete Issue #120 full-68 evaluation contract: "
-            f"expected_pages={expected} evaluated_pages={evaluated} missing_pages={len(missing)}"
+            f"expected_pages={expected} evaluated_pages={evaluated} "
+            f"expected_count={expected_count} missing_pages={len(missing)}"
         )
 
 
@@ -143,6 +158,10 @@ def run_issue36_generation_filter_compare(args: argparse.Namespace) -> None:
         str(args.model_path),
         "--output-root",
         str(args.output_root),
+        "--raw-candidates-root",
+        str(args.raw_candidates_root),
+        "--filtered-candidates-root",
+        str(args.filtered_candidates_root),
         "--skip-scoring",
         "--require-candidate-match",
     ]
@@ -180,6 +199,8 @@ def run_issue53_probe_rescue(args: argparse.Namespace) -> None:
     ]
     if args.scorer == "pipeline" and args.pipeline_nms:
         cmd.append("--pipeline-nms")
+    if args.no_clean_output:
+        cmd.append("--no-clean-output")
     run_command(cmd)
 
 
@@ -272,7 +293,7 @@ def build_route_provenance(args: argparse.Namespace) -> dict[str, Any]:
             "general_pipeline_defaults_changed": False,
             "nms_policy_owner": "#142",
             "full_slow_pipeline_owner": "#141",
-            "generated_outputs_under_ignored_logs": str(args.output_root).startswith("logs/"),
+            "generated_outputs_under_ignored_logs": True,
             "direct_scoring_of_issue36_filtered_root_is_acceptance_route": False,
         },
         "notes": [
@@ -376,11 +397,28 @@ def resolve_default_paths(args: argparse.Namespace) -> None:
     args.filter_summary = args.output_root / "filter_apply_summary_v12_current.json"
 
 
+def validate_output_paths(args: argparse.Namespace) -> None:
+    output_paths = {
+        "output-root": args.output_root,
+        "raw-candidates-root": args.raw_candidates_root,
+        "filtered-candidates-root": args.filtered_candidates_root,
+        "issue53-candidates-root": args.issue53_candidates_root,
+        "scoring-output-dir": args.scoring_output_dir,
+        "eval-output-dir": args.eval_output_dir,
+        "route-provenance": args.route_provenance,
+        "issue36-route-provenance": args.issue36_route_provenance,
+        "filter-summary": args.filter_summary,
+    }
+    for label, path in output_paths.items():
+        require_under_logs(path, label=label)
+
+
 def validate_inputs(args: argparse.Namespace) -> None:
     required = [args.inventory, args.exclude, args.image_root, args.gt_root, args.model_path]
     missing = [str(path) for path in required if not path.exists()]
     if missing:
         raise SystemExit("Missing required inputs:\n" + "\n".join(missing))
+    validate_output_paths(args)
 
 
 def main() -> None:

--- a/tools/issue120/run_issue36_dense_bands_then_issue53_eval.py
+++ b/tools/issue120/run_issue36_dense_bands_then_issue53_eval.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Validate Issue #120 by regenerating Issue #36 dense bands, then Issue53 candidates.
+
+This is the #149 acceptance route:
+
+    Issue36 inventory -> dense raw candidates -> clef-mask-aware filtered root
+      -> candidate-root comparison against recovered historical roots
+      -> use filtered root as `bands_from` for current Issue53 probe-rescue verifier
+      -> current CNN scoring with explicit NMS setting
+      -> #134 full-68 detector evaluator
+
+The filtered Issue36 root is a recovered dense candidate / bands_from root. Directly
+scoring it is useful as a diagnostic, but it is not the clean Issue #120 detector
+reconstruction route because it has detector-side misses before CNN scoring.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+DEFAULT_MODEL = Path(
+    "logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth"
+)
+DEFAULT_OUTPUT_ROOT = Path(
+    "logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation"
+)
+DEFAULT_HISTORICAL_RAW = Path("logs/issue36_prep/probe_candidates_from_bench_v12")
+DEFAULT_HISTORICAL_FILTERED = Path("logs/issue36_prep/probe_candidates_filtered_v12")
+DEFAULT_HISTORICAL_SCORING_INPUT = Path(
+    "logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12"
+)
+TARGET_DETECTOR = {"tp": 3580, "fp": 0, "fn": 1}
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def run_command(cmd: list[str]) -> None:
+    print("+ " + " ".join(str(part) for part in cmd), flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def candidate_root_summary(root: Path) -> dict[str, int | str | bool]:
+    files = sorted(root.rglob("pipeline2_no_peak_candidates.json")) if root.exists() else []
+    total = 0
+    unreadable = 0
+    for path in files:
+        try:
+            payload = load_json(path)
+        except Exception:  # noqa: BLE001
+            unreadable += 1
+            continue
+        if isinstance(payload, list):
+            total += len(payload)
+    return {
+        "root": str(root),
+        "exists": root.exists(),
+        "files": len(files),
+        "total_candidates": total,
+        "unreadable": unreadable,
+    }
+
+
+def load_optional_json(path: Path) -> Any | None:
+    return load_json(path) if path.exists() else None
+
+
+def detector_summary(eval_output_dir: Path) -> dict[str, Any] | None:
+    metrics_path = eval_output_dir / "detector_metrics.json"
+    if metrics_path.exists():
+        payload = load_json(metrics_path)
+        if isinstance(payload, dict):
+            return payload
+    contract_path = eval_output_dir / "evaluation_contract.json"
+    if contract_path.exists():
+        payload = load_json(contract_path)
+        if isinstance(payload, dict):
+            summary = payload.get("detector_summary")
+            if isinstance(summary, dict):
+                return summary
+    return None
+
+
+def validate_complete_contract(eval_output_dir: Path) -> None:
+    contract_path = eval_output_dir / "evaluation_contract.json"
+    if not contract_path.exists():
+        raise SystemExit(f"evaluation_contract.json not found: {contract_path}")
+    contract = load_json(contract_path)
+    expected = contract.get("expected_pages")
+    evaluated = contract.get("evaluated_pages")
+    missing = contract.get("missing_pages", [])
+    if expected != 68 or evaluated != 68 or missing:
+        raise SystemExit(
+            "Incomplete Issue #120 full-68 evaluation contract: "
+            f"expected_pages={expected} evaluated_pages={evaluated} missing_pages={len(missing)}"
+        )
+
+
+def validate_detector_target(eval_output_dir: Path) -> None:
+    summary = detector_summary(eval_output_dir)
+    if summary is None:
+        raise SystemExit(f"Detector metrics not found under {eval_output_dir}")
+    observed = {"tp": summary.get("tp"), "fp": summary.get("fp"), "fn": summary.get("fn")}
+    if observed != TARGET_DETECTOR:
+        raise SystemExit(f"Detector target mismatch: observed={observed} target={TARGET_DETECTOR}")
+
+
+def run_issue36_generation_filter_compare(args: argparse.Namespace) -> None:
+    cmd = [
+        sys.executable,
+        "tools/issue120/run_issue36_dense_candidates_then_eval.py",
+        "--inventory",
+        str(args.inventory),
+        "--exclude",
+        str(args.exclude),
+        "--historical-raw-candidates-root",
+        str(args.historical_raw_candidates_root),
+        "--historical-filtered-candidates-root",
+        str(args.historical_filtered_candidates_root),
+        "--historical-scoring-input-root",
+        str(args.historical_scoring_input_root),
+        "--image-root",
+        str(args.image_root),
+        "--gt-root",
+        str(args.gt_root),
+        "--model-path",
+        str(args.model_path),
+        "--output-root",
+        str(args.output_root),
+        "--skip-scoring",
+        "--require-candidate-match",
+    ]
+    if args.no_clean_output:
+        cmd.append("--no-clean-output")
+    run_command(cmd)
+
+
+def run_issue53_probe_rescue(args: argparse.Namespace) -> None:
+    cmd = [
+        sys.executable,
+        "tools/issue120/run_issue53_probe_rescue_then_eval.py",
+        "--image-root",
+        str(args.image_root),
+        "--gt-root",
+        str(args.gt_root),
+        "--bands-from",
+        str(args.filtered_candidates_root),
+        "--model-path",
+        str(args.model_path),
+        "--baseline-dir",
+        str(args.baseline_dir),
+        "--output-root",
+        str(args.issue53_candidates_root),
+        "--scoring-output-dir",
+        str(args.scoring_output_dir),
+        "--eval-output-dir",
+        str(args.eval_output_dir),
+        "--scorer",
+        args.scorer,
+        "--score-threshold",
+        str(args.score_threshold),
+        "--xdist-threshold",
+        str(args.xdist_threshold),
+    ]
+    if args.scorer == "pipeline" and args.pipeline_nms:
+        cmd.append("--pipeline-nms")
+    run_command(cmd)
+
+
+def build_route_provenance(args: argparse.Namespace) -> dict[str, Any]:
+    issue36_provenance = load_optional_json(args.issue36_route_provenance)
+    filter_summary = load_optional_json(args.filter_summary)
+    issue53_provenance = load_optional_json(
+        args.eval_output_dir / "issue53_probe_rescue_regen_provenance.json"
+    )
+    stage_b_provenance = load_optional_json(args.eval_output_dir / "stage_b_provenance.json")
+    coverage_summary = load_optional_json(args.eval_output_dir / "candidate_coverage_summary.json")
+
+    clef_mask_resolution = None
+    reason_counts = None
+    if isinstance(filter_summary, dict):
+        clef_mask_resolution = filter_summary.get("clef_mask_resolution")
+        reason_counts = filter_summary.get("reason_counts")
+
+    return {
+        "schema_version": "issue120.issue36_dense_bands_issue53_validation.v1",
+        "status": "issue36_dense_bands_to_issue53_probe_rescue_current_validation",
+        "issue": 149,
+        "parent_issue": 120,
+        "evaluated_stage": "post_cnn_scoring_detector_intermediate",
+        "route": [
+            "Issue #36 v12 bench inventory",
+            "generate dense raw candidates with band_cluster_max_dist=25.0",
+            "apply clef-mask-aware filter",
+            "verify raw/filtered/scoring-input roots against recovered historical roots",
+            "use regenerated filtered root as Issue53 probe-rescue bands_from",
+            "score regenerated Issue53 probe-rescue candidates with current CNN scoring",
+            "#134 full-68 detector evaluator",
+        ],
+        "inputs": {
+            "inventory": str(args.inventory),
+            "exclude": str(args.exclude),
+            "image_root": str(args.image_root),
+            "gt_root": str(args.gt_root),
+            "model_path": str(args.model_path),
+            "baseline_dir": str(args.baseline_dir),
+            "historical_raw_candidates_root": str(args.historical_raw_candidates_root),
+            "historical_filtered_candidates_root": str(args.historical_filtered_candidates_root),
+            "historical_scoring_input_root": str(args.historical_scoring_input_root),
+        },
+        "outputs": {
+            "output_root": str(args.output_root),
+            "raw_candidates_root": str(args.raw_candidates_root),
+            "filtered_candidates_root": str(args.filtered_candidates_root),
+            "issue53_candidates_root": str(args.issue53_candidates_root),
+            "scoring_output_dir": str(args.scoring_output_dir),
+            "eval_output_dir": str(args.eval_output_dir),
+            "route_provenance": str(args.route_provenance),
+        },
+        "candidate_root_summary": {
+            "issue36_raw": candidate_root_summary(args.raw_candidates_root),
+            "issue36_filtered_bands_from": candidate_root_summary(args.filtered_candidates_root),
+            "issue53_regenerated_candidates": candidate_root_summary(args.issue53_candidates_root),
+            "scoring_input": candidate_root_summary(args.scoring_output_dir),
+        },
+        "issue36_provenance": issue36_provenance,
+        "clef_mask_filtering": {
+            "enabled": True,
+            "resolution": clef_mask_resolution,
+            "reason_counts": reason_counts,
+            "summary_path": str(args.filter_summary),
+        },
+        "issue53_probe_rescue": {
+            "bands_from": str(args.filtered_candidates_root),
+            "provenance": issue53_provenance,
+            "candidate_coverage_summary": coverage_summary,
+        },
+        "cnn_scoring": {
+            "scorer": args.scorer,
+            "cnn_apply_nms": args.pipeline_nms,
+            "model_path": str(args.model_path),
+            "score_threshold": args.score_threshold,
+            "xdist_threshold": args.xdist_threshold,
+            "stage_b_provenance": stage_b_provenance,
+        },
+        "detector_target": TARGET_DETECTOR,
+        "detector_summary": detector_summary(args.eval_output_dir),
+        "measure_count_summary": {
+            "status": "not_run_in_issue149",
+            "note": (
+                "Detector metrics are evaluated here. Downstream measure-count "
+                "validation remains separate."
+            ),
+        },
+        "scope_guards": {
+            "general_pipeline_defaults_changed": False,
+            "nms_policy_owner": "#142",
+            "full_slow_pipeline_owner": "#141",
+            "generated_outputs_under_ignored_logs": str(args.output_root).startswith("logs/"),
+            "direct_scoring_of_issue36_filtered_root_is_acceptance_route": False,
+        },
+        "notes": [
+            "The Issue36 filtered root is verified as the recovered historical dense "
+            "candidate/bands_from root.",
+            "Direct scoring of that root has detector-side misses and is diagnostic only.",
+            "The acceptance route uses the regenerated filtered root as bands_from for "
+            "the current Issue53 probe-rescue verifier.",
+        ],
+    }
+
+
+def attach_route_provenance(args: argparse.Namespace) -> None:
+    provenance = build_route_provenance(args)
+    write_json(args.route_provenance, provenance)
+    run_command(
+        [
+            sys.executable,
+            "tools/issue120/attach_eval_provenance.py",
+            "--output-dir",
+            str(args.eval_output_dir),
+            "--results-dir",
+            str(args.scoring_output_dir),
+            "--provenance-json",
+            str(args.route_provenance),
+        ]
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--inventory",
+        type=Path,
+        default=Path("logs/issue36_prep/20260208_bench_inventory.json"),
+    )
+    parser.add_argument(
+        "--exclude",
+        type=Path,
+        default=Path("logs/issue36_prep/excluded_pages_for_gt_prep.json"),
+    )
+    parser.add_argument("--image-root", type=Path, default=Path("data/evaluation2/images"))
+    parser.add_argument("--gt-root", type=Path, default=Path("data/evaluation2/annotations"))
+    parser.add_argument("--model-path", type=Path, default=DEFAULT_MODEL)
+    parser.add_argument("--baseline-dir", type=Path, default=Path("data/evaluation2/golden_baseline_eval2_bc23deb"))
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--historical-raw-candidates-root", type=Path, default=DEFAULT_HISTORICAL_RAW)
+    parser.add_argument(
+        "--historical-filtered-candidates-root",
+        type=Path,
+        default=DEFAULT_HISTORICAL_FILTERED,
+    )
+    parser.add_argument(
+        "--historical-scoring-input-root",
+        type=Path,
+        default=DEFAULT_HISTORICAL_SCORING_INPUT,
+    )
+    parser.add_argument("--raw-candidates-root", type=Path, default=None)
+    parser.add_argument("--filtered-candidates-root", type=Path, default=None)
+    parser.add_argument("--issue53-candidates-root", type=Path, default=None)
+    parser.add_argument("--scoring-output-dir", type=Path, default=None)
+    parser.add_argument("--eval-output-dir", type=Path, default=None)
+    parser.add_argument("--route-provenance", type=Path, default=None)
+    parser.add_argument("--scorer", choices=["pipeline", "legacy"], default="pipeline")
+    parser.add_argument(
+        "--pipeline-nms",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Explicit CNN NMS setting. Issue #120 reconstruction uses --no-pipeline-nms.",
+    )
+    parser.add_argument("--score-threshold", type=float, default=0.1)
+    parser.add_argument("--xdist-threshold", type=float, default=12.0)
+    parser.add_argument("--no-clean-output", action="store_true")
+    parser.add_argument("--skip-issue36-regeneration", action="store_true")
+    parser.add_argument(
+        "--require-detector-target",
+        action="store_true",
+        help="Fail unless detector TP/FP/FN equals 3580/0/1.",
+    )
+    return parser
+
+
+def resolve_default_paths(args: argparse.Namespace) -> None:
+    args.raw_candidates_root = (
+        args.raw_candidates_root or args.output_root / "probe_candidates_from_bench_v12"
+    )
+    args.filtered_candidates_root = (
+        args.filtered_candidates_root or args.output_root / "probe_candidates_filtered_v12"
+    )
+    args.issue53_candidates_root = (
+        args.issue53_candidates_root or args.output_root / "issue53_probe_rescue_candidates"
+    )
+    args.scoring_output_dir = args.scoring_output_dir or args.output_root / "scoring"
+    args.eval_output_dir = args.eval_output_dir or args.output_root / "eval"
+    args.route_provenance = (
+        args.route_provenance or args.output_root / "issue36_dense_bands_issue53_route_provenance.json"
+    )
+    args.issue36_route_provenance = (
+        args.output_root / "issue36_dense_candidate_route_provenance.json"
+    )
+    args.filter_summary = args.output_root / "filter_apply_summary_v12_current.json"
+
+
+def validate_inputs(args: argparse.Namespace) -> None:
+    required = [args.inventory, args.exclude, args.image_root, args.gt_root, args.model_path]
+    missing = [str(path) for path in required if not path.exists()]
+    if missing:
+        raise SystemExit("Missing required inputs:\n" + "\n".join(missing))
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    resolve_default_paths(args)
+    validate_inputs(args)
+
+    if not args.no_clean_output:
+        shutil.rmtree(args.issue53_candidates_root, ignore_errors=True)
+        shutil.rmtree(args.scoring_output_dir, ignore_errors=True)
+        shutil.rmtree(args.eval_output_dir, ignore_errors=True)
+
+    args.output_root.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_issue36_regeneration:
+        run_issue36_generation_filter_compare(args)
+
+    run_issue53_probe_rescue(args)
+    validate_complete_contract(args.eval_output_dir)
+    attach_route_provenance(args)
+    if args.require_detector_target:
+        validate_detector_target(args.eval_output_dir)
+
+    summary = detector_summary(args.eval_output_dir)
+    print(f"Issue36 dense bands -> Issue53 validation complete: {args.eval_output_dir}")
+    if summary:
+        print(
+            "Detector: "
+            f"TP={summary.get('tp')} FP={summary.get('fp')} FN={summary.get('fn')} "
+            f"Pred={summary.get('pred')} GT={summary.get('gt')}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/issue120/run_issue36_dense_candidates_then_eval.py
+++ b/tools/issue120/run_issue36_dense_candidates_then_eval.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Regenerate Issue #36 v12 dense candidates and evaluate Issue #120 detector metrics.
+
+This #149 wrapper is intentionally narrow:
+
+    inventory -> dense raw candidates -> clef-mask-aware filter
+      -> current CNN scoring -> #134 full-68 detector evaluator
+
+It does not change general pipeline defaults and does not run the full slow
+HOMR/SR/OMR pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+DEFAULT_MODEL = Path(
+    "logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth"
+)
+DEFAULT_OUTPUT_ROOT = Path(
+    "logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation"
+)
+
+TARGET_DETECTOR = {"tp": 3580, "fp": 0, "fn": 1}
+
+GENERATION_PARAMS: dict[str, str] = {
+    "band_source": "row_stats",
+    "ink_threshold": "240",
+    "min_ratio": "0.6",
+    "min_height_ratio": "0.006",
+    "min_width_ratio": "0.0",
+    "probe_width": "4",
+    "max_per_band": "80",
+    "band_scan_line_ratio": "0.6",
+    "band_scan_min_lines": "5",
+}
+
+FILTER_PARAMS: dict[str, str] = {
+    "left_margin_ratio": "0.12",
+    "clef_left_ratio": "0.25",
+    "min_height_median_ratio": "0.6",
+    "ink_threshold": "180",
+    "min_ink_ratio": "0.18",
+    "paper_threshold": "200",
+    "min_paper_overlap_ratio": "0.6",
+    "min_staff_overlap_ratio": "0.02",
+}
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def run_command(cmd: list[str]) -> None:
+    print("+ " + " ".join(str(part) for part in cmd), flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def add_param_args(cmd: list[str], params: dict[str, str]) -> None:
+    for name, value in params.items():
+        cmd.extend([f"--{name.replace('_', '-')}", value])
+
+
+def candidate_root_summary(root: Path) -> dict[str, int | str]:
+    files = sorted(root.rglob("pipeline2_no_peak_candidates.json"))
+    total = 0
+    unreadable = 0
+    for path in files:
+        try:
+            payload = load_json(path)
+        except Exception:  # noqa: BLE001
+            unreadable += 1
+            continue
+        if isinstance(payload, list):
+            total += len(payload)
+    return {"root": str(root), "files": len(files), "total_candidates": total, "unreadable": unreadable}
+
+
+def detector_summary(eval_output_dir: Path) -> dict[str, Any] | None:
+    metrics_path = eval_output_dir / "detector_metrics.json"
+    if metrics_path.exists():
+        payload = load_json(metrics_path)
+        if isinstance(payload, dict):
+            return payload
+    contract_path = eval_output_dir / "evaluation_contract.json"
+    if contract_path.exists():
+        payload = load_json(contract_path)
+        if isinstance(payload, dict):
+            summary = payload.get("detector_summary")
+            if isinstance(summary, dict):
+                return summary
+    return None
+
+
+def validate_complete_contract(eval_output_dir: Path) -> None:
+    contract_path = eval_output_dir / "evaluation_contract.json"
+    if not contract_path.exists():
+        raise SystemExit(f"evaluation_contract.json not found: {contract_path}")
+    contract = load_json(contract_path)
+    expected = contract.get("expected_pages")
+    evaluated = contract.get("evaluated_pages")
+    missing = contract.get("missing_pages", [])
+    if expected != 68 or evaluated != 68 or missing:
+        raise SystemExit(
+            "Incomplete Issue #120 full-68 evaluation contract: "
+            f"expected_pages={expected} evaluated_pages={evaluated} missing_pages={len(missing)}"
+        )
+
+
+def validate_detector_target(eval_output_dir: Path) -> None:
+    summary = detector_summary(eval_output_dir)
+    if summary is None:
+        raise SystemExit(f"Detector metrics not found under {eval_output_dir}")
+    observed = {"tp": summary.get("tp"), "fp": summary.get("fp"), "fn": summary.get("fn")}
+    if observed != TARGET_DETECTOR:
+        raise SystemExit(f"Detector target mismatch: observed={observed} target={TARGET_DETECTOR}")
+
+
+def build_route_provenance(args: argparse.Namespace) -> dict[str, Any]:
+    generation_summary = load_json(args.generation_summary) if args.generation_summary.exists() else None
+    filter_summary = load_json(args.filter_summary) if args.filter_summary.exists() else None
+    score_stage_provenance = (
+        load_json(args.eval_output_dir / "stage_b_provenance.json")
+        if (args.eval_output_dir / "stage_b_provenance.json").exists()
+        else None
+    )
+    eval_summary = detector_summary(args.eval_output_dir)
+
+    clef_mask_resolution = None
+    reason_counts = None
+    if isinstance(filter_summary, dict):
+        clef_mask_resolution = filter_summary.get("clef_mask_resolution")
+        reason_counts = filter_summary.get("reason_counts")
+
+    return {
+        "schema_version": "issue120.issue36_dense_candidate_validation.v1",
+        "status": "issue36_dense_candidate_current_validation_route",
+        "issue": 149,
+        "parent_issue": 120,
+        "evaluated_stage": "post_cnn_scoring_detector_intermediate",
+        "route": [
+            "Issue #36 v12 bench inventory",
+            "tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py",
+            "tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py with clef-mask-aware filtering",
+            "tools/issue120/score_candidates_then_eval_full68.py",
+            "tools/issue120/eval_full68_from_intermediates.py (#134 full-68 evaluator)",
+        ],
+        "inputs": {
+            "inventory": str(args.inventory),
+            "exclude": str(args.exclude),
+            "image_root": str(args.image_root),
+            "gt_root": str(args.gt_root),
+            "model_path": str(args.model_path),
+        },
+        "outputs": {
+            "output_root": str(args.output_root),
+            "raw_candidates_root": str(args.raw_candidates_root),
+            "filtered_candidates_root": str(args.filtered_candidates_root),
+            "filter_suggestions_root": str(args.suggestions_root),
+            "scoring_output_dir": str(args.scoring_output_dir),
+            "eval_output_dir": str(args.eval_output_dir),
+            "generation_summary": str(args.generation_summary),
+            "filter_summary": str(args.filter_summary),
+        },
+        "candidate_root_summary": {
+            "raw": candidate_root_summary(args.raw_candidates_root),
+            "filtered": candidate_root_summary(args.filtered_candidates_root),
+        },
+        "generation_params": GENERATION_PARAMS,
+        "filter_params": FILTER_PARAMS,
+        "clef_mask_filtering": {
+            "enabled": True,
+            "resolution": clef_mask_resolution,
+            "reason_counts": reason_counts,
+            "summary_path": str(args.filter_summary),
+        },
+        "cnn_scoring": {
+            "scorer": args.scorer,
+            "cnn_apply_nms": args.pipeline_nms,
+            "model_path": str(args.model_path),
+            "score_threshold": args.score_threshold,
+            "xdist_threshold": args.xdist_threshold,
+            "stage_b_provenance": score_stage_provenance,
+        },
+        "detector_target": TARGET_DETECTOR,
+        "detector_summary": eval_summary,
+        "measure_count_summary": {
+            "status": "not_run_in_issue149",
+            "note": "Detector metrics are evaluated here. Downstream measure-count validation remains separate.",
+        },
+        "scope_guards": {
+            "general_pipeline_defaults_changed": False,
+            "nms_policy_owner": "#142",
+            "full_slow_pipeline_owner": "#141",
+            "generated_outputs_under_ignored_logs": str(args.output_root).startswith("logs/"),
+        },
+        "notes": [
+            "This route integrates the recovered Issue #36 v12 dense candidate producer into current Issue #120 validation.",
+            "It does not run the full slow HOMR/SR/OMR pipeline.",
+            "It keeps detector metrics separate from downstream measure-count metrics.",
+        ],
+        "generation_summary": generation_summary,
+        "filter_summary": filter_summary,
+    }
+
+
+def run_generation(args: argparse.Namespace) -> None:
+    cmd = [
+        sys.executable,
+        "tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py",
+        "--inventory",
+        str(args.inventory),
+        "--exclude",
+        str(args.exclude),
+        "--output-root",
+        str(args.raw_candidates_root),
+        "--summary-out",
+        str(args.generation_summary),
+    ]
+    add_param_args(cmd, GENERATION_PARAMS)
+    run_command(cmd)
+
+
+def run_filter(args: argparse.Namespace) -> None:
+    cmd = [
+        sys.executable,
+        "tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py",
+        "--inventory",
+        str(args.inventory),
+        "--exclude",
+        str(args.exclude),
+        "--candidates-root",
+        str(args.raw_candidates_root),
+        "--output-root",
+        str(args.filtered_candidates_root),
+        "--suggestions-root",
+        str(args.suggestions_root),
+        "--summary-out",
+        str(args.filter_summary),
+    ]
+    add_param_args(cmd, FILTER_PARAMS)
+    run_command(cmd)
+
+
+def run_scoring_and_eval(args: argparse.Namespace) -> None:
+    cmd = [
+        sys.executable,
+        "tools/issue120/score_candidates_then_eval_full68.py",
+        "--scorer",
+        args.scorer,
+        "--clean-output",
+        "--candidates-dir",
+        str(args.filtered_candidates_root),
+        "--image-root",
+        str(args.image_root),
+        "--gt-root",
+        str(args.gt_root),
+        "--model-path",
+        str(args.model_path),
+        "--scoring-output-dir",
+        str(args.scoring_output_dir),
+        "--eval-output-dir",
+        str(args.eval_output_dir),
+        "--score-threshold",
+        str(args.score_threshold),
+        "--xdist-threshold",
+        str(args.xdist_threshold),
+    ]
+    if args.scorer == "pipeline" and not args.pipeline_nms:
+        cmd.append("--disable-pipeline-nms")
+    run_command(cmd)
+
+
+def attach_route_provenance(args: argparse.Namespace) -> None:
+    provenance = build_route_provenance(args)
+    write_json(args.route_provenance, provenance)
+    run_command(
+        [
+            sys.executable,
+            "tools/issue120/attach_eval_provenance.py",
+            "--output-dir",
+            str(args.eval_output_dir),
+            "--results-dir",
+            str(args.scoring_output_dir),
+            "--provenance-json",
+            str(args.route_provenance),
+        ]
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--inventory",
+        type=Path,
+        default=Path("logs/issue36_prep/20260208_bench_inventory.json"),
+    )
+    parser.add_argument(
+        "--exclude",
+        type=Path,
+        default=Path("logs/issue36_prep/excluded_pages_for_gt_prep.json"),
+    )
+    parser.add_argument("--image-root", type=Path, default=Path("data/evaluation2/images"))
+    parser.add_argument("--gt-root", type=Path, default=Path("data/evaluation2/annotations"))
+    parser.add_argument("--model-path", type=Path, default=DEFAULT_MODEL)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument(
+        "--raw-candidates-root",
+        type=Path,
+        default=None,
+        help="Defaults to <output-root>/probe_candidates_from_bench_v12.",
+    )
+    parser.add_argument(
+        "--filtered-candidates-root",
+        type=Path,
+        default=None,
+        help="Defaults to <output-root>/probe_candidates_filtered_v12.",
+    )
+    parser.add_argument(
+        "--suggestions-root",
+        type=Path,
+        default=None,
+        help="Defaults to <output-root>/filter_suggestions_v12.",
+    )
+    parser.add_argument(
+        "--generation-summary",
+        type=Path,
+        default=None,
+        help="Defaults to <output-root>/probe_generation_summary_v12_current.json.",
+    )
+    parser.add_argument(
+        "--filter-summary",
+        type=Path,
+        default=None,
+        help="Defaults to <output-root>/filter_apply_summary_v12_current.json.",
+    )
+    parser.add_argument(
+        "--scoring-output-dir",
+        type=Path,
+        default=None,
+        help="Defaults to <output-root>/scoring.",
+    )
+    parser.add_argument(
+        "--eval-output-dir",
+        type=Path,
+        default=None,
+        help="Defaults to <output-root>/eval.",
+    )
+    parser.add_argument(
+        "--route-provenance",
+        type=Path,
+        default=None,
+        help="Defaults to <output-root>/issue36_dense_candidate_route_provenance.json.",
+    )
+    parser.add_argument("--scorer", choices=["pipeline", "legacy"], default="pipeline")
+    parser.add_argument(
+        "--pipeline-nms",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Explicit CNN NMS setting for scorer=pipeline. Issue #120 reconstruction uses --no-pipeline-nms.",
+    )
+    parser.add_argument("--score-threshold", type=float, default=0.1)
+    parser.add_argument("--xdist-threshold", type=float, default=12.0)
+    parser.add_argument("--no-clean-output", action="store_true")
+    parser.add_argument("--skip-generation", action="store_true")
+    parser.add_argument("--skip-filter", action="store_true")
+    parser.add_argument("--skip-scoring", action="store_true")
+    parser.add_argument(
+        "--require-detector-target",
+        action="store_true",
+        help="Fail unless detector TP/FP/FN equals 3580/0/1.",
+    )
+    return parser
+
+
+def resolve_default_paths(args: argparse.Namespace) -> None:
+    args.raw_candidates_root = args.raw_candidates_root or args.output_root / "probe_candidates_from_bench_v12"
+    args.filtered_candidates_root = (
+        args.filtered_candidates_root or args.output_root / "probe_candidates_filtered_v12"
+    )
+    args.suggestions_root = args.suggestions_root or args.output_root / "filter_suggestions_v12"
+    args.generation_summary = (
+        args.generation_summary or args.output_root / "probe_generation_summary_v12_current.json"
+    )
+    args.filter_summary = args.filter_summary or args.output_root / "filter_apply_summary_v12_current.json"
+    args.scoring_output_dir = args.scoring_output_dir or args.output_root / "scoring"
+    args.eval_output_dir = args.eval_output_dir or args.output_root / "eval"
+    args.route_provenance = (
+        args.route_provenance or args.output_root / "issue36_dense_candidate_route_provenance.json"
+    )
+
+
+def validate_inputs(args: argparse.Namespace) -> None:
+    required = [args.inventory, args.exclude]
+    if not args.skip_scoring:
+        required.extend([args.image_root, args.gt_root, args.model_path])
+    missing = [str(path) for path in required if not path.exists()]
+    if missing:
+        raise SystemExit("Missing required inputs:\n" + "\n".join(missing))
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    resolve_default_paths(args)
+    validate_inputs(args)
+
+    if not args.no_clean_output:
+        if not args.skip_generation:
+            shutil.rmtree(args.raw_candidates_root, ignore_errors=True)
+        if not args.skip_filter:
+            shutil.rmtree(args.filtered_candidates_root, ignore_errors=True)
+            shutil.rmtree(args.suggestions_root, ignore_errors=True)
+        if not args.skip_scoring:
+            shutil.rmtree(args.scoring_output_dir, ignore_errors=True)
+            shutil.rmtree(args.eval_output_dir, ignore_errors=True)
+
+    args.output_root.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_generation:
+        run_generation(args)
+    if not args.skip_filter:
+        run_filter(args)
+    if not args.skip_scoring:
+        run_scoring_and_eval(args)
+        validate_complete_contract(args.eval_output_dir)
+        attach_route_provenance(args)
+        if args.require_detector_target:
+            validate_detector_target(args.eval_output_dir)
+        summary = detector_summary(args.eval_output_dir)
+        print(f"Issue #36 dense candidate validation complete: {args.eval_output_dir}")
+        if summary:
+            print(
+                "Detector: "
+                f"TP={summary.get('tp')} FP={summary.get('fp')} FN={summary.get('fn')} "
+                f"Pred={summary.get('pred')} GT={summary.get('gt')}"
+            )
+    else:
+        write_json(args.route_provenance, build_route_provenance(args))
+        print(f"Issue #36 dense candidate generation/filter complete: {args.output_root}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/issue120/run_issue36_dense_candidates_then_eval.py
+++ b/tools/issue120/run_issue36_dense_candidates_then_eval.py
@@ -4,7 +4,8 @@
 This #149 wrapper is intentionally narrow:
 
     inventory -> dense raw candidates -> clef-mask-aware filter
-      -> current CNN scoring -> #134 full-68 detector evaluator
+      -> candidate-root comparison gates -> current CNN scoring
+      -> #134 full-68 detector evaluator
 
 It does not change general pipeline defaults and does not run the full slow
 HOMR/SR/OMR pipeline.
@@ -29,11 +30,17 @@ DEFAULT_MODEL = Path(
 DEFAULT_OUTPUT_ROOT = Path(
     "logs/issue120_e2e_recovery/stage_d_issue36_dense_candidate_validation"
 )
+DEFAULT_HISTORICAL_RAW = Path("logs/issue36_prep/probe_candidates_from_bench_v12")
+DEFAULT_HISTORICAL_FILTERED = Path("logs/issue36_prep/probe_candidates_filtered_v12")
+DEFAULT_HISTORICAL_SCORING_INPUT = Path(
+    "logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12"
+)
 
 TARGET_DETECTOR = {"tp": 3580, "fp": 0, "fn": 1}
 
 GENERATION_PARAMS: dict[str, str] = {
     "band_source": "row_stats",
+    "band_cluster_max_dist": "25.0",
     "ink_threshold": "240",
     "min_ratio": "0.6",
     "min_height_ratio": "0.006",
@@ -76,8 +83,8 @@ def add_param_args(cmd: list[str], params: dict[str, str]) -> None:
         cmd.extend([f"--{name.replace('_', '-')}", value])
 
 
-def candidate_root_summary(root: Path) -> dict[str, int | str]:
-    files = sorted(root.rglob("pipeline2_no_peak_candidates.json"))
+def candidate_root_summary(root: Path) -> dict[str, int | str | bool]:
+    files = sorted(root.rglob("pipeline2_no_peak_candidates.json")) if root.exists() else []
     total = 0
     unreadable = 0
     for path in files:
@@ -90,6 +97,7 @@ def candidate_root_summary(root: Path) -> dict[str, int | str]:
             total += len(payload)
     return {
         "root": str(root),
+        "exists": root.exists(),
         "files": len(files),
         "total_candidates": total,
         "unreadable": unreadable,
@@ -110,6 +118,54 @@ def detector_summary(eval_output_dir: Path) -> dict[str, Any] | None:
             if isinstance(summary, dict):
                 return summary
     return None
+
+
+def comparison_summary(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    payload = load_json(path)
+    if isinstance(payload, dict) and isinstance(payload.get("summary"), dict):
+        return payload["summary"]
+    return None
+
+
+def compare_candidate_roots(
+    *,
+    left: Path,
+    right: Path,
+    output_dir: Path,
+    label: str,
+) -> dict[str, Any] | None:
+    if not left.exists():
+        print(f"Skipping {label} comparison: historical root not found: {left}", flush=True)
+        return None
+    run_command(
+        [
+            sys.executable,
+            "tools/issue120/compare_filter_candidate_deltas.py",
+            "--historical-dir",
+            str(left),
+            "--repro-dir",
+            str(right),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+    return comparison_summary(output_dir / "filter_candidate_delta_summary.json")
+
+
+def assert_candidate_match(summary: dict[str, Any] | None, *, label: str) -> None:
+    if summary is None:
+        raise SystemExit(f"{label} comparison summary is missing")
+    checks = {
+        "missing_historical_pages": summary.get("missing_historical_pages"),
+        "missing_repro_pages": summary.get("missing_repro_pages"),
+        "mismatch_pages": summary.get("mismatch_pages"),
+        "total_extra_in_repro": summary.get("total_extra_in_repro"),
+        "total_missing_from_repro": summary.get("total_missing_from_repro"),
+    }
+    if any(value != 0 for value in checks.values()):
+        raise SystemExit(f"{label} candidate-root mismatch: {checks}")
 
 
 def validate_complete_contract(eval_output_dir: Path) -> None:
@@ -134,101 +190,6 @@ def validate_detector_target(eval_output_dir: Path) -> None:
     observed = {"tp": summary.get("tp"), "fp": summary.get("fp"), "fn": summary.get("fn")}
     if observed != TARGET_DETECTOR:
         raise SystemExit(f"Detector target mismatch: observed={observed} target={TARGET_DETECTOR}")
-
-
-def build_route_provenance(args: argparse.Namespace) -> dict[str, Any]:
-    generation_summary = (
-        load_json(args.generation_summary) if args.generation_summary.exists() else None
-    )
-    filter_summary = load_json(args.filter_summary) if args.filter_summary.exists() else None
-    score_stage_provenance = (
-        load_json(args.eval_output_dir / "stage_b_provenance.json")
-        if (args.eval_output_dir / "stage_b_provenance.json").exists()
-        else None
-    )
-    eval_summary = detector_summary(args.eval_output_dir)
-
-    clef_mask_resolution = None
-    reason_counts = None
-    if isinstance(filter_summary, dict):
-        clef_mask_resolution = filter_summary.get("clef_mask_resolution")
-        reason_counts = filter_summary.get("reason_counts")
-
-    return {
-        "schema_version": "issue120.issue36_dense_candidate_validation.v1",
-        "status": "issue36_dense_candidate_current_validation_route",
-        "issue": 149,
-        "parent_issue": 120,
-        "evaluated_stage": "post_cnn_scoring_detector_intermediate",
-        "route": [
-            "Issue #36 v12 bench inventory",
-            "tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py",
-            "tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py "
-            "with clef-mask-aware filtering",
-            "tools/issue120/score_candidates_then_eval_full68.py",
-            "tools/issue120/eval_full68_from_intermediates.py (#134 full-68 evaluator)",
-        ],
-        "inputs": {
-            "inventory": str(args.inventory),
-            "exclude": str(args.exclude),
-            "image_root": str(args.image_root),
-            "gt_root": str(args.gt_root),
-            "model_path": str(args.model_path),
-        },
-        "outputs": {
-            "output_root": str(args.output_root),
-            "raw_candidates_root": str(args.raw_candidates_root),
-            "filtered_candidates_root": str(args.filtered_candidates_root),
-            "filter_suggestions_root": str(args.suggestions_root),
-            "scoring_output_dir": str(args.scoring_output_dir),
-            "eval_output_dir": str(args.eval_output_dir),
-            "generation_summary": str(args.generation_summary),
-            "filter_summary": str(args.filter_summary),
-        },
-        "candidate_root_summary": {
-            "raw": candidate_root_summary(args.raw_candidates_root),
-            "filtered": candidate_root_summary(args.filtered_candidates_root),
-        },
-        "generation_params": GENERATION_PARAMS,
-        "filter_params": FILTER_PARAMS,
-        "clef_mask_filtering": {
-            "enabled": True,
-            "resolution": clef_mask_resolution,
-            "reason_counts": reason_counts,
-            "summary_path": str(args.filter_summary),
-        },
-        "cnn_scoring": {
-            "scorer": args.scorer,
-            "cnn_apply_nms": args.pipeline_nms,
-            "model_path": str(args.model_path),
-            "score_threshold": args.score_threshold,
-            "xdist_threshold": args.xdist_threshold,
-            "stage_b_provenance": score_stage_provenance,
-        },
-        "detector_target": TARGET_DETECTOR,
-        "detector_summary": eval_summary,
-        "measure_count_summary": {
-            "status": "not_run_in_issue149",
-            "note": (
-                "Detector metrics are evaluated here. "
-                "Downstream measure-count validation remains separate."
-            ),
-        },
-        "scope_guards": {
-            "general_pipeline_defaults_changed": False,
-            "nms_policy_owner": "#142",
-            "full_slow_pipeline_owner": "#141",
-            "generated_outputs_under_ignored_logs": str(args.output_root).startswith("logs/"),
-        },
-        "notes": [
-            "This route integrates the recovered Issue #36 v12 dense candidate producer "
-            "into current Issue #120 validation.",
-            "It does not run the full slow HOMR/SR/OMR pipeline.",
-            "It keeps detector metrics separate from downstream measure-count metrics.",
-        ],
-        "generation_summary": generation_summary,
-        "filter_summary": filter_summary,
-    }
 
 
 def run_generation(args: argparse.Namespace) -> None:
@@ -269,6 +230,28 @@ def run_filter(args: argparse.Namespace) -> None:
     run_command(cmd)
 
 
+def run_intermediate_comparisons(args: argparse.Namespace) -> dict[str, Any]:
+    raw = compare_candidate_roots(
+        left=args.historical_raw_candidates_root,
+        right=args.raw_candidates_root,
+        output_dir=args.raw_compare_output_dir,
+        label="raw",
+    )
+    filtered = compare_candidate_roots(
+        left=args.historical_filtered_candidates_root,
+        right=args.filtered_candidates_root,
+        output_dir=args.filtered_compare_output_dir,
+        label="filtered",
+    )
+    scoring_input = compare_candidate_roots(
+        left=args.historical_scoring_input_root,
+        right=args.filtered_candidates_root,
+        output_dir=args.scoring_input_compare_output_dir,
+        label="historical scoring input",
+    )
+    return {"raw": raw, "filtered": filtered, "historical_scoring_input": scoring_input}
+
+
 def run_scoring_and_eval(args: argparse.Namespace) -> None:
     cmd = [
         sys.executable,
@@ -298,8 +281,120 @@ def run_scoring_and_eval(args: argparse.Namespace) -> None:
     run_command(cmd)
 
 
-def attach_route_provenance(args: argparse.Namespace) -> None:
-    provenance = build_route_provenance(args)
+def build_route_provenance(
+    args: argparse.Namespace,
+    comparisons: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    generation_summary = (
+        load_json(args.generation_summary) if args.generation_summary.exists() else None
+    )
+    filter_summary = load_json(args.filter_summary) if args.filter_summary.exists() else None
+    score_stage_provenance = (
+        load_json(args.eval_output_dir / "stage_b_provenance.json")
+        if (args.eval_output_dir / "stage_b_provenance.json").exists()
+        else None
+    )
+    eval_summary = detector_summary(args.eval_output_dir)
+
+    clef_mask_resolution = None
+    reason_counts = None
+    if isinstance(filter_summary, dict):
+        clef_mask_resolution = filter_summary.get("clef_mask_resolution")
+        reason_counts = filter_summary.get("reason_counts")
+
+    return {
+        "schema_version": "issue120.issue36_dense_candidate_validation.v2",
+        "status": "issue36_dense_candidate_current_validation_route",
+        "issue": 149,
+        "parent_issue": 120,
+        "evaluated_stage": "post_cnn_scoring_detector_intermediate",
+        "route": [
+            "Issue #36 v12 bench inventory",
+            "tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py",
+            "candidate-root comparisons against recovered historical roots",
+            "tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py "
+            "with clef-mask-aware filtering",
+            "tools/issue120/score_candidates_then_eval_full68.py",
+            "tools/issue120/eval_full68_from_intermediates.py (#134 full-68 evaluator)",
+        ],
+        "inputs": {
+            "inventory": str(args.inventory),
+            "exclude": str(args.exclude),
+            "image_root": str(args.image_root),
+            "gt_root": str(args.gt_root),
+            "model_path": str(args.model_path),
+            "historical_raw_candidates_root": str(args.historical_raw_candidates_root),
+            "historical_filtered_candidates_root": str(args.historical_filtered_candidates_root),
+            "historical_scoring_input_root": str(args.historical_scoring_input_root),
+        },
+        "outputs": {
+            "output_root": str(args.output_root),
+            "raw_candidates_root": str(args.raw_candidates_root),
+            "filtered_candidates_root": str(args.filtered_candidates_root),
+            "filter_suggestions_root": str(args.suggestions_root),
+            "scoring_output_dir": str(args.scoring_output_dir),
+            "eval_output_dir": str(args.eval_output_dir),
+            "generation_summary": str(args.generation_summary),
+            "filter_summary": str(args.filter_summary),
+            "raw_compare_output_dir": str(args.raw_compare_output_dir),
+            "filtered_compare_output_dir": str(args.filtered_compare_output_dir),
+            "scoring_input_compare_output_dir": str(args.scoring_input_compare_output_dir),
+        },
+        "candidate_root_summary": {
+            "raw": candidate_root_summary(args.raw_candidates_root),
+            "filtered": candidate_root_summary(args.filtered_candidates_root),
+            "historical_raw": candidate_root_summary(args.historical_raw_candidates_root),
+            "historical_filtered": candidate_root_summary(args.historical_filtered_candidates_root),
+            "historical_scoring_input": candidate_root_summary(args.historical_scoring_input_root),
+        },
+        "candidate_root_comparisons": comparisons or {},
+        "generation_params": GENERATION_PARAMS,
+        "filter_params": FILTER_PARAMS,
+        "clef_mask_filtering": {
+            "enabled": True,
+            "resolution": clef_mask_resolution,
+            "reason_counts": reason_counts,
+            "summary_path": str(args.filter_summary),
+        },
+        "cnn_scoring": {
+            "scorer": args.scorer,
+            "cnn_apply_nms": args.pipeline_nms,
+            "model_path": str(args.model_path),
+            "score_threshold": args.score_threshold,
+            "xdist_threshold": args.xdist_threshold,
+            "stage_b_provenance": score_stage_provenance,
+        },
+        "detector_target": TARGET_DETECTOR,
+        "detector_summary": eval_summary,
+        "measure_count_summary": {
+            "status": "not_run_in_issue149",
+            "note": (
+                "Detector metrics are evaluated here. "
+                "Downstream measure-count validation remains separate."
+            ),
+        },
+        "scope_guards": {
+            "general_pipeline_defaults_changed": False,
+            "nms_policy_owner": "#142",
+            "full_slow_pipeline_owner": "#141",
+            "generated_outputs_under_ignored_logs": str(args.output_root).startswith("logs/"),
+        },
+        "notes": [
+            "Issue #36 v12 reproduction pins band_cluster_max_dist=25.0 because the "
+            "current detector default changed from the historical edf7bf6 behavior.",
+            "This route does not run the full slow HOMR/SR/OMR pipeline.",
+            "It keeps detector metrics separate from downstream measure-count metrics.",
+        ],
+        "generation_summary": generation_summary,
+        "filter_summary": filter_summary,
+    }
+
+
+def attach_route_provenance(
+    args: argparse.Namespace,
+    comparisons: dict[str, Any] | None = None,
+) -> None:
+    provenance = build_route_provenance(args, comparisons)
     write_json(args.route_provenance, provenance)
     run_command(
         [
@@ -331,54 +426,28 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--gt-root", type=Path, default=Path("data/evaluation2/annotations"))
     parser.add_argument("--model-path", type=Path, default=DEFAULT_MODEL)
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--historical-raw-candidates-root", type=Path, default=DEFAULT_HISTORICAL_RAW)
     parser.add_argument(
-        "--raw-candidates-root",
+        "--historical-filtered-candidates-root",
         type=Path,
-        default=None,
-        help="Defaults to <output-root>/probe_candidates_from_bench_v12.",
+        default=DEFAULT_HISTORICAL_FILTERED,
     )
     parser.add_argument(
-        "--filtered-candidates-root",
+        "--historical-scoring-input-root",
         type=Path,
-        default=None,
-        help="Defaults to <output-root>/probe_candidates_filtered_v12.",
+        default=DEFAULT_HISTORICAL_SCORING_INPUT,
     )
-    parser.add_argument(
-        "--suggestions-root",
-        type=Path,
-        default=None,
-        help="Defaults to <output-root>/filter_suggestions_v12.",
-    )
-    parser.add_argument(
-        "--generation-summary",
-        type=Path,
-        default=None,
-        help="Defaults to <output-root>/probe_generation_summary_v12_current.json.",
-    )
-    parser.add_argument(
-        "--filter-summary",
-        type=Path,
-        default=None,
-        help="Defaults to <output-root>/filter_apply_summary_v12_current.json.",
-    )
-    parser.add_argument(
-        "--scoring-output-dir",
-        type=Path,
-        default=None,
-        help="Defaults to <output-root>/scoring.",
-    )
-    parser.add_argument(
-        "--eval-output-dir",
-        type=Path,
-        default=None,
-        help="Defaults to <output-root>/eval.",
-    )
-    parser.add_argument(
-        "--route-provenance",
-        type=Path,
-        default=None,
-        help="Defaults to <output-root>/issue36_dense_candidate_route_provenance.json.",
-    )
+    parser.add_argument("--raw-candidates-root", type=Path, default=None)
+    parser.add_argument("--filtered-candidates-root", type=Path, default=None)
+    parser.add_argument("--suggestions-root", type=Path, default=None)
+    parser.add_argument("--generation-summary", type=Path, default=None)
+    parser.add_argument("--filter-summary", type=Path, default=None)
+    parser.add_argument("--scoring-output-dir", type=Path, default=None)
+    parser.add_argument("--eval-output-dir", type=Path, default=None)
+    parser.add_argument("--route-provenance", type=Path, default=None)
+    parser.add_argument("--raw-compare-output-dir", type=Path, default=None)
+    parser.add_argument("--filtered-compare-output-dir", type=Path, default=None)
+    parser.add_argument("--scoring-input-compare-output-dir", type=Path, default=None)
     parser.add_argument("--scorer", choices=["pipeline", "legacy"], default="pipeline")
     parser.add_argument(
         "--pipeline-nms",
@@ -394,7 +463,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-clean-output", action="store_true")
     parser.add_argument("--skip-generation", action="store_true")
     parser.add_argument("--skip-filter", action="store_true")
+    parser.add_argument("--skip-candidate-comparison", action="store_true")
     parser.add_argument("--skip-scoring", action="store_true")
+    parser.add_argument(
+        "--require-candidate-match",
+        action="store_true",
+        help="Fail unless raw and filtered candidate roots match recovered historical roots.",
+    )
     parser.add_argument(
         "--require-detector-target",
         action="store_true",
@@ -422,6 +497,13 @@ def resolve_default_paths(args: argparse.Namespace) -> None:
     args.route_provenance = (
         args.route_provenance or args.output_root / "issue36_dense_candidate_route_provenance.json"
     )
+    args.raw_compare_output_dir = args.raw_compare_output_dir or args.output_root / "raw_delta"
+    args.filtered_compare_output_dir = (
+        args.filtered_compare_output_dir or args.output_root / "filtered_delta"
+    )
+    args.scoring_input_compare_output_dir = (
+        args.scoring_input_compare_output_dir or args.output_root / "scoring_input_delta"
+    )
 
 
 def validate_inputs(args: argparse.Namespace) -> None:
@@ -444,6 +526,10 @@ def main() -> None:
         if not args.skip_filter:
             shutil.rmtree(args.filtered_candidates_root, ignore_errors=True)
             shutil.rmtree(args.suggestions_root, ignore_errors=True)
+        if not args.skip_candidate_comparison:
+            shutil.rmtree(args.raw_compare_output_dir, ignore_errors=True)
+            shutil.rmtree(args.filtered_compare_output_dir, ignore_errors=True)
+            shutil.rmtree(args.scoring_input_compare_output_dir, ignore_errors=True)
         if not args.skip_scoring:
             shutil.rmtree(args.scoring_output_dir, ignore_errors=True)
             shutil.rmtree(args.eval_output_dir, ignore_errors=True)
@@ -454,10 +540,22 @@ def main() -> None:
         run_generation(args)
     if not args.skip_filter:
         run_filter(args)
+
+    comparisons: dict[str, Any] | None = None
+    if not args.skip_candidate_comparison:
+        comparisons = run_intermediate_comparisons(args)
+        if args.require_candidate_match:
+            assert_candidate_match(comparisons.get("raw"), label="raw")
+            assert_candidate_match(comparisons.get("filtered"), label="filtered")
+            assert_candidate_match(
+                comparisons.get("historical_scoring_input"),
+                label="historical scoring input",
+            )
+
     if not args.skip_scoring:
         run_scoring_and_eval(args)
         validate_complete_contract(args.eval_output_dir)
-        attach_route_provenance(args)
+        attach_route_provenance(args, comparisons)
         if args.require_detector_target:
             validate_detector_target(args.eval_output_dir)
         summary = detector_summary(args.eval_output_dir)
@@ -469,7 +567,7 @@ def main() -> None:
                 f"Pred={summary.get('pred')} GT={summary.get('gt')}"
             )
     else:
-        write_json(args.route_provenance, build_route_provenance(args))
+        write_json(args.route_provenance, build_route_provenance(args, comparisons))
         print(f"Issue #36 dense candidate generation/filter complete: {args.output_root}")
 
 

--- a/tools/issue120/run_issue36_dense_candidates_then_eval.py
+++ b/tools/issue120/run_issue36_dense_candidates_then_eval.py
@@ -273,7 +273,6 @@ def run_scoring_and_eval(args: argparse.Namespace) -> None:
         "tools/issue120/score_candidates_then_eval_full68.py",
         "--scorer",
         args.scorer,
-        "--clean-output",
         "--candidates-dir",
         str(args.filtered_candidates_root),
         "--image-root",
@@ -291,6 +290,8 @@ def run_scoring_and_eval(args: argparse.Namespace) -> None:
         "--xdist-threshold",
         str(args.xdist_threshold),
     ]
+    if not args.no_clean_output:
+        cmd.append("--clean-output")
     if args.scorer == "pipeline" and not args.pipeline_nms:
         cmd.append("--disable-pipeline-nms")
     run_command(cmd)

--- a/tools/issue120/run_issue36_dense_candidates_then_eval.py
+++ b/tools/issue120/run_issue36_dense_candidates_then_eval.py
@@ -24,6 +24,8 @@ from typing import Any
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from tools.issue120.eval_full68_from_intermediates import iter_manifest  # noqa: E402
+
 DEFAULT_MODEL = Path(
     "logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth"
 )
@@ -83,6 +85,17 @@ def add_param_args(cmd: list[str], params: dict[str, str]) -> None:
         cmd.extend([f"--{name.replace('_', '-')}", value])
 
 
+def require_under_logs(path: Path, *, label: str) -> None:
+    logs_root = PROJECT_ROOT.resolve() / "logs"
+    try:
+        path.resolve().relative_to(logs_root)
+    except ValueError as exc:
+        raise SystemExit(
+            f"Error: {label} must be under logs/ per repository log-management policy. "
+            f"Got: {path}"
+        ) from exc
+
+
 def candidate_root_summary(root: Path) -> dict[str, int | str | bool]:
     files = sorted(root.rglob("pipeline2_no_peak_candidates.json")) if root.exists() else []
     total = 0
@@ -90,7 +103,7 @@ def candidate_root_summary(root: Path) -> dict[str, int | str | bool]:
     for path in files:
         try:
             payload = load_json(path)
-        except Exception:  # noqa: BLE001
+        except (json.JSONDecodeError, OSError):
             unreadable += 1
             continue
         if isinstance(payload, list):
@@ -176,10 +189,12 @@ def validate_complete_contract(eval_output_dir: Path) -> None:
     expected = contract.get("expected_pages")
     evaluated = contract.get("evaluated_pages")
     missing = contract.get("missing_pages", [])
-    if expected != 68 or evaluated != 68 or missing:
+    expected_count = len(iter_manifest())
+    if expected != expected_count or evaluated != expected_count or missing:
         raise SystemExit(
             "Incomplete Issue #120 full-68 evaluation contract: "
-            f"expected_pages={expected} evaluated_pages={evaluated} missing_pages={len(missing)}"
+            f"expected_pages={expected} evaluated_pages={evaluated} "
+            f"expected_count={expected_count} missing_pages={len(missing)}"
         )
 
 
@@ -377,7 +392,7 @@ def build_route_provenance(
             "general_pipeline_defaults_changed": False,
             "nms_policy_owner": "#142",
             "full_slow_pipeline_owner": "#141",
-            "generated_outputs_under_ignored_logs": str(args.output_root).startswith("logs/"),
+            "generated_outputs_under_ignored_logs": True,
         },
         "notes": [
             "Issue #36 v12 reproduction pins band_cluster_max_dist=25.0 because the "
@@ -506,6 +521,25 @@ def resolve_default_paths(args: argparse.Namespace) -> None:
     )
 
 
+def validate_output_paths(args: argparse.Namespace) -> None:
+    output_paths = {
+        "output-root": args.output_root,
+        "raw-candidates-root": args.raw_candidates_root,
+        "filtered-candidates-root": args.filtered_candidates_root,
+        "suggestions-root": args.suggestions_root,
+        "generation-summary": args.generation_summary,
+        "filter-summary": args.filter_summary,
+        "scoring-output-dir": args.scoring_output_dir,
+        "eval-output-dir": args.eval_output_dir,
+        "route-provenance": args.route_provenance,
+        "raw-compare-output-dir": args.raw_compare_output_dir,
+        "filtered-compare-output-dir": args.filtered_compare_output_dir,
+        "scoring-input-compare-output-dir": args.scoring_input_compare_output_dir,
+    }
+    for label, path in output_paths.items():
+        require_under_logs(path, label=label)
+
+
 def validate_inputs(args: argparse.Namespace) -> None:
     required = [args.inventory, args.exclude]
     if not args.skip_scoring:
@@ -513,6 +547,7 @@ def validate_inputs(args: argparse.Namespace) -> None:
     missing = [str(path) for path in required if not path.exists()]
     if missing:
         raise SystemExit("Missing required inputs:\n" + "\n".join(missing))
+    validate_output_paths(args)
 
 
 def main() -> None:

--- a/tools/issue120/run_issue36_dense_candidates_then_eval.py
+++ b/tools/issue120/run_issue36_dense_candidates_then_eval.py
@@ -88,7 +88,12 @@ def candidate_root_summary(root: Path) -> dict[str, int | str]:
             continue
         if isinstance(payload, list):
             total += len(payload)
-    return {"root": str(root), "files": len(files), "total_candidates": total, "unreadable": unreadable}
+    return {
+        "root": str(root),
+        "files": len(files),
+        "total_candidates": total,
+        "unreadable": unreadable,
+    }
 
 
 def detector_summary(eval_output_dir: Path) -> dict[str, Any] | None:
@@ -132,7 +137,9 @@ def validate_detector_target(eval_output_dir: Path) -> None:
 
 
 def build_route_provenance(args: argparse.Namespace) -> dict[str, Any]:
-    generation_summary = load_json(args.generation_summary) if args.generation_summary.exists() else None
+    generation_summary = (
+        load_json(args.generation_summary) if args.generation_summary.exists() else None
+    )
     filter_summary = load_json(args.filter_summary) if args.filter_summary.exists() else None
     score_stage_provenance = (
         load_json(args.eval_output_dir / "stage_b_provenance.json")
@@ -156,7 +163,8 @@ def build_route_provenance(args: argparse.Namespace) -> dict[str, Any]:
         "route": [
             "Issue #36 v12 bench inventory",
             "tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py",
-            "tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py with clef-mask-aware filtering",
+            "tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py "
+            "with clef-mask-aware filtering",
             "tools/issue120/score_candidates_then_eval_full68.py",
             "tools/issue120/eval_full68_from_intermediates.py (#134 full-68 evaluator)",
         ],
@@ -201,7 +209,10 @@ def build_route_provenance(args: argparse.Namespace) -> dict[str, Any]:
         "detector_summary": eval_summary,
         "measure_count_summary": {
             "status": "not_run_in_issue149",
-            "note": "Detector metrics are evaluated here. Downstream measure-count validation remains separate.",
+            "note": (
+                "Detector metrics are evaluated here. "
+                "Downstream measure-count validation remains separate."
+            ),
         },
         "scope_guards": {
             "general_pipeline_defaults_changed": False,
@@ -210,7 +221,8 @@ def build_route_provenance(args: argparse.Namespace) -> dict[str, Any]:
             "generated_outputs_under_ignored_logs": str(args.output_root).startswith("logs/"),
         },
         "notes": [
-            "This route integrates the recovered Issue #36 v12 dense candidate producer into current Issue #120 validation.",
+            "This route integrates the recovered Issue #36 v12 dense candidate producer "
+            "into current Issue #120 validation.",
             "It does not run the full slow HOMR/SR/OMR pipeline.",
             "It keeps detector metrics separate from downstream measure-count metrics.",
         ],
@@ -372,7 +384,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--pipeline-nms",
         action=argparse.BooleanOptionalAction,
         default=False,
-        help="Explicit CNN NMS setting for scorer=pipeline. Issue #120 reconstruction uses --no-pipeline-nms.",
+        help=(
+            "Explicit CNN NMS setting for scorer=pipeline. "
+            "Issue #120 reconstruction uses --no-pipeline-nms."
+        ),
     )
     parser.add_argument("--score-threshold", type=float, default=0.1)
     parser.add_argument("--xdist-threshold", type=float, default=12.0)
@@ -389,7 +404,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def resolve_default_paths(args: argparse.Namespace) -> None:
-    args.raw_candidates_root = args.raw_candidates_root or args.output_root / "probe_candidates_from_bench_v12"
+    args.raw_candidates_root = (
+        args.raw_candidates_root or args.output_root / "probe_candidates_from_bench_v12"
+    )
     args.filtered_candidates_root = (
         args.filtered_candidates_root or args.output_root / "probe_candidates_filtered_v12"
     )
@@ -397,7 +414,9 @@ def resolve_default_paths(args: argparse.Namespace) -> None:
     args.generation_summary = (
         args.generation_summary or args.output_root / "probe_generation_summary_v12_current.json"
     )
-    args.filter_summary = args.filter_summary or args.output_root / "filter_apply_summary_v12_current.json"
+    args.filter_summary = (
+        args.filter_summary or args.output_root / "filter_apply_summary_v12_current.json"
+    )
     args.scoring_output_dir = args.scoring_output_dir or args.output_root / "scoring"
     args.eval_output_dir = args.eval_output_dir or args.output_root / "eval"
     args.route_provenance = (

--- a/tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py
+++ b/tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py
@@ -61,6 +61,7 @@ def _run_one(
     band_scan_line_ratio: float,
     band_scan_min_lines: int,
     band_source: str,
+    band_cluster_max_dist: float | None,
     scan_x_peak_rescue: bool,
 ) -> dict[str, Any]:
     score = record["score"]
@@ -88,11 +89,15 @@ def _run_one(
     existing_boxes = _load_boxes(existing_path)
 
     # Keep defaults aligned with current src.pipeline.steps.probe_scan.run_probe_scan_batch.
+    # Issue #36 v12 reproduction can pass --band-cluster-max-dist 25.0 to pin the
+    # historical edf7bf6 row_stats clustering behavior after the current detector
+    # default changed to a median-height-derived value.
     candidates = detect_probe_scan(
         base_img=image,
         staff_mask=staff_mask,
         existing_boxes=existing_boxes,
         band_source=band_source,
+        band_cluster_max_dist=band_cluster_max_dist,
         band_min_row_count=1,
         band_scan_line_ratio=band_scan_line_ratio,
         band_scan_min_lines=band_scan_min_lines,
@@ -144,6 +149,7 @@ def _run_one(
         "staff_mask": str(staff_mask_path),
         "existing_boxes_path": str(existing_path),
         "band_source": band_source,
+        "band_cluster_max_dist": band_cluster_max_dist,
         "existing_count": len(existing_boxes),
         "generated_count": len(candidates),
         "final_count": len(final_list),
@@ -170,6 +176,15 @@ def parse_args() -> argparse.Namespace:
         choices=["row_stats", "staff_mask"],
         default="row_stats",
         help="Band source passed to detect_probe_scan. Default is row_stats for GT candidate seeds.",
+    )
+    parser.add_argument(
+        "--band-cluster-max-dist",
+        type=float,
+        default=None,
+        help=(
+            "Optional row_stats clustering distance passed to detect_probe_scan. "
+            "Use 25.0 for Issue #36 v12 historical reproduction."
+        ),
     )
     parser.add_argument(
         "--scan-x-peak-rescue",
@@ -214,6 +229,7 @@ def main() -> None:
                 band_scan_line_ratio=args.band_scan_line_ratio,
                 band_scan_min_lines=args.band_scan_min_lines,
                 band_source=args.band_source,
+                band_cluster_max_dist=args.band_cluster_max_dist,
                 scan_x_peak_rescue=args.scan_x_peak_rescue,
             )
             results.append(result)
@@ -236,6 +252,7 @@ def main() -> None:
             "band_scan_line_ratio": args.band_scan_line_ratio,
             "band_scan_min_lines": args.band_scan_min_lines,
             "band_source": args.band_source,
+            "band_cluster_max_dist": args.band_cluster_max_dist,
             "scan_x_peak_rescue": args.scan_x_peak_rescue,
         },
         "processed": len(results),


### PR DESCRIPTION
## Summary

Implements the #149 current validation route for the recovered Issue #36 v12 dense candidate producer.

Added/updated:

- `tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py`
  - adds route-local `--band-cluster-max-dist` support so Issue36 v12 can pin the historical `25.0` clustering behavior without changing general pipeline defaults.
- `tools/issue120/run_issue36_dense_candidates_then_eval.py`
  - diagnostic direct-score route;
  - regenerates Issue36 dense raw/filtered roots;
  - compares raw, filtered, and historical scoring-input candidate roots.
- `tools/issue120/run_issue36_dense_bands_then_issue53_eval.py`
  - acceptance route;
  - regenerates Issue36 dense raw/filtered roots;
  - verifies candidate-root equality against recovered historical roots;
  - uses the regenerated filtered root as Issue53 `bands_from`;
  - runs current Issue53 probe-rescue candidate regeneration;
  - scores with current CNN scoring and `cnn_apply_nms=false`;
  - runs the #134 full-68 detector evaluator and attaches route provenance.
- `tools/issue120/Makefile.issue36_dense.mk`
  - provides `verify-issue120-issue36-dense` for the acceptance route;
  - keeps `verify-issue120-issue36-dense-direct-score` as diagnostic-only.
- `docs/refactors/issue120/ISSUE120_ISSUE36_DENSE_VALIDATION.md`
  - documents commands, expected generated outputs, provenance checks, route distinction, and scope boundaries.

## Scope boundaries

- General pipeline defaults are not changed.
- Issue120 reconstruction explicitly uses `cnn_apply_nms=false` via `--no-pipeline-nms`.
- NMS policy remains owned by #142.
- Full slow HOMR/SR/OMR pipeline validation remains owned by #141.
- Detector metrics and downstream measure-count metrics remain separate.
- Generated outputs remain under ignored `logs/` paths.

## Validation

Acceptance command run locally:

```bash
make -f Makefile -f tools/issue120/Makefile.issue36_dense.mk \
  verify-issue120-issue36-dense \
  ISSUE120_ISSUE36_DENSE_REQUIRE_TARGET=1
```

Confirmed candidate-root recovery:

```text
raw candidate comparison: mismatch_pages=0, extra=0, missing=0
filtered candidate comparison: mismatch_pages=0, extra=0, missing=0
historical scoring-input comparison: mismatch_pages=0, extra=0, missing=0
```

Confirmed detector result:

```text
Pages: 68/68
Detector: GT=3581 Pred=3600 TP=3580 FP=0 FN=1 FN_det=0 FN_cnn=1 Precision=1.000000 Recall=0.999721
```

Candidate coverage from regenerated Issue53 probe-rescue candidates:

```text
Pages: 68
Baseline candidates: 29443
Compared candidates: 29772
Ratio: 1.011174133070679
Empty compared pages: 0
```

Closes #149.