### PR TITLE
Set CNN NMS default off for Issue120

### DIFF
--- a/docs/ISSUE120_HISTORICAL_BEST_AUDIT.md
+++ b/docs/ISSUE120_HISTORICAL_BEST_AUDIT.md
@@ -97,7 +97,7 @@ Interpretation:
 
 - The saved candidates, model artifact, images, GT, and current CNN inference path are sufficient to reproduce the detector target.
 - The Stage B regression is caused by current pipeline CNN scoring NMS.
-- This does not justify silently changing the global default. General pipeline behavior remains `cnn_apply_nms=true`.
+- #142 later changed the general CNN scoring default to `cnn_apply_nms=false`; NMS is retained as an explicit opt-in setting.
 - Issue #120 reconstruction must explicitly record `cnn_apply_nms=false`.
 
 Primary Stage B command:

--- a/docs/ISSUE120_NMS_POLICY.md
+++ b/docs/ISSUE120_NMS_POLICY.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document records what the CNN scoring NMS step means, why it exists, what Stage B proved, and how Issue #120 should handle it going forward.
+This document records what the CNN scoring NMS step means, why it exists, what Stage B proved, and how Issue #120 / #142 should handle it going forward.
 
 ## What NMS means here
 
@@ -23,7 +23,7 @@ NMS is intended to reduce duplicate detections.
 
 Without NMS, a detector can emit multiple nearby boxes around the same visual barline. Those duplicates may become false positives under a one-to-one matching evaluator or may cause downstream measure-count instability.
 
-Therefore, NMS is not inherently wrong. It can be useful as a precision and stability mechanism.
+Therefore, NMS is not inherently wrong. It can be useful as a precision and stability mechanism, but it must earn default status with measured evidence.
 
 ## What Stage B proved
 
@@ -58,21 +58,30 @@ Stage B pipeline scorer no NMS: Pred=3597 TP=3580 FP=0 FN=1
 
 The Stage B regression is caused by the current pipeline scorer's NMS step.
 
-This does not prove that NMS should be globally removed. It proves only that the current NMS rule is not compatible with the Issue #120 historical detector target on the canonical 68-page saved candidates.
+This proves that the current NMS rule is not compatible with the Issue #120 historical detector target on the canonical 68-page saved candidates.
 
 The current NMS rule suppresses true-positive candidates that the historical scorer retained. Because the false-positive count is already `0` in the historical target, this specific NMS application removes recall without improving precision for this benchmark.
+
+The Issue #120 evaluation2 set is not a single-score special case. It contains multiple score patterns and is the current canonical detector benchmark for this reconstruction. With no known counterexample where CNN scoring NMS improves detector accuracy or downstream measure-count metrics, the observed regression is sufficient reason to make NMS opt-in rather than default-on.
 
 ## Policy
 
 ### Default behavior
 
-Keep NMS enabled by default in the general pipeline until a broader accuracy comparison proves that changing the default is safe.
+Keep CNN scoring NMS disabled by default in the general pipeline.
+
+NMS remains available as an explicit opt-in setting:
+
+```yaml
+detection:
+  cnn_apply_nms: true
+```
+
+Making NMS default-on again requires canonical evidence that it improves, or at least does not regress, detector metrics and downstream measure-count metrics on the relevant evaluation set.
 
 ### Issue #120 reconstruction behavior
 
-Issue #120 canonical reconstruction may disable CNN scoring NMS explicitly.
-
-This must be explicit in config, command, or provenance. A result produced with NMS disabled must not be described as using default pipeline scoring.
+Issue #120 canonical reconstruction uses CNN scoring NMS disabled. Route configs and provenance should still record the setting explicitly so historical reports remain self-describing.
 
 ### Required recording
 
@@ -84,34 +93,56 @@ cnn_apply_nms: true|false
 
 or equivalent provenance field.
 
+For #142 policy evidence, report detector metrics and downstream measure-count metrics separately:
+
+```text
+TP / FP / FN
+measure-count net delta
+measure-count absolute delta sum
+pages with measure-count delta
+```
+
+If downstream measure numbering was not run, record the measure-count fields as `not_provided` rather than mixing detector metrics with proxy conclusions.
+
 ### Forbidden shortcut
 
