### PR TITLE
Productionize Stage E dense full-pipeline route

### DIFF
--- a/src/pipeline/core/run_ids.py
+++ b/src/pipeline/core/run_ids.py
@@ -14,3 +14,18 @@ def build_probe_run_id(image_path: Path, score_name: Optional[str] = None) -> st
     """Build run id used by probe_scan/cnn_scoring page directories."""
     resolved_score_name = score_name or image_path.parent.name
     return build_probe_run_id_from_parts(resolved_score_name, image_path.stem)
+
+
+def split_score_page_from_composite_stem(stem: str) -> tuple[str, str] | None:
+    """Split composite stems like ``Score_page_001`` into score and page.
+
+    Regular page stems such as ``page_001`` return ``None``. This keeps the
+    default pipeline path unchanged while supporting Stage E copied image names.
+    """
+    marker = "_page_"
+    idx = stem.rfind(marker)
+    if idx < 0:
+        return None
+    score = stem[:idx]
+    page = f"page_{stem[idx + len(marker):]}"
+    return score, page

--- a/src/pipeline/detection/orchestrator.py
+++ b/src/pipeline/detection/orchestrator.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from src.pipeline.core.config import get_nested
-from src.pipeline.core.run_ids import build_probe_run_id
+from src.pipeline.core.run_ids import build_probe_run_id, split_score_page_from_composite_stem
 from src.pipeline.steps.cnn_scoring import run_cnn_scoring_batch
 from src.pipeline.steps.probe_scan import run_probe_scan_batch
 from src.pipeline.utils.io import ensure_dir
@@ -22,17 +22,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _split_score_page_from_stem(stem: str) -> tuple[str, str] | None:
-    """Split composite Stage E stems like ``Score_page_001``.
-
-    Regular pipeline stems such as ``page_001`` return ``None``.
-    """
-    marker = "_page_"
-    idx = stem.rfind(marker)
-    if idx < 0:
-        return None
-    score = stem[:idx]
-    page = f"page_{stem[idx + len(marker):]}"
-    return score, page
+    """Compatibility wrapper for composite Stage E image stems."""
+    return split_score_page_from_composite_stem(stem)
 
 
 def _candidate_json_candidates(

--- a/src/pipeline/detection/orchestrator.py
+++ b/src/pipeline/detection/orchestrator.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import logging
+import shutil
 from pathlib import Path
 from typing import Any, Dict, List
 
 from src.pipeline.core.config import get_nested
+from src.pipeline.core.run_ids import build_probe_run_id
 from src.pipeline.steps.cnn_scoring import run_cnn_scoring_batch
 from src.pipeline.steps.probe_scan import run_probe_scan_batch
 from src.pipeline.utils.io import ensure_dir
@@ -17,6 +19,43 @@ from .hybrid import HybridDetector
 logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _split_score_page_from_stem(stem: str) -> tuple[str, str] | None:
+    """Split composite Stage E stems like ``Score_page_001``.
+
+    Regular pipeline stems such as ``page_001`` return ``None``.
+    """
+    marker = "_page_"
+    idx = stem.rfind(marker)
+    if idx < 0:
+        return None
+    score = stem[:idx]
+    page = f"page_{stem[idx + len(marker):]}"
+    return score, page
+
+
+def _candidate_json_candidates(
+    *,
+    root: Path,
+    image_path: Path,
+    score_name: str | None,
+) -> list[Path]:
+    """Return supported locations for a precomputed probe candidate JSON."""
+    candidates = [
+        root / build_probe_run_id(image_path, score_name=score_name) / "pipeline2_no_peak_candidates.json",
+        root / image_path.parent.name / image_path.stem / "pipeline2_no_peak_candidates.json",
+    ]
+    split = _split_score_page_from_stem(image_path.stem)
+    if split is not None:
+        score, page = split
+        candidates.extend(
+            [
+                root / f"eval2_{score}_{page}" / "pipeline2_no_peak_candidates.json",
+                root / score / page / "pipeline2_no_peak_candidates.json",
+            ]
+        )
+    return candidates
 
 
 class DetectorOrchestrator:
@@ -88,68 +127,82 @@ class DetectorOrchestrator:
         effective_score_name = self._get_effective_score_name()
         resolved_staff_mask_dir = self._resolve_staff_mask_dir()
         resolved_clef_mask_dir = self._resolve_clef_mask_dir()
+        precomputed_candidates_root = self._resolve_precomputed_probe_candidates_root()
 
         if not self.dry_run:
-            detect_probe_kwargs = get_probe_kwargs(self.det_cfg)
+            if precomputed_candidates_root is not None:
+                processed = self._copy_precomputed_probe_candidates(
+                    root=precomputed_candidates_root,
+                    images=effective_images,
+                    output_root=probe_output_root,
+                    score_name=effective_score_name,
+                )
+                logger.info(
+                    "Copied precomputed probe candidates for %s pages from %s",
+                    processed,
+                    precomputed_candidates_root,
+                )
+            else:
+                detect_probe_kwargs = get_probe_kwargs(self.det_cfg)
 
-            # Use verified Golden settings as default if not overridden
-            default_filter_kwargs = {
-                "left_margin_ratio": 0.25,
-                "clef_left_ratio": 0.30,
-                "min_height_median_ratio": 0.85,
-                "ink_threshold": 180,
-                "min_ink_ratio": 0.70,
-                "paper_threshold": 200,
-                "min_paper_overlap_ratio": 0.6,
-                "min_staff_overlap_ratio": 0.15,
-                "max_width_ratio": 0.05,
-            }
-            filter_kwargs = dict(default_filter_kwargs)
-            filter_kwargs.update(self.det_cfg.get("candidate_filter_kwargs", {}))
+                # Use verified Golden settings as default if not overridden
+                default_filter_kwargs = {
+                    "left_margin_ratio": 0.25,
+                    "clef_left_ratio": 0.30,
+                    "min_height_median_ratio": 0.85,
+                    "ink_threshold": 180,
+                    "min_ink_ratio": 0.70,
+                    "paper_threshold": 200,
+                    "min_paper_overlap_ratio": 0.6,
+                    "min_staff_overlap_ratio": 0.15,
+                    "max_width_ratio": 0.05,
+                }
+                filter_kwargs = dict(default_filter_kwargs)
+                filter_kwargs.update(self.det_cfg.get("candidate_filter_kwargs", {}))
 
-            run_probe_scan_batch(
-                images=effective_images,
-                output_root=probe_output_root,
-                bands_from=self.hybrid_output_dir,
-                staff_mask_dir=resolved_staff_mask_dir,
-                clef_mask_dir=resolved_clef_mask_dir,
-                ink_threshold=int(self.det_cfg.get("ink_threshold", 180)),
-                min_ratio=float(self.det_cfg.get("min_ratio", 0.50)),
-                min_height_ratio=float(self.det_cfg.get("min_height_ratio", 0.012)),
-                min_width_ratio=(
-                    float(self.det_cfg.get("min_width_ratio"))
-                    if self.det_cfg.get("min_width_ratio") is not None
-                    else 0.0001
-                ),
-                score_name=effective_score_name,
-                band_cluster_max_dist=(
-                    float(self.det_cfg.get("band_cluster_max_dist"))
-                    if self.det_cfg.get("band_cluster_max_dist") is not None
-                    else None
-                ),
-                band_min_row_count=int(self.det_cfg.get("band_min_row_count", 1)),
-                vertical_closing=int(self.det_cfg.get("vertical_closing", 4)),
-                detect_probe_kwargs=detect_probe_kwargs,
-                probe_row_filter_mode=(
-                    str(self.det_cfg.get("probe_row_filter_mode"))
-                    if self.det_cfg.get("probe_row_filter_mode") is not None
-                    else None
-                ),
-                probe_endpoint_x_scale=(
-                    float(self.det_cfg.get("probe_endpoint_x_scale"))
-                    if self.det_cfg.get("probe_endpoint_x_scale") is not None
-                    else None
-                ),
-                probe_endpoint_y_scale=(
-                    float(self.det_cfg.get("probe_endpoint_y_scale"))
-                    if self.det_cfg.get("probe_endpoint_y_scale") is not None
-                    else None
-                ),
-                skip_existing=self.skip_existing,
-                input_image_scale=float(effective_sr_scale),
-                enable_heuristic_filters=self.det_cfg.get("enable_heuristic_filters", True),
-                candidate_filter_kwargs=filter_kwargs,
-            )
+                run_probe_scan_batch(
+                    images=effective_images,
+                    output_root=probe_output_root,
+                    bands_from=self.hybrid_output_dir,
+                    staff_mask_dir=resolved_staff_mask_dir,
+                    clef_mask_dir=resolved_clef_mask_dir,
+                    ink_threshold=int(self.det_cfg.get("ink_threshold", 180)),
+                    min_ratio=float(self.det_cfg.get("min_ratio", 0.50)),
+                    min_height_ratio=float(self.det_cfg.get("min_height_ratio", 0.012)),
+                    min_width_ratio=(
+                        float(self.det_cfg.get("min_width_ratio"))
+                        if self.det_cfg.get("min_width_ratio") is not None
+                        else 0.0001
+                    ),
+                    score_name=effective_score_name,
+                    band_cluster_max_dist=(
+                        float(self.det_cfg.get("band_cluster_max_dist"))
+                        if self.det_cfg.get("band_cluster_max_dist") is not None
+                        else None
+                    ),
+                    band_min_row_count=int(self.det_cfg.get("band_min_row_count", 1)),
+                    vertical_closing=int(self.det_cfg.get("vertical_closing", 4)),
+                    detect_probe_kwargs=detect_probe_kwargs,
+                    probe_row_filter_mode=(
+                        str(self.det_cfg.get("probe_row_filter_mode"))
+                        if self.det_cfg.get("probe_row_filter_mode") is not None
+                        else None
+                    ),
+                    probe_endpoint_x_scale=(
+                        float(self.det_cfg.get("probe_endpoint_x_scale"))
+                        if self.det_cfg.get("probe_endpoint_x_scale") is not None
+                        else None
+                    ),
+                    probe_endpoint_y_scale=(
+                        float(self.det_cfg.get("probe_endpoint_y_scale"))
+                        if self.det_cfg.get("probe_endpoint_y_scale") is not None
+                        else None
+                    ),
+                    skip_existing=self.skip_existing,
+                    input_image_scale=float(effective_sr_scale),
+                    enable_heuristic_filters=self.det_cfg.get("enable_heuristic_filters", True),
+                    candidate_filter_kwargs=filter_kwargs,
+                )
 
         # Build command list for logging/return
         cmd_probe = [
@@ -163,6 +216,8 @@ class DetectorOrchestrator:
             "--min-ratio",
             str(self.det_cfg.get("min_ratio", 0.70)),
         ]
+        if precomputed_candidates_root is not None:
+            cmd_probe.extend(["--precomputed-candidates-root", str(precomputed_candidates_root)])
         if self.skip_existing:
             cmd_probe.append("--skip-existing")
 
@@ -176,6 +231,7 @@ class DetectorOrchestrator:
             raise ValueError("detection.cnn_model_path is required.")
 
         cnn_apply_nms = get_cnn_apply_nms(self.det_cfg)
+        cnn_bands_from = self._resolve_cnn_bands_from()
 
         if not self.dry_run:
             effective_images, effective_sr_scale = self._get_effective_images_for_probe()
@@ -193,7 +249,7 @@ class DetectorOrchestrator:
                     self.det_cfg.get("crop_recenter_max_shift_unit_ratio", 0.35)
                 ),
                 input_image_scale=float(effective_sr_scale),
-                bands_from=self.hybrid_output_dir,
+                bands_from=cnn_bands_from,
                 staff_vov_threshold=float(self.det_cfg.get("staff_vov_threshold", 0.5)),
                 apply_nms_enabled=cnn_apply_nms,
                 in_memory_images=self.in_memory_images,
@@ -209,10 +265,14 @@ class DetectorOrchestrator:
             "--apply-nms",
             str(cnn_apply_nms),
         ]
+        if cnn_bands_from is not None and cnn_bands_from != self.hybrid_output_dir:
+            cmd_score.extend(["--bands-from", str(cnn_bands_from)])
         return {"commands": [cmd_score]}
 
     def _get_effective_images_for_probe(self) -> tuple[List[Path], int]:
         """Returns images and scale to use for probe scan (SR or original)."""
+        if bool(self.det_cfg.get("probe_use_original_images", False)):
+            return self.images, 1
         if self.enable_sr:
             effective_images = []
             for img in self.images:
@@ -242,6 +302,59 @@ class DetectorOrchestrator:
         if override == "DEFAULT_SENTINEL":
             return self.hybrid_output_dir
         return Path(override) if override is not None else None
+
+    def _resolve_precomputed_probe_candidates_root(self) -> Path | None:
+        """Resolve optional probe candidate root supplied by a detector route."""
+        value = self.det_cfg.get("precomputed_probe_candidates_root")
+        if value is None:
+            # Backward-compatible temporary key used by the first #141 checkpoint.
+            value = self.det_cfg.get("stage_e_issue53_candidates_root")
+        return Path(value) if value else None
+
+    def _resolve_cnn_bands_from(self) -> Path | None:
+        """Resolve optional bands root used by CNN staff-overlap filtering."""
+        value = self.det_cfg.get("cnn_bands_from")
+        if value is None:
+            # Backward-compatible temporary key used by the first #141 checkpoint.
+            value = self.det_cfg.get("stage_e_dense_reconstruction_root")
+        return Path(value) if value else self.hybrid_output_dir
+
+    def _copy_precomputed_probe_candidates(
+        self,
+        *,
+        root: Path,
+        images: List[Path],
+        output_root: Path,
+        score_name: str | None,
+    ) -> int:
+        """Copy route-supplied probe candidates into the normal probe output tree."""
+        processed = 0
+        missing: list[str] = []
+        for img_path in images:
+            src = next(
+                (
+                    path
+                    for path in _candidate_json_candidates(
+                        root=root,
+                        image_path=img_path,
+                        score_name=score_name,
+                    )
+                    if path.exists()
+                ),
+                None,
+            )
+            if src is None:
+                missing.append(str(img_path))
+                continue
+            dest_dir = output_root / build_probe_run_id(img_path, score_name=score_name)
+            ensure_dir(dest_dir)
+            shutil.copy2(src, dest_dir / "pipeline2_no_peak_candidates.json")
+            processed += 1
+        if missing:
+            raise FileNotFoundError(
+                "Missing precomputed probe candidates for images:\n" + "\n".join(missing)
+            )
+        return processed
 
 
 def run_detection_step(

--- a/src/pipeline/detector_routes/stage_e_dense_full_pipeline.py
+++ b/src/pipeline/detector_routes/stage_e_dense_full_pipeline.py
@@ -1,13 +1,9 @@
 """Stage E dense/Issue53 full-pipeline route support.
 
-This module contains the Stage E-specific bridge needed to run the real
-full pipeline with freshly reconstructed dense and Issue53-style candidates.
-It deliberately preserves the Issue #141 checkpoint behavior while moving the
-runner-local glue out of ``tools/issue120/run_stage_e_full_pipeline.py``.
-
-The bridge is still Stage E-specific.  Follow-up #156 work should replace the
-remaining monkey-patch connection with explicit detector configuration/API
-support in the production orchestrator.
+This module contains the Stage E-specific reconstruction needed to run the
+real full pipeline with freshly rebuilt dense and Issue53-style candidates.
+It deliberately preserves the Issue #141 checkpoint behavior while keeping the
+runtime detector connection in the regular ``DetectorOrchestrator`` config/API.
 """
 
 from __future__ import annotations
@@ -215,115 +211,3 @@ def reconstruct_stage_e_dense_route(
         filtered_root=filtered_root,
         issue53_root=issue53_root,
     )
-
-
-
-def _load_json_boxes(path: Path):
-    payload = json.loads(path.read_text())
-    boxes = []
-    if not isinstance(payload, list):
-        return boxes
-    for item in payload:
-        if isinstance(item, dict) and "bbox" in item:
-            item = item["bbox"]
-        if isinstance(item, list) and len(item) >= 4:
-            boxes.append(tuple(int(round(float(v))) for v in item[:4]))
-    return boxes
-
-
-
-def _split_score_page_from_stem(stem: str):
-    marker = "_page_"
-    idx = stem.rfind(marker)
-    if idx < 0:
-        return None
-    score = stem[:idx]
-    page = f"page_{stem[idx + len(marker):]}"
-    return score, page
-
-
-
-def patch_dense_bands_loader() -> None:
-    """Resolve fresh Stage E dense roots for composite stems like Score_page_001."""
-    from src.pipeline.steps import cnn_scoring, probe_scan
-
-    original_loader = probe_scan._load_bands_for_image
-    if getattr(original_loader, "_stage_e_dense_loader", False):
-        return
-
-    def patched_loader(*, bands_from, current_score_name, stem):
-        if bands_from:
-            root = Path(bands_from)
-            split = _split_score_page_from_stem(stem)
-            if split is not None:
-                score, page = split
-                for candidate in [
-                    root / score / page / "pipeline2_no_peak_candidates.json",
-                    root / score / page / "pipeline2_no_peak_scored.json",
-                ]:
-                    if candidate.exists():
-                        return _load_json_boxes(candidate)
-        return original_loader(
-            bands_from=bands_from,
-            current_score_name=current_score_name,
-            stem=stem,
-        )
-
-    patched_loader._stage_e_dense_loader = True
-    probe_scan._load_bands_for_image = patched_loader
-    cnn_scoring._load_bands_for_image = patched_loader
-
-
-
-def patch_detector_for_stage_e(*, issue53_root: Path, filtered_root: Path) -> None:
-    """Connect reconstructed Issue53 candidates to the full pipeline detector step."""
-    import src.pipeline.detection.orchestrator as detection_orchestrator
-    from src.pipeline.core.run_ids import build_probe_run_id
-    from src.pipeline.detection.orchestrator import DetectorOrchestrator
-    from src.pipeline.utils.io import ensure_dir
-
-    if getattr(detection_orchestrator, "_stage_e_issue53_patch", False):
-        return
-
-    original_cnn_batch = detection_orchestrator.run_cnn_scoring_batch
-    original_get_images = DetectorOrchestrator._get_effective_images_for_probe
-
-    def get_effective_images_for_probe(self):
-        if bool(self.det_cfg.get("probe_use_original_images", False)):
-            return self.images, 1
-        return original_get_images(self)
-
-    def copy_issue53_candidates(**kwargs):
-        images = list(kwargs["images"])
-        output_root = Path(kwargs["output_root"])
-        score_name = kwargs.get("score_name")
-        processed = 0
-        for img_path in images:
-            split = _split_score_page_from_stem(img_path.stem)
-            if split is None:
-                raise RuntimeError(f"Cannot map Stage E image stem to score/page: {img_path.stem}")
-            score, page = split
-            src = issue53_root / f"eval2_{score}_{page}" / "pipeline2_no_peak_candidates.json"
-            if not src.exists():
-                raise FileNotFoundError(f"Missing reconstructed Issue53 candidates: {src}")
-            dest_dir = output_root / build_probe_run_id(img_path, score_name=score_name)
-            ensure_dir(dest_dir)
-            shutil.copy2(src, dest_dir / "pipeline2_no_peak_candidates.json")
-            processed += 1
-        return processed
-
-    def run_cnn_scoring_batch_with_dense_bands(**kwargs):
-        kwargs["bands_from"] = filtered_root
-        return original_cnn_batch(**kwargs)
-
-    DetectorOrchestrator._get_effective_images_for_probe = get_effective_images_for_probe
-    detection_orchestrator.run_probe_scan_batch = copy_issue53_candidates
-    detection_orchestrator.run_cnn_scoring_batch = run_cnn_scoring_batch_with_dense_bands
-    detection_orchestrator._stage_e_issue53_patch = True
-
-
-
-def apply_stage_e_dense_patch(*, issue53_root: Path, filtered_root: Path) -> None:
-    patch_dense_bands_loader()
-    patch_detector_for_stage_e(issue53_root=issue53_root, filtered_root=filtered_root)
-    logger.info("Applied Issue #141 Stage E Issue53 candidate reconstruction patch.")

--- a/src/pipeline/detector_routes/stage_e_dense_full_pipeline.py
+++ b/src/pipeline/detector_routes/stage_e_dense_full_pipeline.py
@@ -1,0 +1,329 @@
+"""Stage E dense/Issue53 full-pipeline route support.
+
+This module contains the Stage E-specific bridge needed to run the real
+full pipeline with freshly reconstructed dense and Issue53-style candidates.
+It deliberately preserves the Issue #141 checkpoint behavior while moving the
+runner-local glue out of ``tools/issue120/run_stage_e_full_pipeline.py``.
+
+The bridge is still Stage E-specific.  Follow-up #156 work should replace the
+remaining monkey-patch connection with explicit detector configuration/API
+support in the production orchestrator.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+GENERATION_PARAMS = {
+    "band_source": "row_stats",
+    "band_cluster_max_dist": "25.0",
+    "ink_threshold": "240",
+    "min_ratio": "0.6",
+    "min_height_ratio": "0.006",
+    "min_width_ratio": "0.0",
+    "probe_width": "4",
+    "max_per_band": "80",
+    "band_scan_line_ratio": "0.6",
+    "band_scan_min_lines": "5",
+}
+
+FILTER_PARAMS = {
+    "left_margin_ratio": "0.12",
+    "clef_left_ratio": "0.25",
+    "min_height_median_ratio": "0.6",
+    "ink_threshold": "180",
+    "min_ink_ratio": "0.18",
+    "paper_threshold": "200",
+    "min_paper_overlap_ratio": "0.6",
+    "min_staff_overlap_ratio": "0.02",
+}
+
+
+@dataclass(frozen=True)
+class StageEDenseRouteArtifacts:
+    """Freshly reconstructed Stage E route inputs."""
+
+    image_paths: list[Path]
+    filtered_root: Path
+    issue53_root: Path
+
+
+
+def _add_params(cmd: list[str], params: dict[str, str]) -> None:
+    for key, value in params.items():
+        cmd.extend([f"--{key.replace('_', '-')}", value])
+
+
+
+def _run_command(cmd: list[str], *, log_path: Path) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info("+ %s > %s", " ".join(cmd), log_path)
+    with log_path.open("w", encoding="utf-8") as log_file:
+        subprocess.run(cmd, check=True, stdout=log_file, stderr=subprocess.STDOUT)
+
+
+
+def load_stage_e_image_paths(
+    *,
+    inventory: Path,
+    exclude: Path,
+    expected_pages: int = 68,
+) -> list[Path]:
+    """Load the canonical Stage E image list from the current run inventory."""
+    inv = json.loads(inventory.read_text())
+    exclude_list = []
+    if exclude.exists():
+        exclude_list = json.loads(exclude.read_text()).get("excluded_pages", [])
+
+    image_paths: list[Path] = []
+    for rec in inv.get("records", []):
+        score = rec["score"]
+        page = rec["page"]
+        if {"score": score, "page": page} in exclude_list:
+            continue
+        image_paths.append(Path(rec["image"]))
+
+    if len(image_paths) != expected_pages:
+        raise RuntimeError(f"Expected {expected_pages} Stage E images, got {len(image_paths)}")
+    return image_paths
+
+
+
+def regenerate_dense_candidates(*, inventory: Path, exclude: Path, stage_e_root: Path) -> Path:
+    """Regenerate the recovered dense candidate/filter root inside this Stage E run."""
+    dense_root = stage_e_root / "dense_candidate_reconstruction"
+    raw_root = dense_root / "probe_candidates_from_inventory"
+    filtered_root = dense_root / "probe_candidates_filtered"
+    suggestions_root = dense_root / "filter_suggestions"
+    generation_summary = dense_root / "probe_generation_summary.json"
+    filter_summary = dense_root / "filter_apply_summary.json"
+    log_dir = dense_root / "logs"
+
+    if dense_root.exists():
+        shutil.rmtree(dense_root)
+    dense_root.mkdir(parents=True, exist_ok=True)
+
+    gen_cmd = [
+        sys.executable,
+        "tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py",
+        "--inventory",
+        str(inventory),
+        "--exclude",
+        str(exclude),
+        "--output-root",
+        str(raw_root),
+        "--summary-out",
+        str(generation_summary),
+    ]
+    _add_params(gen_cmd, GENERATION_PARAMS)
+    _run_command(gen_cmd, log_path=log_dir / "01_generate_probe_candidates.log")
+
+    filter_cmd = [
+        sys.executable,
+        "tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py",
+        "--inventory",
+        str(inventory),
+        "--exclude",
+        str(exclude),
+        "--candidates-root",
+        str(raw_root),
+        "--output-root",
+        str(filtered_root),
+        "--suggestions-root",
+        str(suggestions_root),
+        "--summary-out",
+        str(filter_summary),
+    ]
+    _add_params(filter_cmd, FILTER_PARAMS)
+    _run_command(filter_cmd, log_path=log_dir / "02_apply_candidate_filter.log")
+
+    summary = json.loads(filter_summary.read_text())
+    if summary.get("processed") != 68 or summary.get("errors") != 0:
+        raise RuntimeError(
+            "Dense candidate reconstruction did not complete cleanly: "
+            f"processed={summary.get('processed')} errors={summary.get('errors')}"
+        )
+    return filtered_root
+
+
+
+def regenerate_issue53_candidates(*, image_paths: list[Path], filtered_root: Path, stage_e_root: Path) -> Path:
+    """Regenerate the Issue53-style probe rescue root used by the dense route."""
+    from src.pipeline.steps.probe_scan import run_probe_scan_batch
+
+    issue53_root = stage_e_root / "dense_candidate_reconstruction" / "issue53_probe_rescue_candidates"
+    shutil.rmtree(issue53_root, ignore_errors=True)
+    issue53_root.mkdir(parents=True, exist_ok=True)
+
+    detect_probe_kwargs = {
+        "scan_gap_rescue": True,
+        "scan_gap_threshold_ratio": 1.5,
+        "scan_gap_rescue_min_ratio": 0.3,
+        "scan_x_peak_rescue": True,
+        "scan_rightmost_rescue": True,
+        "divisi_rescue": True,
+        "scan_center_on_peak": True,
+        "max_per_band": 100,
+    }
+    processed = run_probe_scan_batch(
+        images=image_paths,
+        output_root=issue53_root,
+        bands_from=filtered_root,
+        staff_mask_dir=None,
+        clef_mask_dir=None,
+        ink_threshold=180,
+        min_ratio=0.85,
+        min_height_ratio=0.012,
+        min_width_ratio=0.0001,
+        detect_probe_kwargs=detect_probe_kwargs,
+        enable_heuristic_filters=False,
+    )
+    if processed != 68:
+        raise RuntimeError(f"Issue53 candidate reconstruction processed {processed}/68 pages")
+    return issue53_root
+
+
+
+def reconstruct_stage_e_dense_route(
+    *,
+    inventory: Path,
+    exclude: Path,
+    stage_e_root: Path,
+) -> StageEDenseRouteArtifacts:
+    """Rebuild all Stage E detector inputs from current-run sources."""
+    image_paths = load_stage_e_image_paths(inventory=inventory, exclude=exclude)
+    filtered_root = regenerate_dense_candidates(
+        inventory=inventory,
+        exclude=exclude,
+        stage_e_root=stage_e_root,
+    )
+    issue53_root = regenerate_issue53_candidates(
+        image_paths=image_paths,
+        filtered_root=filtered_root,
+        stage_e_root=stage_e_root,
+    )
+    return StageEDenseRouteArtifacts(
+        image_paths=image_paths,
+        filtered_root=filtered_root,
+        issue53_root=issue53_root,
+    )
+
+
+
+def _load_json_boxes(path: Path):
+    payload = json.loads(path.read_text())
+    boxes = []
+    if not isinstance(payload, list):
+        return boxes
+    for item in payload:
+        if isinstance(item, dict) and "bbox" in item:
+            item = item["bbox"]
+        if isinstance(item, list) and len(item) >= 4:
+            boxes.append(tuple(int(round(float(v))) for v in item[:4]))
+    return boxes
+
+
+
+def _split_score_page_from_stem(stem: str):
+    marker = "_page_"
+    idx = stem.rfind(marker)
+    if idx < 0:
+        return None
+    score = stem[:idx]
+    page = f"page_{stem[idx + len(marker):]}"
+    return score, page
+
+
+
+def patch_dense_bands_loader() -> None:
+    """Resolve fresh Stage E dense roots for composite stems like Score_page_001."""
+    from src.pipeline.steps import cnn_scoring, probe_scan
+
+    original_loader = probe_scan._load_bands_for_image
+    if getattr(original_loader, "_stage_e_dense_loader", False):
+        return
+
+    def patched_loader(*, bands_from, current_score_name, stem):
+        if bands_from:
+            root = Path(bands_from)
+            split = _split_score_page_from_stem(stem)
+            if split is not None:
+                score, page = split
+                for candidate in [
+                    root / score / page / "pipeline2_no_peak_candidates.json",
+                    root / score / page / "pipeline2_no_peak_scored.json",
+                ]:
+                    if candidate.exists():
+                        return _load_json_boxes(candidate)
+        return original_loader(
+            bands_from=bands_from,
+            current_score_name=current_score_name,
+            stem=stem,
+        )
+
+    patched_loader._stage_e_dense_loader = True
+    probe_scan._load_bands_for_image = patched_loader
+    cnn_scoring._load_bands_for_image = patched_loader
+
+
+
+def patch_detector_for_stage_e(*, issue53_root: Path, filtered_root: Path) -> None:
+    """Connect reconstructed Issue53 candidates to the full pipeline detector step."""
+    import src.pipeline.detection.orchestrator as detection_orchestrator
+    from src.pipeline.core.run_ids import build_probe_run_id
+    from src.pipeline.detection.orchestrator import DetectorOrchestrator
+    from src.pipeline.utils.io import ensure_dir
+
+    if getattr(detection_orchestrator, "_stage_e_issue53_patch", False):
+        return
+
+    original_cnn_batch = detection_orchestrator.run_cnn_scoring_batch
+    original_get_images = DetectorOrchestrator._get_effective_images_for_probe
+
+    def get_effective_images_for_probe(self):
+        if bool(self.det_cfg.get("probe_use_original_images", False)):
+            return self.images, 1
+        return original_get_images(self)
+
+    def copy_issue53_candidates(**kwargs):
+        images = list(kwargs["images"])
+        output_root = Path(kwargs["output_root"])
+        score_name = kwargs.get("score_name")
+        processed = 0
+        for img_path in images:
+            split = _split_score_page_from_stem(img_path.stem)
+            if split is None:
+                raise RuntimeError(f"Cannot map Stage E image stem to score/page: {img_path.stem}")
+            score, page = split
+            src = issue53_root / f"eval2_{score}_{page}" / "pipeline2_no_peak_candidates.json"
+            if not src.exists():
+                raise FileNotFoundError(f"Missing reconstructed Issue53 candidates: {src}")
+            dest_dir = output_root / build_probe_run_id(img_path, score_name=score_name)
+            ensure_dir(dest_dir)
+            shutil.copy2(src, dest_dir / "pipeline2_no_peak_candidates.json")
+            processed += 1
+        return processed
+
+    def run_cnn_scoring_batch_with_dense_bands(**kwargs):
+        kwargs["bands_from"] = filtered_root
+        return original_cnn_batch(**kwargs)
+
+    DetectorOrchestrator._get_effective_images_for_probe = get_effective_images_for_probe
+    detection_orchestrator.run_probe_scan_batch = copy_issue53_candidates
+    detection_orchestrator.run_cnn_scoring_batch = run_cnn_scoring_batch_with_dense_bands
+    detection_orchestrator._stage_e_issue53_patch = True
+
+
+
+def apply_stage_e_dense_patch(*, issue53_root: Path, filtered_root: Path) -> None:
+    patch_dense_bands_loader()
+    patch_detector_for_stage_e(issue53_root=issue53_root, filtered_root=filtered_root)
+    logger.info("Applied Issue #141 Stage E Issue53 candidate reconstruction patch.")

--- a/src/pipeline/detector_routes/stage_e_dense_full_pipeline.py
+++ b/src/pipeline/detector_routes/stage_e_dense_full_pipeline.py
@@ -16,7 +16,11 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from src.pipeline.steps.probe_scan import run_probe_scan_batch
+
 logger = logging.getLogger(__name__)
+
+STAGE_E_EXPECTED_PAGES = 68
 
 GENERATION_PARAMS = {
     "band_source": "row_stats",
@@ -71,7 +75,7 @@ def load_stage_e_image_paths(
     *,
     inventory: Path,
     exclude: Path,
-    expected_pages: int = 68,
+    expected_pages: int = STAGE_E_EXPECTED_PAGES,
 ) -> list[Path]:
     """Load the canonical Stage E image list from the current run inventory."""
     inv = json.loads(inventory.read_text())
@@ -142,7 +146,7 @@ def regenerate_dense_candidates(*, inventory: Path, exclude: Path, stage_e_root:
     _run_command(filter_cmd, log_path=log_dir / "02_apply_candidate_filter.log")
 
     summary = json.loads(filter_summary.read_text())
-    if summary.get("processed") != 68 or summary.get("errors") != 0:
+    if summary.get("processed") != STAGE_E_EXPECTED_PAGES or summary.get("errors") != 0:
         raise RuntimeError(
             "Dense candidate reconstruction did not complete cleanly: "
             f"processed={summary.get('processed')} errors={summary.get('errors')}"
@@ -153,8 +157,6 @@ def regenerate_dense_candidates(*, inventory: Path, exclude: Path, stage_e_root:
 
 def regenerate_issue53_candidates(*, image_paths: list[Path], filtered_root: Path, stage_e_root: Path) -> Path:
     """Regenerate the Issue53-style probe rescue root used by the dense route."""
-    from src.pipeline.steps.probe_scan import run_probe_scan_batch
-
     issue53_root = stage_e_root / "dense_candidate_reconstruction" / "issue53_probe_rescue_candidates"
     shutil.rmtree(issue53_root, ignore_errors=True)
     issue53_root.mkdir(parents=True, exist_ok=True)
@@ -182,8 +184,9 @@ def regenerate_issue53_candidates(*, image_paths: list[Path], filtered_root: Pat
         detect_probe_kwargs=detect_probe_kwargs,
         enable_heuristic_filters=False,
     )
-    if processed != 68:
-        raise RuntimeError(f"Issue53 candidate reconstruction processed {processed}/68 pages")
+    expected_pages = len(image_paths)
+    if processed != expected_pages:
+        raise RuntimeError(f"Issue53 candidate reconstruction processed {processed}/{expected_pages} pages")
     return issue53_root
 
 

--- a/src/pipeline/steps/probe_scan.py
+++ b/src/pipeline/steps/probe_scan.py
@@ -19,7 +19,11 @@ try:
 except ImportError:  # pragma: no cover - optional in minimal test env
     np = None  # type: ignore[assignment]
 
-from src.pipeline.core.run_ids import build_probe_run_id, build_probe_run_id_from_parts
+from src.pipeline.core.run_ids import (
+    build_probe_run_id,
+    build_probe_run_id_from_parts,
+    split_score_page_from_composite_stem,
+)
 from src.pipeline.steps.candidate_filters import (
     filter_probe_candidates,
     split_box_vertically,
@@ -225,16 +229,6 @@ def _augment_unit_normalized_boxes(
     return out
 
 
-def _split_score_page_from_stem(stem: str) -> tuple[str, str] | None:
-    marker = "_page_"
-    idx = stem.rfind(marker)
-    if idx < 0:
-        return None
-    score = stem[:idx]
-    page = f"page_{stem[idx + len(marker):]}"
-    return score, page
-
-
 def _load_bands_for_image(
     *,
     bands_from: Optional[Path],
@@ -257,7 +251,7 @@ def _load_bands_for_image(
         bands_from / f"{stem}.json",
         bands_from / f"{run_subdir}_scored.json",
     ]
-    split = _split_score_page_from_stem(stem)
+    split = split_score_page_from_composite_stem(stem)
     if split is not None:
         score, page = split
         candidates.extend(

--- a/src/pipeline/steps/probe_scan.py
+++ b/src/pipeline/steps/probe_scan.py
@@ -225,6 +225,16 @@ def _augment_unit_normalized_boxes(
     return out
 
 
+def _split_score_page_from_stem(stem: str) -> tuple[str, str] | None:
+    marker = "_page_"
+    idx = stem.rfind(marker)
+    if idx < 0:
+        return None
+    score = stem[:idx]
+    page = f"page_{stem[idx + len(marker):]}"
+    return score, page
+
+
 def _load_bands_for_image(
     *,
     bands_from: Optional[Path],
@@ -247,6 +257,17 @@ def _load_bands_for_image(
         bands_from / f"{stem}.json",
         bands_from / f"{run_subdir}_scored.json",
     ]
+    split = _split_score_page_from_stem(stem)
+    if split is not None:
+        score, page = split
+        candidates.extend(
+            [
+                bands_from / score / page / "pipeline2_no_peak_candidates.json",
+                bands_from / score / page / "pipeline2_no_peak_scored.json",
+                bands_from / f"eval2_{score}_{page}" / "pipeline2_no_peak_candidates.json",
+                bands_from / f"eval2_{score}_{page}" / "pipeline2_no_peak_scored.json",
+            ]
+        )
     for path in candidates:
         if path.exists():
             return load_json_boxes(path)

--- a/tests/test_pipeline_detection.py
+++ b/tests/test_pipeline_detection.py
@@ -164,6 +164,55 @@ class TestPipelineDetection(unittest.TestCase):
             self.assertEqual(mock_probe.call_args.kwargs["score_name"], "FixedScore")
             self.assertEqual(mock_cnn.call_args.kwargs["score_name"], "FixedScore")
 
+    def test_precomputed_probe_candidates_are_copied_and_scored_with_cnn_bands(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            hybrid_output_dir = tmp / "hybrid"
+            hybrid_output_dir.mkdir(parents=True, exist_ok=True)
+            precomputed_root = tmp / "precomputed"
+            precomputed_dir = precomputed_root / "eval2_Score_page_001"
+            precomputed_dir.mkdir(parents=True, exist_ok=True)
+            (precomputed_dir / "pipeline2_no_peak_candidates.json").write_text("[]")
+            cnn_bands_from = tmp / "filtered_bands"
+            cnn_bands_from.mkdir(parents=True, exist_ok=True)
+
+            config = self._base_config()
+            config["detection"].update(
+                {
+                    "precomputed_probe_candidates_root": str(precomputed_root),
+                    "cnn_bands_from": str(cnn_bands_from),
+                    "probe_use_original_images": True,
+                }
+            )
+            images = [Path("data/evaluation/images/Score_page_001.png")]
+            page_ids = ["Score_page_001"]
+
+            with (
+                patch.object(
+                    HybridDetector,
+                    "run",
+                    return_value={"commands": [["hybrid"]], "hybrid_output_dir": hybrid_output_dir},
+                ),
+                patch("src.pipeline.detection.orchestrator.run_probe_scan_batch") as mock_probe,
+                patch("src.pipeline.detection.orchestrator.run_cnn_scoring_batch") as mock_cnn,
+            ):
+                result = run_detection_step(
+                    config=config,
+                    images=images,
+                    page_ids=page_ids,
+                    run_id="run123",
+                    run_dir=tmp,
+                    dry_run=False,
+                )
+
+            copied = tmp / "intermediate" / "probe_scan" / "eval2_images_Score_page_001" / "pipeline2_no_peak_candidates.json"
+            self.assertTrue(copied.exists())
+            mock_probe.assert_not_called()
+            mock_cnn.assert_called_once()
+            self.assertEqual(mock_cnn.call_args.kwargs["bands_from"], cnn_bands_from)
+            self.assertIn("--precomputed-candidates-root", result["commands"][1])
+            self.assertIn("--bands-from", result["commands"][2])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -1,252 +1,18 @@
 import argparse
-import json
 import logging
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 
 from src.pipeline.core.config import load_yaml
+from src.pipeline.detector_routes.stage_e_dense_full_pipeline import (
+    apply_stage_e_dense_patch,
+    reconstruct_stage_e_dense_route,
+)
 from src.pipeline.main import run_pipeline
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
 logger = logging.getLogger(__name__)
-
-GENERATION_PARAMS = {
-    "band_source": "row_stats",
-    "band_cluster_max_dist": "25.0",
-    "ink_threshold": "240",
-    "min_ratio": "0.6",
-    "min_height_ratio": "0.006",
-    "min_width_ratio": "0.0",
-    "probe_width": "4",
-    "max_per_band": "80",
-    "band_scan_line_ratio": "0.6",
-    "band_scan_min_lines": "5",
-}
-
-FILTER_PARAMS = {
-    "left_margin_ratio": "0.12",
-    "clef_left_ratio": "0.25",
-    "min_height_median_ratio": "0.6",
-    "ink_threshold": "180",
-    "min_ink_ratio": "0.18",
-    "paper_threshold": "200",
-    "min_paper_overlap_ratio": "0.6",
-    "min_staff_overlap_ratio": "0.02",
-}
-
-
-def _add_params(cmd: list[str], params: dict[str, str]) -> None:
-    for key, value in params.items():
-        cmd.extend([f"--{key.replace('_', '-')}", value])
-
-
-def _run_command(cmd: list[str], *, log_path: Path) -> None:
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    logger.info("+ %s > %s", " ".join(cmd), log_path)
-    with log_path.open("w", encoding="utf-8") as log_file:
-        subprocess.run(cmd, check=True, stdout=log_file, stderr=subprocess.STDOUT)
-
-
-def regenerate_dense_candidates(*, inventory: Path, exclude: Path, stage_e_root: Path) -> Path:
-    """Regenerate the recovered dense candidate/filter root inside this Stage E run."""
-    dense_root = stage_e_root / "dense_candidate_reconstruction"
-    raw_root = dense_root / "probe_candidates_from_inventory"
-    filtered_root = dense_root / "probe_candidates_filtered"
-    suggestions_root = dense_root / "filter_suggestions"
-    generation_summary = dense_root / "probe_generation_summary.json"
-    filter_summary = dense_root / "filter_apply_summary.json"
-    log_dir = dense_root / "logs"
-
-    if dense_root.exists():
-        shutil.rmtree(dense_root)
-    dense_root.mkdir(parents=True, exist_ok=True)
-
-    gen_cmd = [
-        sys.executable,
-        "tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py",
-        "--inventory",
-        str(inventory),
-        "--exclude",
-        str(exclude),
-        "--output-root",
-        str(raw_root),
-        "--summary-out",
-        str(generation_summary),
-    ]
-    _add_params(gen_cmd, GENERATION_PARAMS)
-    _run_command(gen_cmd, log_path=log_dir / "01_generate_probe_candidates.log")
-
-    filter_cmd = [
-        sys.executable,
-        "tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py",
-        "--inventory",
-        str(inventory),
-        "--exclude",
-        str(exclude),
-        "--candidates-root",
-        str(raw_root),
-        "--output-root",
-        str(filtered_root),
-        "--suggestions-root",
-        str(suggestions_root),
-        "--summary-out",
-        str(filter_summary),
-    ]
-    _add_params(filter_cmd, FILTER_PARAMS)
-    _run_command(filter_cmd, log_path=log_dir / "02_apply_candidate_filter.log")
-
-    summary = json.loads(filter_summary.read_text())
-    if summary.get("processed") != 68 or summary.get("errors") != 0:
-        raise RuntimeError(
-            "Dense candidate reconstruction did not complete cleanly: "
-            f"processed={summary.get('processed')} errors={summary.get('errors')}"
-        )
-    return filtered_root
-
-
-def regenerate_issue53_candidates(*, image_paths: list[Path], filtered_root: Path, stage_e_root: Path) -> Path:
-    """Regenerate the Issue53-style probe rescue root used by the dense route."""
-    from src.pipeline.steps.probe_scan import run_probe_scan_batch
-
-    issue53_root = stage_e_root / "dense_candidate_reconstruction" / "issue53_probe_rescue_candidates"
-    shutil.rmtree(issue53_root, ignore_errors=True)
-    issue53_root.mkdir(parents=True, exist_ok=True)
-
-    detect_probe_kwargs = {
-        "scan_gap_rescue": True,
-        "scan_gap_threshold_ratio": 1.5,
-        "scan_gap_rescue_min_ratio": 0.3,
-        "scan_x_peak_rescue": True,
-        "scan_rightmost_rescue": True,
-        "divisi_rescue": True,
-        "scan_center_on_peak": True,
-        "max_per_band": 100,
-    }
-    processed = run_probe_scan_batch(
-        images=image_paths,
-        output_root=issue53_root,
-        bands_from=filtered_root,
-        staff_mask_dir=None,
-        clef_mask_dir=None,
-        ink_threshold=180,
-        min_ratio=0.85,
-        min_height_ratio=0.012,
-        min_width_ratio=0.0001,
-        detect_probe_kwargs=detect_probe_kwargs,
-        enable_heuristic_filters=False,
-    )
-    if processed != 68:
-        raise RuntimeError(f"Issue53 candidate reconstruction processed {processed}/68 pages")
-    return issue53_root
-
-
-def _load_json_boxes(path: Path):
-    payload = json.loads(path.read_text())
-    boxes = []
-    if not isinstance(payload, list):
-        return boxes
-    for item in payload:
-        if isinstance(item, dict) and "bbox" in item:
-            item = item["bbox"]
-        if isinstance(item, list) and len(item) >= 4:
-            boxes.append(tuple(int(round(float(v))) for v in item[:4]))
-    return boxes
-
-
-def _split_score_page_from_stem(stem: str):
-    marker = "_page_"
-    idx = stem.rfind(marker)
-    if idx < 0:
-        return None
-    score = stem[:idx]
-    page = f"page_{stem[idx + len(marker):]}"
-    return score, page
-
-
-def patch_dense_bands_loader() -> None:
-    """Resolve fresh Stage E dense roots for composite stems like Score_page_001."""
-    from src.pipeline.steps import cnn_scoring, probe_scan
-
-    original_loader = probe_scan._load_bands_for_image
-    if getattr(original_loader, "_stage_e_dense_loader", False):
-        return
-
-    def patched_loader(*, bands_from, current_score_name, stem):
-        if bands_from:
-            root = Path(bands_from)
-            split = _split_score_page_from_stem(stem)
-            if split is not None:
-                score, page = split
-                for candidate in [
-                    root / score / page / "pipeline2_no_peak_candidates.json",
-                    root / score / page / "pipeline2_no_peak_scored.json",
-                ]:
-                    if candidate.exists():
-                        return _load_json_boxes(candidate)
-        return original_loader(
-            bands_from=bands_from,
-            current_score_name=current_score_name,
-            stem=stem,
-        )
-
-    patched_loader._stage_e_dense_loader = True
-    probe_scan._load_bands_for_image = patched_loader
-    cnn_scoring._load_bands_for_image = patched_loader
-
-
-def patch_detector_for_stage_e(*, issue53_root: Path, filtered_root: Path) -> None:
-    """Connect reconstructed Issue53 candidates to the full pipeline detector step."""
-    import src.pipeline.detection.orchestrator as detection_orchestrator
-    from src.pipeline.core.run_ids import build_probe_run_id
-    from src.pipeline.utils.io import ensure_dir
-    from src.pipeline.detection.orchestrator import DetectorOrchestrator
-
-    if getattr(detection_orchestrator, "_stage_e_issue53_patch", False):
-        return
-
-    original_cnn_batch = detection_orchestrator.run_cnn_scoring_batch
-    original_get_images = DetectorOrchestrator._get_effective_images_for_probe
-
-    def get_effective_images_for_probe(self):
-        if bool(self.det_cfg.get("probe_use_original_images", False)):
-            return self.images, 1
-        return original_get_images(self)
-
-    def copy_issue53_candidates(**kwargs):
-        images = list(kwargs["images"])
-        output_root = Path(kwargs["output_root"])
-        score_name = kwargs.get("score_name")
-        processed = 0
-        for img_path in images:
-            split = _split_score_page_from_stem(img_path.stem)
-            if split is None:
-                raise RuntimeError(f"Cannot map Stage E image stem to score/page: {img_path.stem}")
-            score, page = split
-            src = issue53_root / f"eval2_{score}_{page}" / "pipeline2_no_peak_candidates.json"
-            if not src.exists():
-                raise FileNotFoundError(f"Missing reconstructed Issue53 candidates: {src}")
-            dest_dir = output_root / build_probe_run_id(img_path, score_name=score_name)
-            ensure_dir(dest_dir)
-            shutil.copy2(src, dest_dir / "pipeline2_no_peak_candidates.json")
-            processed += 1
-        return processed
-
-    def run_cnn_scoring_batch_with_dense_bands(**kwargs):
-        kwargs["bands_from"] = filtered_root
-        return original_cnn_batch(**kwargs)
-
-    DetectorOrchestrator._get_effective_images_for_probe = get_effective_images_for_probe
-    detection_orchestrator.run_probe_scan_batch = copy_issue53_candidates
-    detection_orchestrator.run_cnn_scoring_batch = run_cnn_scoring_batch_with_dense_bands
-    detection_orchestrator._stage_e_issue53_patch = True
-
-
-def apply_stage_e_dense_patch(*, issue53_root: Path, filtered_root: Path) -> None:
-    patch_dense_bands_loader()
-    patch_detector_for_stage_e(issue53_root=issue53_root, filtered_root=filtered_root)
-    logger.info("Applied Issue #141 Stage E Issue53 candidate reconstruction patch.")
 
 
 def main():
@@ -264,46 +30,23 @@ def main():
         logger.error(f"Exclude file not found: {args.exclude}")
         sys.exit(1)
 
-    inv = json.loads(args.inventory.read_text())
-
-    exclude_list = []
-    if args.exclude.exists():
-        exclude_list = json.loads(args.exclude.read_text()).get("excluded_pages", [])
-
-    image_paths = []
-    for rec in inv.get("records", []):
-        score = rec["score"]
-        page = rec["page"]
-        if {"score": score, "page": page} in exclude_list:
-            continue
-        image_paths.append(Path(rec["image"]))
-
-    if len(image_paths) != 68:
-        logger.error(f"Expected 68 images, got {len(image_paths)}")
-        sys.exit(1)
-
     stage_e_root = args.output_root / "stage_e_full_pipeline"
     if stage_e_root.exists():
         logger.info("Removing stale Stage E run directory: %s", stage_e_root)
         shutil.rmtree(stage_e_root)
     stage_e_root.mkdir(parents=True, exist_ok=True)
 
-    filtered_root = regenerate_dense_candidates(
+    route_artifacts = reconstruct_stage_e_dense_route(
         inventory=args.inventory,
         exclude=args.exclude,
-        stage_e_root=stage_e_root,
-    )
-    issue53_root = regenerate_issue53_candidates(
-        image_paths=image_paths,
-        filtered_root=filtered_root,
         stage_e_root=stage_e_root,
     )
 
     stage_e_images_dir = stage_e_root / "images"
     stage_e_images_dir.mkdir(parents=True, exist_ok=True)
 
-    logger.info(f"Copying {len(image_paths)} images to {stage_e_images_dir}...")
-    for img_path in image_paths:
+    logger.info(f"Copying {len(route_artifacts.image_paths)} images to {stage_e_images_dir}...")
+    for img_path in route_artifacts.image_paths:
         dest_path = stage_e_images_dir / f"{img_path.parent.name}_{img_path.name}"
         shutil.copy2(img_path, dest_path)
 
@@ -318,11 +61,14 @@ def main():
     config["inputs"]["pdf_to_images"]["output_dir"] = str(stage_e_images_dir)
     config["inputs"]["pdf_to_images"]["image_glob"] = "*.png"
     config["run"]["run_id"] = "stage_e_full_pipeline"
-    config["detection"]["stage_e_dense_reconstruction_root"] = str(filtered_root)
-    config["detection"]["stage_e_issue53_candidates_root"] = str(issue53_root)
+    config["detection"]["stage_e_dense_reconstruction_root"] = str(route_artifacts.filtered_root)
+    config["detection"]["stage_e_issue53_candidates_root"] = str(route_artifacts.issue53_root)
     config["detection"]["probe_use_original_images"] = True
 
-    apply_stage_e_dense_patch(issue53_root=issue53_root, filtered_root=filtered_root)
+    apply_stage_e_dense_patch(
+        issue53_root=route_artifacts.issue53_root,
+        filtered_root=route_artifacts.filtered_root,
+    )
 
     temp_config_path = stage_e_root / "stage_e_config.yaml"
     import yaml

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -5,10 +5,7 @@ import sys
 from pathlib import Path
 
 from src.pipeline.core.config import load_yaml
-from src.pipeline.detector_routes.stage_e_dense_full_pipeline import (
-    apply_stage_e_dense_patch,
-    reconstruct_stage_e_dense_route,
-)
+from src.pipeline.detector_routes.stage_e_dense_full_pipeline import reconstruct_stage_e_dense_route
 from src.pipeline.main import run_pipeline
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
@@ -61,14 +58,9 @@ def main():
     config["inputs"]["pdf_to_images"]["output_dir"] = str(stage_e_images_dir)
     config["inputs"]["pdf_to_images"]["image_glob"] = "*.png"
     config["run"]["run_id"] = "stage_e_full_pipeline"
-    config["detection"]["stage_e_dense_reconstruction_root"] = str(route_artifacts.filtered_root)
-    config["detection"]["stage_e_issue53_candidates_root"] = str(route_artifacts.issue53_root)
+    config["detection"]["precomputed_probe_candidates_root"] = str(route_artifacts.issue53_root)
+    config["detection"]["cnn_bands_from"] = str(route_artifacts.filtered_root)
     config["detection"]["probe_use_original_images"] = True
-
-    apply_stage_e_dense_patch(
-        issue53_root=route_artifacts.issue53_root,
-        filtered_root=route_artifacts.filtered_root,
-    )
 
     temp_config_path = stage_e_root / "stage_e_config.yaml"
     import yaml


### PR DESCRIPTION
## Related Issue
- Refs #156
- Parent: #120
- Preserves checkpoint from #141 / PR #155

## What
Productionizes the Issue120 Stage E dense/Issue53 full-pipeline route in small steps while preserving the canonical detector checkpoint.

Changes included:
- Moves Stage E dense candidate reconstruction and Issue53-style candidate reconstruction out of `tools/issue120/run_stage_e_full_pipeline.py` into `src/pipeline/detector_routes/stage_e_dense_full_pipeline.py`.
- Adds explicit detector route hooks in `DetectorOrchestrator`:
  - `detection.precomputed_probe_candidates_root`
  - `detection.cnn_bands_from`
  - `detection.probe_use_original_images`
- Removes the Stage E detector monkey-patch bridge from the runner/module path.
- Adds composite score/page stem lookup support for `bands_from` roots, e.g. `Score_page_001` -> `Score/page_001`.
- Adds an orchestrator test for precomputed probe candidates and explicit CNN bands root wiring.

## Scope boundary
This PR does not change detector thresholds, CNN threshold, NMS policy, or the canonical Stage E target.

It keeps the following separation intact:
- #151 remains detector-level partial route evidence.
- #141 / #156 Stage E remains the real full HOMR/SR/OMR-inclusive pipeline route.
- Detector metrics remain separate from downstream measure-count metrics.

## Validation
Local Stage E validation after this refactor still meets the canonical detector target:

```text
Pages:     68/68
GT:        3581
Pred:      3600
TP:        3580
FP:        0
FN:        1
  FN_det:  0
  FN_cnn:  1
Precision: 1.000000
Recall:    0.999721
cnn_apply_nms=false
target_met.detector=true
```

Machine-readable contract fields confirmed:

```json
{
  "expected_pages": 68,
  "evaluated_pages": 68,
  "missing_pages": [],
  "target_met": {"detector": true},
  "cnn_apply_nms": false,
  "detector_summary": {
    "gt": 3581,
    "pred": 3600,
    "tp": 3580,
    "fp": 0,
    "fn": 1,
    "fn_det": 0,
    "fn_cnn": 1
  },
  "measure_count_summary": {"status": "not_provided"}
}
```

Validation commands used:

```bash
make run-issue120-stage-e-full
make eval-issue120-stage-e-full

PYTHONPATH=. python3 tools/issue120/attach_stage_e_eval_contract.py \
  --manifest logs/issue120_e2e_recovery/stage_e_full_pipeline/manifest.json \
  --eval-dir logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector \
  --score-threshold 0.1 \
  --xdist-threshold 12.0
```

## Notes
Generated logs and evaluation artifacts remain under ignored `logs/` paths and are not committed.

Draft until reviewer comments and any CI/static checks are addressed.