-Do not silently remove or weaken NMS globally just to recover the historical target.
+Do not silently change NMS behavior. The default is now off because the canonical evidence shows a detector regression when it is on. Any run that opts back into NMS must record that setting in config, command output, or provenance.
 
 ### Future repair
 
-After Stage C/D/E determine the candidate-generation path, NMS can be repaired or tuned under #137. Candidate approaches include:
+NMS can be repaired or tuned in a later targeted task. Candidate approaches include:
 
-- disable NMS only for Issue #120 canonical reconstruction;
 - make NMS thresholds configurable;
 - replace the current X-distance suppression with a more conservative rule;
 - apply NMS only where it improves downstream measure-count metrics;
-- compare detector metrics and measure-count metrics before accepting any new default.
+- compare detector metrics and measure-count metrics before accepting any default-on behavior.
 
 ## Current decision
 
-For #136:
+For #142:
 
 ```text
 cnn_apply_nms=false
 ```
 
-is the canonical Stage B setting for reproducing the historical detector target from saved candidates using the current pipeline scorer.
+is the general CNN scoring default and the Issue #120 reconstruction setting.
 
-For general pipeline operation:
+For explicit NMS experiments:
 
 ```text
 cnn_apply_nms=true
 ```
 
-remains the default until #137 or a later PR changes it with evidence.
+is allowed only as an opt-in config/provenance setting. Current canonical evidence does not support default-on behavior.
+
+The summary helper for #142 evidence is:
+
+```bash
+python3 tools/issue120/summarize_nms_policy_evidence.py \
+  --case stage_b_nms_on=logs/issue120_e2e_recovery/issue142_nms_policy/stage_b_nms_on_eval \
+  --case stage_b_nms_off=logs/issue120_e2e_recovery/issue142_nms_policy/stage_b_nms_off_eval \
+  --case dense_route_nms_on=logs/issue120_e2e_recovery/issue142_nms_policy/dense_route_nms_on_eval \
+  --case dense_route_nms_off=logs/issue120_e2e_recovery/dense_probe_candidate_route/eval
+```
+
+Outputs are written under ignored `logs/issue120_e2e_recovery/issue142_nms_policy/`.

--- a/docs/ISSUE120_RESTART_PLAN.md
+++ b/docs/ISSUE120_RESTART_PLAN.md
@@ -193,7 +193,8 @@ Decide whether the current NMS should be kept, tuned, made conditional, or disab
 Current policy:
 
 ```text
-general pipeline default: cnn_apply_nms=true
+general pipeline default: cnn_apply_nms=false
+NMS experiments: cnn_apply_nms=true only as explicit opt-in
 Issue120 reconstruction: cnn_apply_nms=false, explicitly recorded
 ```
 
@@ -392,7 +393,8 @@ Until changed by a later audited issue:
 ```text
 detector target: TP=3580 / FP=0 / FN=1
 Issue120 reconstruction CNN setting: cnn_apply_nms=false
-general pipeline CNN setting: cnn_apply_nms=true
+general pipeline CNN setting: cnn_apply_nms=false
+NMS experiment setting: cnn_apply_nms=true only as explicit opt-in
 ```
 
 This detector target is not a downstream measure-count target and is not yet full-pipeline reproduction.

--- a/docs/ISSUE120_ROADMAP.md
+++ b/docs/ISSUE120_ROADMAP.md
@@ -329,14 +329,15 @@ Decide whether NMS should be kept, tuned, made conditional, or disabled in speci
 Current policy:
 
 ```text
-default general pipeline: cnn_apply_nms=true
+default general pipeline: cnn_apply_nms=false
+NMS experiments: cnn_apply_nms=true only as explicit opt-in
 Issue120 reconstruction: cnn_apply_nms=false, explicitly recorded
 ```
 
 Acceptance:
 
-- no silent global NMS weakening;
-- any default change requires detector and measure-count evidence.
+- no silent NMS behavior changes;
+- any future default-on change requires detector and measure-count evidence.
 
 ### #141: Stage E full 68-page pipeline validation
 

--- a/src/pipeline/detection/__init__.py
+++ b/src/pipeline/detection/__init__.py
@@ -1,6 +1,5 @@
 """Detection package providing barlines detection orchestration."""
 
-from .orchestrator import DetectorOrchestrator, run_detection_step
 from .utils import resolve_barlines_and_masks_config, resolve_paths_from_detection
 
 __all__ = [
@@ -9,3 +8,14 @@ __all__ = [
     "resolve_barlines_and_masks_config",
     "resolve_paths_from_detection",
 ]
+
+
+def __getattr__(name: str):
+    if name in {"DetectorOrchestrator", "run_detection_step"}:
+        from .orchestrator import DetectorOrchestrator, run_detection_step
+
+        return {
+            "DetectorOrchestrator": DetectorOrchestrator,
+            "run_detection_step": run_detection_step,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/pipeline/detection/config.py
+++ b/src/pipeline/detection/config.py
@@ -81,5 +81,5 @@ def get_probe_kwargs(det_cfg: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def get_cnn_apply_nms(det_cfg: Dict[str, Any]) -> bool:
-    """Return explicit CNN NMS setting, defaulting to opt-out."""
+    """Return explicit CNN NMS setting, defaulting to False (opt-in)."""
     return bool(det_cfg.get("cnn_apply_nms", DEFAULT_CNN_APPLY_NMS))

--- a/src/pipeline/detection/config.py
+++ b/src/pipeline/detection/config.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict
 
+DEFAULT_CNN_APPLY_NMS = False
+
 PROBE_SCAN_KWARG_KEYS = (
     "probe_width",
     "use_peak_relative_ratio",
@@ -76,3 +78,8 @@ def get_probe_kwargs(det_cfg: Dict[str, Any]) -> Dict[str, Any]:
         for key in PROBE_SCAN_KWARG_KEYS
         if key in det_cfg and det_cfg.get(key) is not None
     }
+
+
+def get_cnn_apply_nms(det_cfg: Dict[str, Any]) -> bool:
+    """Return explicit CNN NMS setting, defaulting to opt-out."""
+    return bool(det_cfg.get("cnn_apply_nms", DEFAULT_CNN_APPLY_NMS))

--- a/src/pipeline/detection/orchestrator.py
+++ b/src/pipeline/detection/orchestrator.py
@@ -11,7 +11,7 @@ from src.pipeline.steps.cnn_scoring import run_cnn_scoring_batch
 from src.pipeline.steps.probe_scan import run_probe_scan_batch
 from src.pipeline.utils.io import ensure_dir
 
-from .config import get_probe_kwargs
+from .config import get_cnn_apply_nms, get_probe_kwargs
 from .hybrid import HybridDetector
 
 logger = logging.getLogger(__name__)
@@ -175,7 +175,7 @@ class DetectorOrchestrator:
         if not cnn_model:
             raise ValueError("detection.cnn_model_path is required.")
 
-        cnn_apply_nms = bool(self.det_cfg.get("cnn_apply_nms", True))
+        cnn_apply_nms = get_cnn_apply_nms(self.det_cfg)
 
         if not self.dry_run:
             effective_images, effective_sr_scale = self._get_effective_images_for_probe()

--- a/tests/test_detection_config.py
+++ b/tests/test_detection_config.py
@@ -1,25 +1,10 @@
-import importlib.util
-from pathlib import Path
-
-
-def load_detection_config():
-    path = Path(__file__).resolve().parents[1] / "src/pipeline/detection/config.py"
-    spec = importlib.util.spec_from_file_location("detection_config_under_test", path)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+from src.pipeline.detection.config import DEFAULT_CNN_APPLY_NMS, get_cnn_apply_nms
 
 
 def test_cnn_apply_nms_defaults_to_false():
-    config = load_detection_config()
-
-    assert config.DEFAULT_CNN_APPLY_NMS is False
-    assert config.get_cnn_apply_nms({}) is False
+    assert DEFAULT_CNN_APPLY_NMS is False
+    assert get_cnn_apply_nms({}) is False
 
 
 def test_cnn_apply_nms_can_opt_in():
-    config = load_detection_config()
-
-    assert config.get_cnn_apply_nms({"cnn_apply_nms": True}) is True
+    assert get_cnn_apply_nms({"cnn_apply_nms": True}) is True

--- a/tests/test_detection_config.py
+++ b/tests/test_detection_config.py
@@ -1,0 +1,25 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_detection_config():
+    path = Path(__file__).resolve().parents[1] / "src/pipeline/detection/config.py"
+    spec = importlib.util.spec_from_file_location("detection_config_under_test", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cnn_apply_nms_defaults_to_false():
+    config = load_detection_config()
+
+    assert config.DEFAULT_CNN_APPLY_NMS is False
+    assert config.get_cnn_apply_nms({}) is False
+
+
+def test_cnn_apply_nms_can_opt_in():
+    config = load_detection_config()
+
+    assert config.get_cnn_apply_nms({"cnn_apply_nms": True}) is True

--- a/tests/test_issue142_nms_policy_evidence.py
+++ b/tests/test_issue142_nms_policy_evidence.py
@@ -1,0 +1,69 @@
+import json
+
+from tools.issue120.summarize_nms_policy_evidence import (
+    load_case,
+    write_json,
+    write_markdown,
+)
+
+
+def test_load_case_reports_detector_and_measure_count_separately(tmp_path):
+    eval_dir = tmp_path / "eval"
+    eval_dir.mkdir()
+    (eval_dir / "detector_metrics.json").write_text(
+        json.dumps({"gt": 20, "pred": 19, "tp": 18, "fp": 1, "fn": 2}),
+        encoding="utf-8",
+    )
+    (eval_dir / "stage_b_provenance.json").write_text(
+        json.dumps({"pipeline_nms_enabled": True}),
+        encoding="utf-8",
+    )
+    (eval_dir / "evaluation_contract.json").write_text(
+        json.dumps(
+            {
+                "measure_count_summary": {
+                    "status": "provided",
+                    "net_delta": -1,
+                    "abs_delta_sum": 3,
+                    "delta_pages": 2,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    case = load_case("nms_on", eval_dir)
+
+    assert case.cnn_apply_nms is True
+    assert case.tp == 18
+    assert case.fp == 1
+    assert case.fn == 2
+    assert case.measure_count_status == "provided"
+    assert case.measure_count_net_delta == -1
+    assert case.measure_count_abs_delta_sum == 3
+    assert case.measure_count_delta_pages == 2
+
+
+def test_write_outputs_preserve_missing_measure_count_status(tmp_path):
+    eval_dir = tmp_path / "eval"
+    eval_dir.mkdir()
+    (eval_dir / "detector_metrics.json").write_text(
+        json.dumps({"gt": 20, "pred": 20, "tp": 20, "fp": 0, "fn": 0}),
+        encoding="utf-8",
+    )
+    (eval_dir / "evaluation_contract.json").write_text(
+        json.dumps({"measure_count_summary": {"status": "not_provided"}}),
+        encoding="utf-8",
+    )
+
+    case = load_case("nms_off", eval_dir)
+    output_json = tmp_path / "summary.json"
+    output_md = tmp_path / "summary.md"
+
+    write_json(output_json, [case], "default off")
+    write_markdown(output_md, [case], "default off")
+
+    payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert payload["decision"] == "default off"
+    assert payload["cases"][0]["measure_count_status"] == "not_provided"
+    assert "not_provided" in output_md.read_text(encoding="utf-8")

--- a/tests/test_issue142_nms_policy_evidence.py
+++ b/tests/test_issue142_nms_policy_evidence.py
@@ -1,4 +1,10 @@
 import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from tools.issue120.summarize_nms_policy_evidence import (
     load_case,
@@ -67,3 +73,21 @@ def test_write_outputs_preserve_missing_measure_count_status(tmp_path):
     assert payload["decision"] == "default off"
     assert payload["cases"][0]["measure_count_status"] == "not_provided"
     assert "not_provided" in output_md.read_text(encoding="utf-8")
+
+
+def test_load_case_tolerates_missing_detector_metrics(tmp_path):
+    eval_dir = tmp_path / "eval"
+    eval_dir.mkdir()
+    (eval_dir / "evaluation_contract.json").write_text(
+        json.dumps({"measure_count_summary": {"status": "not_provided"}}),
+        encoding="utf-8",
+    )
+
+    case = load_case("incomplete", eval_dir)
+
+    assert case.tp is None
+    assert case.fp is None
+    assert case.fn is None
+    assert case.pred is None
+    assert case.gt is None
+    assert case.measure_count_status == "not_provided"

--- a/tests/test_pipeline_detection.py
+++ b/tests/test_pipeline_detection.py
@@ -63,6 +63,40 @@ class TestPipelineDetection(unittest.TestCase):
             self.assertEqual(commands[0], ["hybrid"])
             self.assertIn("inprocess:probe_scan", commands[1][0])
             self.assertIn("inprocess:cnn_scoring", commands[2][0])
+            self.assertEqual(mock_cnn.call_args.kwargs["apply_nms_enabled"], False)
+            self.assertEqual(commands[2][-1], "False")
+
+    def test_run_detection_step_allows_explicit_cnn_nms_opt_in(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hybrid_output_dir = Path(tmpdir) / "hybrid"
+            hybrid_output_dir.mkdir(parents=True, exist_ok=True)
+
+            config = self._base_config()
+            config["detection"]["cnn_apply_nms"] = True
+            images = [Path("data/evaluation/images/page_001.png")]
+            page_ids = ["page_001"]
+
+            with (
+                patch.object(
+                    HybridDetector,
+                    "run",
+                    return_value={"commands": [["hybrid"]], "hybrid_output_dir": hybrid_output_dir},
+                ),
+                patch("src.pipeline.detection.orchestrator.ensure_dir"),
+                patch("src.pipeline.detection.orchestrator.run_probe_scan_batch"),
+                patch("src.pipeline.detection.orchestrator.run_cnn_scoring_batch") as mock_cnn,
+            ):
+                result = run_detection_step(
+                    config=config,
+                    images=images,
+                    page_ids=page_ids,
+                    run_id="run123",
+                    run_dir=Path(tmpdir),
+                    dry_run=False,
+                )
+
+            self.assertEqual(mock_cnn.call_args.kwargs["apply_nms_enabled"], True)
+            self.assertEqual(result["commands"][2][-1], "True")
 
     def test_run_detection_step_skips_probe_and_cnn_on_dry_run(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tools/issue120/summarize_nms_policy_evidence.py
+++ b/tools/issue120/summarize_nms_policy_evidence.py
@@ -72,7 +72,8 @@ def _measure_count_summary(eval_dir: Path) -> dict[str, Any]:
 
 
 def load_case(label: str, eval_dir: Path) -> NmsEvidenceCase:
-    detector = load_json(eval_dir / "detector_metrics.json")
+    detector_path = eval_dir / "detector_metrics.json"
+    detector = load_json(detector_path) if detector_path.exists() else {}
     measure = _measure_count_summary(eval_dir)
     return NmsEvidenceCase(
         label=label,

--- a/tools/issue120/summarize_nms_policy_evidence.py
+++ b/tools/issue120/summarize_nms_policy_evidence.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Summarize Issue #142 CNN NMS policy evidence from canonical eval outputs.
+
+This tool reads existing Issue #120 canonical evaluation directories and writes
+one compact JSON/Markdown record for the NMS policy decision.  It does not run
+CNN scoring, detector evaluation, or downstream measure numbering.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class NmsEvidenceCase:
+    label: str
+    eval_dir: str
+    cnn_apply_nms: bool | None
+    tp: int | None
+    fp: int | None
+    fn: int | None
+    pred: int | None
+    gt: int | None
+    measure_count_status: str
+    measure_count_net_delta: int | None
+    measure_count_abs_delta_sum: int | None
+    measure_count_delta_pages: int | None
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def parse_case_arg(value: str) -> tuple[str, Path]:
+    label, sep, eval_dir = value.partition("=")
+    if not sep or not label or not eval_dir:
+        raise argparse.ArgumentTypeError("case must be LABEL=EVAL_DIR")
+    return label, Path(eval_dir)
+
+
+def _nms_from_provenance(eval_dir: Path) -> bool | None:
+    candidates = [
+        eval_dir / "stage_b_provenance.json",
+        eval_dir / "intermediate_provenance.json",
+    ]
+    for path in candidates:
+        if not path.exists():
+            continue
+        payload = load_json(path)
+        if "pipeline_nms_enabled" in payload:
+            return bool(payload["pipeline_nms_enabled"])
+        cnn_scoring = payload.get("cnn_scoring")
+        if isinstance(cnn_scoring, dict) and "cnn_apply_nms" in cnn_scoring:
+            return bool(cnn_scoring["cnn_apply_nms"])
+    return None
+
+
+def _measure_count_summary(eval_dir: Path) -> dict[str, Any]:
+    contract_path = eval_dir / "evaluation_contract.json"
+    if not contract_path.exists():
+        return {"status": "missing_evaluation_contract"}
+    contract = load_json(contract_path)
+    summary = contract.get("measure_count_summary")
+    if not isinstance(summary, dict):
+        return {"status": "missing_measure_count_summary"}
+    return summary
+
+
+def load_case(label: str, eval_dir: Path) -> NmsEvidenceCase:
+    detector = load_json(eval_dir / "detector_metrics.json")
+    measure = _measure_count_summary(eval_dir)
+    return NmsEvidenceCase(
+        label=label,
+        eval_dir=str(eval_dir),
+        cnn_apply_nms=_nms_from_provenance(eval_dir),
+        tp=detector.get("tp"),
+        fp=detector.get("fp"),
+        fn=detector.get("fn"),
+        pred=detector.get("pred"),
+        gt=detector.get("gt"),
+        measure_count_status=str(measure.get("status", "unknown")),
+        measure_count_net_delta=measure.get("net_delta"),
+        measure_count_abs_delta_sum=measure.get("abs_delta_sum"),
+        measure_count_delta_pages=measure.get("delta_pages"),
+    )
+
+
+def write_json(path: Path, cases: list[NmsEvidenceCase], decision: str) -> None:
+    payload = {
+        "schema_version": "issue142.nms_policy_evidence.v1",
+        "issue": 142,
+        "parent_issue": 120,
+        "decision": decision,
+        "cases": [asdict(case) for case in cases],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def format_nullable(value: object) -> str:
+    if value is None:
+        return "not_provided"
+    return str(value)
+
+
+def write_markdown(path: Path, cases: list[NmsEvidenceCase], decision: str) -> None:
+    lines = [
+        "# Issue 142 NMS Policy Evidence",
+        "",
+        f"Decision: {decision}",
+        "",
+        "| Case | cnn_apply_nms | TP | FP | FN | Pred | GT | measure-count status | net delta | abs delta sum | delta pages |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: |",
+    ]
+    for case in cases:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    case.label,
+                    format_nullable(case.cnn_apply_nms),
+                    format_nullable(case.tp),
+                    format_nullable(case.fp),
+                    format_nullable(case.fn),
+                    format_nullable(case.pred),
+                    format_nullable(case.gt),
+                    case.measure_count_status,
+                    format_nullable(case.measure_count_net_delta),
+                    format_nullable(case.measure_count_abs_delta_sum),
+                    format_nullable(case.measure_count_delta_pages),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "Detector metrics and downstream measure-count metrics are reported separately.",
+            "A missing measure-count value means no downstream numbering summary was attached to that eval contract.",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--case",
+        action="append",
+        type=parse_case_arg,
+        required=True,
+        metavar="LABEL=EVAL_DIR",
+        help="Evaluation case to summarize. May be provided multiple times.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("logs/issue120_e2e_recovery/issue142_nms_policy/evidence_summary.json"),
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("logs/issue120_e2e_recovery/issue142_nms_policy/evidence_summary.md"),
+    )
+    parser.add_argument(
+        "--decision",
+        default=(
+            "Set general CNN scoring NMS default to off. Keep NMS available as an "
+            "explicit opt-in setting until canonical detector and measure-count "
+            "evidence supports making it default again."
+        ),
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    cases = [load_case(label, eval_dir) for label, eval_dir in args.case]
+    write_json(args.output_json, cases, args.decision)
+    write_markdown(args.output_md, cases, args.decision)
+    print(f"Wrote: {args.output_json}")
+    print(f"Wrote: {args.output_md}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Related Issue
- Closes #142

## What (What was implemented)
- Changed the general CNN scoring NMS default to `cnn_apply_nms=false`.
- Kept NMS available as an explicit opt-in with `detection.cnn_apply_nms: true`.
- Added `tools/issue120/summarize_nms_policy_evidence.py` to summarize NMS policy evidence from canonical eval outputs.
- Updated Issue120 NMS policy, roadmap, restart-plan, and historical-audit docs to reflect default-off / opt-in NMS behavior.
- Added lightweight tests for the default-off helper and evidence summary formatting.

## Why (Why this change is needed)
- #136/#142 evidence shows current CNN scoring NMS suppresses true positives on the canonical Issue120 evaluation set.
- Rechecked with GPU Docker runs:
  - Stage B NMS on: `TP=3507 FP=0 FN=74`
  - Stage B NMS off: `TP=3580 FP=0 FN=1`
  - Dense route NMS on: `TP=3507 FP=0 FN=74`
  - Dense route NMS off: `TP=3580 FP=0 FN=1`
- There is currently no counter-evidence that NMS improves detector accuracy or downstream measure-count metrics, so default-on behavior is not justified.

## Scope (In / Out)
**In:**
- CNN scoring NMS default-policy change.
- Explicit opt-in behavior for NMS experiments.
- Detector-level NMS evidence summary tooling.
- Documentation/provenance guidance for detector metrics and measure-count separation.
- Lightweight tests around config defaults and summary generation.

**Out:**
- No NMS threshold tuning.
- No broad accuracy repair.
- No full slow HOMR/SR/OMR pipeline validation.
- No downstream measure-numbering or measure-count validation implementation.
- No generated logs or detector artifacts committed.

## How to test

### AI-side checks (performed by author / AI)
- `.venv_pdf/bin/python -m pytest tests/test_detection_config.py tests/test_issue142_nms_policy_evidence.py tests/test_dense_probe_candidate_route.py`
  - `15 passed`
- `.venv_pdf/bin/python -m pytest tests/test_pipeline_detection.py`
  - skipped on host because `.venv_pdf` does not include `homr`
- `make format`
  - passed
- `make lint`
  - passed
- Docker GPU NMS evidence runs in `pdfscore_pipeline_gpu`:
  - Stage B saved candidates + NMS on: `TP=3507 FP=0 FN=74 Pred=3507 GT=3581`
  - Stage B saved candidates + NMS off: `TP=3580 FP=0 FN=1 Pred=3597 GT=3581`
  - Dense route candidates + NMS on: `TP=3507 FP=0 FN=74 Pred=3507 GT=3581`
  - Dense route candidates + NMS off: `TP=3580 FP=0 FN=1 Pred=3600 GT=3581`

### Human-side checks (to be performed locally)
- Optional evidence regeneration:
  - `python3 tools/issue120/summarize_nms_policy_evidence.py --case stage_b_nms_on=logs/issue120_e2e_recovery/issue142_nms_policy/stage_b_nms_on_eval --case stage_b_nms_off=logs/issue120_e2e_recovery/issue142_nms_policy/stage_b_nms_off_eval --case dense_route_nms_on=logs/issue120_e2e_recovery/issue142_nms_policy/dense_route_nms_on_eval --case dense_route_nms_off=logs/issue120_e2e_recovery/dense_probe_candidate_route/eval`
- Full HOMR/SR/OMR-inclusive pipeline validation remains separate under #141.

## Notes / Implementation details
- `src.pipeline.detection.config.DEFAULT_CNN_APPLY_NMS` now records the default explicitly.
- `src.pipeline.detection.config.get_cnn_apply_nms()` centralizes default handling.
- The Issue120 dense route already records `cnn_apply_nms=false`; this PR keeps that route explicit.
- Measure-count fields are reported as `not_provided` when no downstream numbering summary is attached.
- A Stage E test-scope/environment note was added to #141: https://github.com/M763468/PDFScoreBar/issues/141#issuecomment-4465182933

## Screenshots / Logs (optional)
- Ignored local evidence summary:
  - `logs/issue120_e2e_recovery/issue142_nms_policy/evidence_summary.md`
  - `logs/issue120_e2e_recovery/issue142_nms_policy/evidence_summary.json`
- Issue #142 progress comment:
  - https://github.com/M763468/PDFScoreBar/issues/142#issuecomment-4465161173

## Checklist
- [x] 対象 Issue の Goal / Acceptance Criteria をすべて満たしている
- [x] Issue に書かれていない機能を先取りしていない
- [x] 入出力仕様（パス・ファイル名）が Issue と一致している
- [x] エラー時のログが分かりやすい
- [x] 依存追加が最小限である
- [x] README / ドキュメント更新の要否を確認した
