### PR TITLE
#159 Stage E runtime/resource/log observability

### DIFF
--- a/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
+++ b/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
@@ -20,7 +20,7 @@ Issue #159 adds metric-neutral runtime/log observability to the Stage E runner:
 - `dense_route_execution_summary.json` records dense-route phase durations, command log paths, log sizes, and generated artifact roots.
 - `stage_e_runtime_summary.json` records the dense-route summary plus image-copy and full-pipeline durations.
 - Dense reconstruction subprocess logs are compact by default. The compact log keeps bounded head/tail output and records omitted middle-line counts.
-- Diagnostic full logs can be enabled with `--dense-route-verbose-logs` on `tools/issue120/run_stage_e_full_pipeline.py`.
+- Diagnostic full logs can be enabled with `--dense-route-verbose-logs` on `tools/issue120/run_stage_e_full_pipeline.py`, but the command must be run through the same managed pipeline environment used by the Stage E make target. It is not expected to work from a global Python interpreter without the repository's PDF/image-processing dependencies.
 
 These summaries are generated under `logs/` and should not be committed.
 

--- a/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
+++ b/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-This document records the final full 68-page Stage E pipeline validation result against the Issue #120 detector target.
+This document records the full 68-page Stage E pipeline validation result against the Issue #120 detector target.
 
-Stage E validates the real full pipeline path. It is intentionally distinct from the #151 dense probe-candidate route, which is a detector-level partial route and does not run the full HOMR/SR/OMR-inclusive pipeline or downstream measure numbering.
+Stage E validates the real full pipeline path. It is distinct from the #151 dense probe-candidate route, which is a detector-level partial route and does not run the full HOMR/SR/OMR-inclusive pipeline or downstream measure numbering.
 
 ## Execution Configuration
 
@@ -15,29 +15,32 @@ Stage E validates the real full pipeline path. It is intentionally distinct from
 
 ## Runtime, Resource, and Log Surface
 
-Issue #159 adds metric-neutral runtime/log observability to the Stage E runner:
+Issue #159 adds metric-neutral observability around the Stage E runner and dense route:
 
 - `dense_route_execution_summary.json` records dense-route phase durations, command log paths, log sizes, and generated artifact roots.
 - `stage_e_runtime_summary.json` records the dense-route summary plus image-copy and full-pipeline durations.
-- `pipeline_phase_summary.json` records full-pipeline phase and detector subphase durations when `run.write_phase_summary: true` is enabled. This is enabled for the Stage E config, not for ordinary pipeline runs by default.
-- `stage_e_resource_samples.jsonl` records best-effort CPU/RSS/GPU resource samples during full-pipeline execution.
-- `stage_e_resource_samples.summary.json` records peak and continuous CPU/RSS/GPU resource summaries derived from those samples.
-- `pipeline_stdout_stderr.log` captures stdout/stderr emitted during full-pipeline execution, including noisy external-tool output such as HOMR and Real-ESRGAN messages.
+- `stage_e_resource_samples.jsonl` records best-effort CPU/RSS/GPU samples during full-pipeline execution.
+- `stage_e_resource_samples.summary.json` records best-effort peak CPU/RSS/GPU summaries derived from those samples.
+- `pipeline_stdout_stderr.log` captures stdout/stderr emitted during full-pipeline execution.
+- `pipeline_stdout_stderr.summary.json` records compact counts and markers from the captured console log.
+- If a pipeline phase summary is produced by the run, `stage_e_runtime_summary.json` attaches its path and payload for convenience. Issue #159 does not make full-pipeline phase timing a default pipeline artifact.
 - Dense reconstruction subprocess logs are compact by default. The compact log keeps bounded head/tail output and records omitted middle-line counts.
-- Diagnostic full logs can be enabled with `--dense-route-verbose-logs` on `tools/issue120/run_stage_e_full_pipeline.py`, but the command must be run through the same managed pipeline environment used by the Stage E make target. It is not expected to work from a global Python interpreter without the repository's PDF/image-processing dependencies.
+- Diagnostic full logs can be enabled with `--dense-route-verbose-logs`, but the runner should be invoked through the Stage E make target / managed pipeline environment.
 
 Resource sampling is best-effort:
 
 - Process memory uses Python `resource` and, when installed, `psutil` process-tree RSS.
+- Live process-tree CPU percentage uses `psutil` process-tree CPU-time deltas when available.
+- Child-process `resource` CPU deltas are kept only as a diagnostic signal, not as live subprocess CPU.
 - GPU memory/utilization uses `nvidia-smi` when available.
 - Sampling can be disabled with `--no-resource-sampling`.
-- The sampling interval can be adjusted with `--resource-sample-interval-sec`.
+- The sampling interval can be adjusted with `--resource-sample-interval-sec`; non-positive intervals are rejected while sampling is enabled.
 
 These summaries are generated under `logs/` and should not be committed.
 
-Issue #159 uses these artifacts to identify safe parallelization opportunities. The measurements showed that Stage E runtime is dominated by HOMR/SR detection, especially `homr_sr` and `homr_baseline`. Actual HOMR/SR parallelization experiments are intentionally deferred to follow-up issue #163 so this validated checkpoint does not introduce new resource scheduling behavior.
+Issue #159 uses these artifacts to identify safe parallelization opportunities. The measurements showed that Stage E runtime is dominated by HOMR/SR detection, but actual HOMR/SR parallelization experiments are intentionally deferred to follow-up issue #163/#166 so this validated checkpoint does not introduce new resource scheduling behavior.
 
-Pipeline logging taxonomy and default noisy-log policy are also deferred to follow-up issue #162. Issue #159 captures and summarizes stdout/stderr but does not redesign default logger semantics.
+Pipeline logging taxonomy and default noisy-log policy are deferred to follow-up issue #162/#164. Issue #159 captures and summarizes stdout/stderr but does not redesign default logger semantics.
 
 ## Detector Metrics vs Target
 

--- a/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
+++ b/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
@@ -10,8 +10,19 @@ Stage E validates the real full pipeline path. It is intentionally distinct from
 
 - **Run ID**: `stage_e_full_pipeline`
 - **Output location**: `logs/issue120_e2e_recovery/stage_e_full_pipeline/`
-- **Components run**: dense candidate reconstruction, Issue53-style probe rescue candidate reconstruction, HOMR/SR/OMR-inclusive full pipeline execution, CNN scoring, and downstream measure numbering.
+- **Components run**: dense candidate reconstruction, probe-rescue candidate reconstruction, HOMR/SR/OMR-inclusive full pipeline execution, CNN scoring, and downstream measure numbering.
 - **NMS policy**: `cnn_apply_nms: false` per Issue #142.
+
+## Runtime and Log Surface
+
+Issue #159 adds metric-neutral runtime/log observability to the Stage E runner:
+
+- `dense_route_execution_summary.json` records dense-route phase durations, command log paths, log sizes, and generated artifact roots.
+- `stage_e_runtime_summary.json` records the dense-route summary plus image-copy and full-pipeline durations.
+- Dense reconstruction subprocess logs are compact by default. The compact log keeps bounded head/tail output and records omitted middle-line counts.
+- Diagnostic full logs can be enabled with `--dense-route-verbose-logs` on `tools/issue120/run_stage_e_full_pipeline.py`.
+
+These summaries are generated under `logs/` and should not be committed.
 
 ## Detector Metrics vs Target
 
@@ -51,8 +62,8 @@ The repair connects Stage E to the recovered route without consuming historical 
 
 1. Regenerate dense probe candidates inside the current Stage E run.
 2. Apply clef/staff-aware candidate filtering inside the current Stage E run.
-3. Regenerate Issue53-style probe rescue candidates from that filtered root inside the current Stage E run.
-4. Feed the freshly regenerated Issue53 candidate root into the full pipeline detector/CNN scoring path.
+3. Regenerate probe-rescue candidates from that filtered root inside the current Stage E run.
+4. Feed the freshly regenerated probe-rescue candidate root into the full pipeline detector/CNN scoring path.
 5. Evaluate detector metrics from the full-pipeline manifest.
 
 This keeps #151 as detector-level evidence while making #141 validate a real full-pipeline Stage E run.

--- a/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
+++ b/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
@@ -19,8 +19,9 @@ Issue #159 adds metric-neutral runtime/log observability to the Stage E runner:
 
 - `dense_route_execution_summary.json` records dense-route phase durations, command log paths, log sizes, and generated artifact roots.
 - `stage_e_runtime_summary.json` records the dense-route summary plus image-copy and full-pipeline durations.
+- `pipeline_phase_summary.json` records full-pipeline phase and detector subphase durations when `run.write_phase_summary: true` is enabled. This is enabled for the Stage E config, not for ordinary pipeline runs by default.
 - `stage_e_resource_samples.jsonl` records best-effort CPU/RSS/GPU resource samples during full-pipeline execution.
-- `stage_e_resource_samples.summary.json` records resource peaks derived from those samples.
+- `stage_e_resource_samples.summary.json` records peak and continuous CPU/RSS/GPU resource summaries derived from those samples.
 - `pipeline_stdout_stderr.log` captures stdout/stderr emitted during full-pipeline execution, including noisy external-tool output such as HOMR and Real-ESRGAN messages.
 - Dense reconstruction subprocess logs are compact by default. The compact log keeps bounded head/tail output and records omitted middle-line counts.
 - Diagnostic full logs can be enabled with `--dense-route-verbose-logs` on `tools/issue120/run_stage_e_full_pipeline.py`, but the command must be run through the same managed pipeline environment used by the Stage E make target. It is not expected to work from a global Python interpreter without the repository's PDF/image-processing dependencies.
@@ -33,6 +34,10 @@ Resource sampling is best-effort:
 - The sampling interval can be adjusted with `--resource-sample-interval-sec`.
 
 These summaries are generated under `logs/` and should not be committed.
+
+Issue #159 uses these artifacts to identify safe parallelization opportunities. The measurements showed that Stage E runtime is dominated by HOMR/SR detection, especially `homr_sr` and `homr_baseline`. Actual HOMR/SR parallelization experiments are intentionally deferred to follow-up issue #163 so this validated checkpoint does not introduce new resource scheduling behavior.
+
+Pipeline logging taxonomy and default noisy-log policy are also deferred to follow-up issue #162. Issue #159 captures and summarizes stdout/stderr but does not redesign default logger semantics.
 
 ## Detector Metrics vs Target
 

--- a/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
+++ b/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
@@ -13,14 +13,24 @@ Stage E validates the real full pipeline path. It is intentionally distinct from
 - **Components run**: dense candidate reconstruction, probe-rescue candidate reconstruction, HOMR/SR/OMR-inclusive full pipeline execution, CNN scoring, and downstream measure numbering.
 - **NMS policy**: `cnn_apply_nms: false` per Issue #142.
 
-## Runtime and Log Surface
+## Runtime, Resource, and Log Surface
 
 Issue #159 adds metric-neutral runtime/log observability to the Stage E runner:
 
 - `dense_route_execution_summary.json` records dense-route phase durations, command log paths, log sizes, and generated artifact roots.
 - `stage_e_runtime_summary.json` records the dense-route summary plus image-copy and full-pipeline durations.
+- `stage_e_resource_samples.jsonl` records best-effort CPU/RSS/GPU resource samples during full-pipeline execution.
+- `stage_e_resource_samples.summary.json` records resource peaks derived from those samples.
+- `pipeline_stdout_stderr.log` captures stdout/stderr emitted during full-pipeline execution, including noisy external-tool output such as HOMR and Real-ESRGAN messages.
 - Dense reconstruction subprocess logs are compact by default. The compact log keeps bounded head/tail output and records omitted middle-line counts.
 - Diagnostic full logs can be enabled with `--dense-route-verbose-logs` on `tools/issue120/run_stage_e_full_pipeline.py`, but the command must be run through the same managed pipeline environment used by the Stage E make target. It is not expected to work from a global Python interpreter without the repository's PDF/image-processing dependencies.
+
+Resource sampling is best-effort:
+
+- Process memory uses Python `resource` and, when installed, `psutil` process-tree RSS.
+- GPU memory/utilization uses `nvidia-smi` when available.
+- Sampling can be disabled with `--no-resource-sampling`.
+- The sampling interval can be adjusted with `--resource-sample-interval-sec`.
 
 These summaries are generated under `logs/` and should not be committed.
 

--- a/src/pipeline/detector_routes/dense_full_pipeline.py
+++ b/src/pipeline/detector_routes/dense_full_pipeline.py
@@ -13,14 +13,19 @@ import logging
 import shutil
 import subprocess
 import sys
+import time
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from src.pipeline.steps.probe_scan import run_probe_scan_batch
 
 logger = logging.getLogger(__name__)
 
 DENSE_ROUTE_EXPECTED_PAGES = 68
+DEFAULT_LOG_HEAD_LINES = 200
+DEFAULT_LOG_TAIL_LINES = 200
 
 GENERATION_PARAMS = {
     "band_source": "row_stats",
@@ -54,6 +59,33 @@ class DenseRouteArtifacts:
     image_paths: list[Path]
     filtered_root: Path
     probe_rescue_root: Path
+    execution_summary: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class CommandLogSummary:
+    command: list[str]
+    log_path: Path
+    log_mode: str
+    returncode: int
+    duration_sec: float
+    output_lines: int
+    output_bytes: int
+    omitted_middle_lines: int
+    log_size_bytes: int
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "command": self.command,
+            "log_path": str(self.log_path),
+            "log_mode": self.log_mode,
+            "returncode": self.returncode,
+            "duration_sec": self.duration_sec,
+            "output_lines": self.output_lines,
+            "output_bytes": self.output_bytes,
+            "omitted_middle_lines": self.omitted_middle_lines,
+            "log_size_bytes": self.log_size_bytes,
+        }
 
 
 def _add_params(cmd: list[str], params: dict[str, str]) -> None:
@@ -61,11 +93,120 @@ def _add_params(cmd: list[str], params: dict[str, str]) -> None:
         cmd.extend([f"--{key.replace('_', '-')}", value])
 
 
-def _run_command(cmd: list[str], *, log_path: Path) -> None:
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    logger.info("+ %s > %s", " ".join(cmd), log_path)
+def _compact_log_path(log_path: Path) -> Path:
+    if log_path.suffix:
+        return log_path.with_name(f"{log_path.stem}.compact{log_path.suffix}")
+    return log_path.with_name(f"{log_path.name}.compact")
+
+
+def _write_compact_log(
+    log_path: Path,
+    *,
+    cmd: list[str],
+    process: subprocess.Popen[str],
+    started_at: float,
+    head_lines_limit: int = DEFAULT_LOG_HEAD_LINES,
+    tail_lines_limit: int = DEFAULT_LOG_TAIL_LINES,
+) -> CommandLogSummary:
+    head: list[str] = []
+    tail: deque[str] = deque(maxlen=tail_lines_limit)
+    output_lines = 0
+    output_bytes = 0
+
+    assert process.stdout is not None
+    for line in process.stdout:
+        output_lines += 1
+        output_bytes += len(line.encode("utf-8", errors="replace"))
+        if len(head) < head_lines_limit:
+            head.append(line)
+        else:
+            tail.append(line)
+
+    returncode = process.wait()
+    duration_sec = time.perf_counter() - started_at
+    omitted_middle_lines = max(output_lines - len(head) - len(tail), 0)
+
     with log_path.open("w", encoding="utf-8") as log_file:
-        subprocess.run(cmd, check=True, stdout=log_file, stderr=subprocess.STDOUT)
+        log_file.write("# Compact command log\n")
+        log_file.write("# Full verbose logs are disabled by default for Issue #159 log-volume control.\n")
+        log_file.write("# Command: " + " ".join(str(part) for part in cmd) + "\n")
+        log_file.write(f"# Return code: {returncode}\n")
+        log_file.write(f"# Duration seconds: {duration_sec:.3f}\n")
+        log_file.write(f"# Captured output lines: {output_lines}\n")
+        log_file.write(f"# Captured output bytes: {output_bytes}\n")
+        log_file.write(f"# Head lines retained: {len(head)}\n")
+        log_file.write(f"# Tail lines retained: {len(tail)}\n")
+        log_file.write(f"# Omitted middle lines: {omitted_middle_lines}\n\n")
+        log_file.writelines(head)
+        if omitted_middle_lines:
+            log_file.write(f"\n# ... omitted {omitted_middle_lines} middle log lines ...\n\n")
+        if omitted_middle_lines or output_lines > len(head):
+            log_file.writelines(tail)
+
+    return CommandLogSummary(
+        command=cmd,
+        log_path=log_path,
+        log_mode="compact",
+        returncode=returncode,
+        duration_sec=duration_sec,
+        output_lines=output_lines,
+        output_bytes=output_bytes,
+        omitted_middle_lines=omitted_middle_lines,
+        log_size_bytes=log_path.stat().st_size,
+    )
+
+
+def _run_command(cmd: list[str], *, log_path: Path, verbose_logs: bool = False) -> CommandLogSummary:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    effective_log_path = log_path if verbose_logs else _compact_log_path(log_path)
+    logger.info("+ %s > %s", " ".join(cmd), effective_log_path)
+    started_at = time.perf_counter()
+
+    if verbose_logs:
+        with effective_log_path.open("w", encoding="utf-8") as log_file:
+            process = subprocess.run(cmd, stdout=log_file, stderr=subprocess.STDOUT)
+        duration_sec = time.perf_counter() - started_at
+        summary = CommandLogSummary(
+            command=cmd,
+            log_path=effective_log_path,
+            log_mode="verbose",
+            returncode=process.returncode,
+            duration_sec=duration_sec,
+            output_lines=-1,
+            output_bytes=-1,
+            omitted_middle_lines=0,
+            log_size_bytes=effective_log_path.stat().st_size,
+        )
+    else:
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+        )
+        summary = _write_compact_log(
+            effective_log_path,
+            cmd=cmd,
+            process=process,
+            started_at=started_at,
+        )
+
+    if summary.returncode != 0:
+        raise subprocess.CalledProcessError(summary.returncode, cmd)
+    return summary
+
+
+def _phase_summary(name: str, started_at: float, **extra: Any) -> dict[str, Any]:
+    return {"name": name, "duration_sec": time.perf_counter() - started_at, **extra}
+
+
+def _write_execution_summary(route_root: Path, summary: dict[str, Any]) -> Path:
+    path = route_root / "dense_route_execution_summary.json"
+    path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    return path
 
 
 def load_route_image_paths(
@@ -99,7 +240,8 @@ def regenerate_dense_candidates(
     exclude: Path,
     route_root: Path,
     expected_pages: int = DENSE_ROUTE_EXPECTED_PAGES,
-) -> Path:
+    verbose_logs: bool = False,
+) -> tuple[Path, dict[str, Any]]:
     """Regenerate the dense candidate/filter root inside this route run."""
     dense_root = route_root / "dense_candidate_reconstruction"
     raw_root = dense_root / "probe_candidates_from_inventory"
@@ -112,6 +254,9 @@ def regenerate_dense_candidates(
     if dense_root.exists():
         shutil.rmtree(dense_root)
     dense_root.mkdir(parents=True, exist_ok=True)
+
+    phase_started = time.perf_counter()
+    command_summaries: list[CommandLogSummary] = []
 
     gen_cmd = [
         sys.executable,
@@ -126,7 +271,9 @@ def regenerate_dense_candidates(
         str(generation_summary),
     ]
     _add_params(gen_cmd, GENERATION_PARAMS)
-    _run_command(gen_cmd, log_path=log_dir / "01_generate_probe_candidates.log")
+    command_summaries.append(
+        _run_command(gen_cmd, log_path=log_dir / "01_generate_probe_candidates.log", verbose_logs=verbose_logs)
+    )
 
     filter_cmd = [
         sys.executable,
@@ -145,7 +292,9 @@ def regenerate_dense_candidates(
         str(filter_summary),
     ]
     _add_params(filter_cmd, FILTER_PARAMS)
-    _run_command(filter_cmd, log_path=log_dir / "02_apply_candidate_filter.log")
+    command_summaries.append(
+        _run_command(filter_cmd, log_path=log_dir / "02_apply_candidate_filter.log", verbose_logs=verbose_logs)
+    )
 
     summary = json.loads(filter_summary.read_text())
     if summary.get("processed") != expected_pages or summary.get("errors") != 0:
@@ -154,7 +303,18 @@ def regenerate_dense_candidates(
             f"processed={summary.get('processed')} expected={expected_pages} "
             f"errors={summary.get('errors')}"
         )
-    return filtered_root
+    phase = _phase_summary(
+        "dense_candidate_reconstruction",
+        phase_started,
+        output_root=str(dense_root),
+        raw_root=str(raw_root),
+        filtered_root=str(filtered_root),
+        suggestions_root=str(suggestions_root),
+        generation_summary=str(generation_summary),
+        filter_summary=str(filter_summary),
+        command_logs=[command.to_json() for command in command_summaries],
+    )
+    return filtered_root, phase
 
 
 def regenerate_probe_rescue_candidates(
@@ -162,8 +322,9 @@ def regenerate_probe_rescue_candidates(
     image_paths: list[Path],
     filtered_root: Path,
     route_root: Path,
-) -> Path:
+) -> tuple[Path, dict[str, Any]]:
     """Regenerate probe-rescue candidates for the dense detector route."""
+    phase_started = time.perf_counter()
     probe_rescue_root = route_root / "dense_candidate_reconstruction" / "probe_rescue_candidates"
     shutil.rmtree(probe_rescue_root, ignore_errors=True)
     probe_rescue_root.mkdir(parents=True, exist_ok=True)
@@ -194,7 +355,14 @@ def regenerate_probe_rescue_candidates(
     expected_pages = len(image_paths)
     if processed != expected_pages:
         raise RuntimeError(f"Probe-rescue candidate reconstruction processed {processed}/{expected_pages} pages")
-    return probe_rescue_root
+    phase = _phase_summary(
+        "probe_rescue_candidate_reconstruction",
+        phase_started,
+        output_root=str(probe_rescue_root),
+        processed_pages=processed,
+        expected_pages=expected_pages,
+    )
+    return probe_rescue_root, phase
 
 
 def reconstruct_dense_full_pipeline_route(
@@ -203,26 +371,62 @@ def reconstruct_dense_full_pipeline_route(
     exclude: Path,
     route_root: Path,
     expected_pages: int = DENSE_ROUTE_EXPECTED_PAGES,
+    verbose_logs: bool = False,
 ) -> DenseRouteArtifacts:
     """Rebuild all dense full-pipeline detector inputs from current-run sources."""
+    started_at = time.perf_counter()
+    phases: list[dict[str, Any]] = []
+
+    phase_started = time.perf_counter()
     image_paths = load_route_image_paths(
         inventory=inventory,
         exclude=exclude,
         expected_pages=expected_pages,
     )
-    filtered_root = regenerate_dense_candidates(
+    phases.append(
+        _phase_summary(
+            "load_route_image_paths",
+            phase_started,
+            inventory=str(inventory),
+            exclude=str(exclude),
+            image_count=len(image_paths),
+        )
+    )
+
+    filtered_root, dense_phase = regenerate_dense_candidates(
         inventory=inventory,
         exclude=exclude,
         route_root=route_root,
         expected_pages=len(image_paths),
+        verbose_logs=verbose_logs,
     )
-    probe_rescue_root = regenerate_probe_rescue_candidates(
+    phases.append(dense_phase)
+
+    probe_rescue_root, probe_phase = regenerate_probe_rescue_candidates(
         image_paths=image_paths,
         filtered_root=filtered_root,
         route_root=route_root,
     )
+    phases.append(probe_phase)
+
+    execution_summary = {
+        "schema_version": "pipeline.detector_routes.dense_full_pipeline.execution_summary.v1",
+        "log_mode": "verbose" if verbose_logs else "compact",
+        "expected_pages": expected_pages,
+        "image_count": len(image_paths),
+        "total_duration_sec": time.perf_counter() - started_at,
+        "artifacts": {
+            "filtered_root": str(filtered_root),
+            "probe_rescue_root": str(probe_rescue_root),
+        },
+        "phases": phases,
+    }
+    summary_path = _write_execution_summary(route_root, execution_summary)
+    execution_summary["summary_path"] = str(summary_path)
+
     return DenseRouteArtifacts(
         image_paths=image_paths,
         filtered_root=filtered_root,
         probe_rescue_root=probe_rescue_root,
+        execution_summary=execution_summary,
     )

--- a/src/pipeline/detector_routes/dense_full_pipeline.py
+++ b/src/pipeline/detector_routes/dense_full_pipeline.py
@@ -241,7 +241,8 @@ def regenerate_dense_candidates(
     route_root: Path,
     expected_pages: int = DENSE_ROUTE_EXPECTED_PAGES,
     verbose_logs: bool = False,
-) -> tuple[Path, dict[str, Any]]:
+    phase_summaries: list[dict[str, Any]] | None = None,
+) -> Path:
     """Regenerate the dense candidate/filter root inside this route run."""
     dense_root = route_root / "dense_candidate_reconstruction"
     raw_root = dense_root / "probe_candidates_from_inventory"
@@ -303,18 +304,21 @@ def regenerate_dense_candidates(
             f"processed={summary.get('processed')} expected={expected_pages} "
             f"errors={summary.get('errors')}"
         )
-    phase = _phase_summary(
-        "dense_candidate_reconstruction",
-        phase_started,
-        output_root=str(dense_root),
-        raw_root=str(raw_root),
-        filtered_root=str(filtered_root),
-        suggestions_root=str(suggestions_root),
-        generation_summary=str(generation_summary),
-        filter_summary=str(filter_summary),
-        command_logs=[command.to_json() for command in command_summaries],
-    )
-    return filtered_root, phase
+    if phase_summaries is not None:
+        phase_summaries.append(
+            _phase_summary(
+                "dense_candidate_reconstruction",
+                phase_started,
+                output_root=str(dense_root),
+                raw_root=str(raw_root),
+                filtered_root=str(filtered_root),
+                suggestions_root=str(suggestions_root),
+                generation_summary=str(generation_summary),
+                filter_summary=str(filter_summary),
+                command_logs=[command.to_json() for command in command_summaries],
+            )
+        )
+    return filtered_root
 
 
 def regenerate_probe_rescue_candidates(
@@ -322,7 +326,8 @@ def regenerate_probe_rescue_candidates(
     image_paths: list[Path],
     filtered_root: Path,
     route_root: Path,
-) -> tuple[Path, dict[str, Any]]:
+    phase_summaries: list[dict[str, Any]] | None = None,
+) -> Path:
     """Regenerate probe-rescue candidates for the dense detector route."""
     phase_started = time.perf_counter()
     probe_rescue_root = route_root / "dense_candidate_reconstruction" / "probe_rescue_candidates"
@@ -355,14 +360,17 @@ def regenerate_probe_rescue_candidates(
     expected_pages = len(image_paths)
     if processed != expected_pages:
         raise RuntimeError(f"Probe-rescue candidate reconstruction processed {processed}/{expected_pages} pages")
-    phase = _phase_summary(
-        "probe_rescue_candidate_reconstruction",
-        phase_started,
-        output_root=str(probe_rescue_root),
-        processed_pages=processed,
-        expected_pages=expected_pages,
-    )
-    return probe_rescue_root, phase
+    if phase_summaries is not None:
+        phase_summaries.append(
+            _phase_summary(
+                "probe_rescue_candidate_reconstruction",
+                phase_started,
+                output_root=str(probe_rescue_root),
+                processed_pages=processed,
+                expected_pages=expected_pages,
+            )
+        )
+    return probe_rescue_root
 
 
 def reconstruct_dense_full_pipeline_route(
@@ -393,21 +401,20 @@ def reconstruct_dense_full_pipeline_route(
         )
     )
 
-    filtered_root, dense_phase = regenerate_dense_candidates(
+    filtered_root = regenerate_dense_candidates(
         inventory=inventory,
         exclude=exclude,
         route_root=route_root,
         expected_pages=len(image_paths),
         verbose_logs=verbose_logs,
+        phase_summaries=phases,
     )
-    phases.append(dense_phase)
-
-    probe_rescue_root, probe_phase = regenerate_probe_rescue_candidates(
+    probe_rescue_root = regenerate_probe_rescue_candidates(
         image_paths=image_paths,
         filtered_root=filtered_root,
         route_root=route_root,
+        phase_summaries=phases,
     )
-    phases.append(probe_phase)
 
     execution_summary = {
         "schema_version": "pipeline.detector_routes.dense_full_pipeline.execution_summary.v1",

--- a/tools/issue120/Makefile.stage_e.mk
+++ b/tools/issue120/Makefile.stage_e.mk
@@ -2,11 +2,12 @@ ISSUE120_STAGE_E_CONFIG ?= configs/issue120_stage_e_full_pipeline.yaml
 ISSUE120_STAGE_E_OUTPUT ?= logs/issue120_e2e_recovery
 ISSUE120_STAGE_E_MANIFEST ?= $(ISSUE120_STAGE_E_OUTPUT)/stage_e_full_pipeline/manifest.json
 ISSUE120_STAGE_E_EVAL_DIR ?= $(ISSUE120_STAGE_E_OUTPUT)/stage_e_full_pipeline/eval_detector
+ISSUE120_STAGE_E_EXTRA_ARGS ?=
 
 run-issue120-stage-e-full: ## Run the full 68-page pipeline inside sr_eval_gpu container
 	@echo "Running Full Stage E Pipeline inside sr_eval_gpu..."
 	@docker run --rm --gpus all -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_gpu \
-		/bin/sh -lc '/opt/venv_pipeline/bin/python tools/issue120/run_stage_e_full_pipeline.py --config $(ISSUE120_STAGE_E_CONFIG) --output-root $(ISSUE120_STAGE_E_OUTPUT); status=$$?; chmod -R a+rwX $(ISSUE120_STAGE_E_OUTPUT)/stage_e_full_pipeline 2>/dev/null || true; exit $$status'
+		/bin/sh -lc '/opt/venv_pipeline/bin/python tools/issue120/run_stage_e_full_pipeline.py --config $(ISSUE120_STAGE_E_CONFIG) --output-root $(ISSUE120_STAGE_E_OUTPUT) $(ISSUE120_STAGE_E_EXTRA_ARGS); status=$$?; chmod -R a+rwX $(ISSUE120_STAGE_E_OUTPUT)/stage_e_full_pipeline 2>/dev/null || true; exit $$status'
 
 eval-issue120-stage-e-full: ## Evaluate Stage E detector metrics from manifest
 	@echo "Evaluating Stage E Detector Metrics from manifest..."

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -25,6 +25,10 @@ def _linux_maxrss_bytes(maxrss: int) -> int:
     return maxrss * 1024
 
 
+def _cpu_seconds(usage: resource.struct_rusage) -> float:
+    return float(usage.ru_utime) + float(usage.ru_stime)
+
+
 def _read_gpu_sample() -> list[dict[str, Any]]:
     """Return a best-effort nvidia-smi sample. Empty when NVIDIA tooling is unavailable."""
     if shutil.which("nvidia-smi") is None:
@@ -62,6 +66,55 @@ def _read_gpu_sample() -> list[dict[str, Any]]:
     return samples
 
 
+def _summarize_console_log(path: Path) -> dict[str, Any]:
+    """Summarize captured stdout/stderr without loading the whole file into memory."""
+    summary: dict[str, Any] = {
+        "path": str(path),
+        "exists": path.exists(),
+        "size_bytes": path.stat().st_size if path.exists() else 0,
+        "line_count": 0,
+        "logger_counts": {},
+        "marker_counts": {},
+    }
+    if not path.exists():
+        return summary
+
+    logger_counts: dict[str, int] = {}
+    marker_counts = {
+        "homr": 0,
+        "real_esrgan": 0,
+        "measure_numbering": 0,
+        "progress_bar": 0,
+        "warning_or_error": 0,
+    }
+    with path.open("r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            summary["line_count"] += 1
+            lower = line.lower()
+            if "homr" in lower:
+                marker_counts["homr"] += 1
+            if "real-esrgan" in lower or "realesrgan" in lower or "real_esrgan" in lower:
+                marker_counts["real_esrgan"] += 1
+            if "measure_numbering" in lower:
+                marker_counts["measure_numbering"] += 1
+            if "|" in line and "%" in line:
+                marker_counts["progress_bar"] += 1
+            if "warning" in lower or "error" in lower or "traceback" in lower:
+                marker_counts["warning_or_error"] += 1
+
+            parts = line.split()
+            if len(parts) >= 4 and parts[2].startswith("[") and parts[2].endswith("]"):
+                logger_name = parts[3].rstrip(":")
+                logger_counts[logger_name] = logger_counts.get(logger_name, 0) + 1
+
+    summary["logger_counts"] = dict(sorted(logger_counts.items(), key=lambda item: item[1], reverse=True)[:20])
+    summary["marker_counts"] = marker_counts
+    summary_path = path.with_suffix(".summary.json")
+    summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    summary["summary_path"] = str(summary_path)
+    return summary
+
+
 class ResourceSampler:
     """Best-effort process/GPU resource sampler for long Stage E runs."""
 
@@ -77,10 +130,14 @@ class ResourceSampler:
         self._peak_psutil_children_rss_bytes = 0
         self._peak_gpu_memory_mb_by_uuid: dict[str, int] = {}
         self._peak_gpu_utilization_pct_by_uuid: dict[str, int] = {}
+        self._peak_process_tree_cpu_percent = 0.0
+        self._peak_rusage_cpu_percent = 0.0
         self._psutil_available: bool | None = None
         self._nvidia_smi_seen = False
         self._started_at: float | None = None
         self._finished_at: float | None = None
+        self._previous_sample_time: float | None = None
+        self._previous_rusage_cpu_sec: float | None = None
 
     def start(self) -> None:
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -99,7 +156,7 @@ class ResourceSampler:
         summary["summary_path"] = str(summary_path)
         return summary
 
-    def _sample_process_tree(self) -> dict[str, Any]:
+    def _sample_rusage(self, sample_time: float) -> dict[str, Any]:
         self_rusage = resource.getrusage(resource.RUSAGE_SELF)
         children_rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
         self_maxrss_bytes = _linux_maxrss_bytes(self_rusage.ru_maxrss)
@@ -107,11 +164,27 @@ class ResourceSampler:
         self._peak_self_maxrss_bytes = max(self._peak_self_maxrss_bytes, self_maxrss_bytes)
         self._peak_children_maxrss_bytes = max(self._peak_children_maxrss_bytes, children_maxrss_bytes)
 
-        sample: dict[str, Any] = {
+        total_cpu_sec = _cpu_seconds(self_rusage) + _cpu_seconds(children_rusage)
+        rusage_cpu_percent = None
+        if self._previous_sample_time is not None and self._previous_rusage_cpu_sec is not None:
+            elapsed = max(sample_time - self._previous_sample_time, 1e-9)
+            cpu_delta = max(total_cpu_sec - self._previous_rusage_cpu_sec, 0.0)
+            rusage_cpu_percent = (cpu_delta / elapsed) * 100.0
+            self._peak_rusage_cpu_percent = max(self._peak_rusage_cpu_percent, rusage_cpu_percent)
+        self._previous_sample_time = sample_time
+        self._previous_rusage_cpu_sec = total_cpu_sec
+
+        return {
             "self_maxrss_bytes": self_maxrss_bytes,
             "children_maxrss_bytes": children_maxrss_bytes,
-            "psutil_available": False,
+            "self_cpu_sec": _cpu_seconds(self_rusage),
+            "children_cpu_sec": _cpu_seconds(children_rusage),
+            "total_rusage_cpu_sec": total_cpu_sec,
+            "rusage_cpu_percent_since_previous_sample": rusage_cpu_percent,
         }
+
+    def _sample_process_tree(self, sample_time: float) -> dict[str, Any]:
+        sample: dict[str, Any] = {**self._sample_rusage(sample_time), "psutil_available": False}
 
         try:
             import psutil  # type: ignore[import-not-found]
@@ -129,28 +202,35 @@ class ResourceSampler:
 
         rss_bytes = 0
         children_rss_bytes = 0
-        cpu_percent = 0.0
         process_count = 0
+        process_cpu_times_sec = 0.0
         for idx, child in enumerate(processes):
             try:
                 memory = child.memory_info()
+                cpu_times = child.cpu_times()
                 rss_bytes += int(memory.rss)
                 if idx > 0:
                     children_rss_bytes += int(memory.rss)
-                cpu_percent += float(child.cpu_percent(interval=None))
+                process_cpu_times_sec += float(cpu_times.user) + float(cpu_times.system)
                 process_count += 1
             except psutil.Error:
                 continue
 
         self._peak_psutil_rss_bytes = max(self._peak_psutil_rss_bytes, rss_bytes)
         self._peak_psutil_children_rss_bytes = max(self._peak_psutil_children_rss_bytes, children_rss_bytes)
+        process_tree_cpu_percent = sample.get("rusage_cpu_percent_since_previous_sample")
+        if isinstance(process_tree_cpu_percent, (int, float)):
+            self._peak_process_tree_cpu_percent = max(
+                self._peak_process_tree_cpu_percent, float(process_tree_cpu_percent)
+            )
         sample.update(
             {
                 "psutil_available": True,
                 "process_tree_rss_bytes": rss_bytes,
                 "children_rss_bytes": children_rss_bytes,
                 "process_count": process_count,
-                "process_tree_cpu_percent": cpu_percent,
+                "process_tree_cpu_times_sec": process_cpu_times_sec,
+                "process_tree_cpu_percent_since_previous_sample": process_tree_cpu_percent,
             }
         )
         return sample
@@ -172,9 +252,10 @@ class ResourceSampler:
     def _run(self) -> None:
         with self.output_path.open("w", encoding="utf-8") as f:
             while not self._stop.is_set():
+                sample_time = time.perf_counter()
                 sample = {
-                    "timestamp_monotonic_sec": time.perf_counter(),
-                    "process": self._sample_process_tree(),
+                    "timestamp_monotonic_sec": sample_time,
+                    "process": self._sample_process_tree(sample_time),
                     "gpu": _read_gpu_sample(),
                 }
                 self._record_gpu_peaks(sample["gpu"])
@@ -189,7 +270,7 @@ class ResourceSampler:
             end = self._finished_at if self._finished_at is not None else time.perf_counter()
             duration_sec = end - self._started_at
         return {
-            "schema_version": "tools.issue120.stage_e_resource_summary.v1",
+            "schema_version": "tools.issue120.stage_e_resource_summary.v2",
             "samples_path": str(self.output_path),
             "sample_count": self._sample_count,
             "sample_interval_sec": self.interval_sec,
@@ -200,6 +281,8 @@ class ResourceSampler:
             "peak_children_maxrss_bytes": self._peak_children_maxrss_bytes,
             "peak_process_tree_rss_bytes": self._peak_psutil_rss_bytes,
             "peak_process_tree_children_rss_bytes": self._peak_psutil_children_rss_bytes,
+            "peak_rusage_cpu_percent": self._peak_rusage_cpu_percent,
+            "peak_process_tree_cpu_percent": self._peak_process_tree_cpu_percent,
             "peak_gpu_memory_mb_by_uuid": self._peak_gpu_memory_mb_by_uuid,
             "peak_gpu_utilization_pct_by_uuid": self._peak_gpu_utilization_pct_by_uuid,
         }
@@ -336,7 +419,7 @@ def main():
             resource_summary = resource_sampler.stop()
     pipeline_duration_sec = time.perf_counter() - pipeline_started_at
 
-    pipeline_console_log_size = pipeline_console_log.stat().st_size if pipeline_console_log.exists() else 0
+    pipeline_console_log_summary = _summarize_console_log(pipeline_console_log)
     run_summary_path = route_root / "stage_e_runtime_summary.json"
     run_summary = {
         "schema_version": "tools.issue120.stage_e_full_pipeline.runtime_summary.v1",
@@ -353,7 +436,8 @@ def main():
             "run_id": "stage_e_full_pipeline",
             "output_root": str(args.output_root),
             "stdout_stderr_log": str(pipeline_console_log),
-            "stdout_stderr_log_size_bytes": pipeline_console_log_size,
+            "stdout_stderr_log_size_bytes": pipeline_console_log_summary["size_bytes"],
+            "stdout_stderr_log_summary": pipeline_console_log_summary,
         },
         "resource_monitor": resource_summary,
     }

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -1,7 +1,9 @@
 import argparse
+import json
 import logging
 import shutil
 import sys
+import time
 from pathlib import Path
 
 from src.pipeline.core.config import load_yaml
@@ -18,6 +20,11 @@ def main():
     parser.add_argument("--inventory", type=Path, default="logs/issue36_prep/20260208_bench_inventory.json")
     parser.add_argument("--exclude", type=Path, default="logs/issue36_prep/excluded_pages_for_gt_prep.json")
     parser.add_argument("--output-root", type=Path, default="logs/issue120_e2e_recovery")
+    parser.add_argument(
+        "--dense-route-verbose-logs",
+        action="store_true",
+        help="Write full subprocess logs for dense-route reconstruction. Defaults to compact bounded logs.",
+    )
     args = parser.parse_args()
 
     if not args.inventory.exists():
@@ -33,19 +40,23 @@ def main():
         shutil.rmtree(route_root)
     route_root.mkdir(parents=True, exist_ok=True)
 
+    run_started_at = time.perf_counter()
     route_artifacts = reconstruct_dense_full_pipeline_route(
         inventory=args.inventory,
         exclude=args.exclude,
         route_root=route_root,
+        verbose_logs=args.dense_route_verbose_logs,
     )
 
     route_images_dir = route_root / "images"
     route_images_dir.mkdir(parents=True, exist_ok=True)
 
+    image_copy_started_at = time.perf_counter()
     logger.info(f"Copying {len(route_artifacts.image_paths)} images to {route_images_dir}...")
     for img_path in route_artifacts.image_paths:
         dest_path = route_images_dir / f"{img_path.parent.name}_{img_path.name}"
         shutil.copy2(img_path, dest_path)
+    image_copy_duration_sec = time.perf_counter() - image_copy_started_at
 
     config = load_yaml(args.config)
     if "inputs" not in config:
@@ -70,12 +81,33 @@ def main():
 
     logger.info(f"Starting pipeline using config: {temp_config_path}")
 
+    pipeline_started_at = time.perf_counter()
     run_pipeline(
         config_path=temp_config_path,
         run_id="stage_e_full_pipeline",
         output_root=args.output_root,
     )
+    pipeline_duration_sec = time.perf_counter() - pipeline_started_at
 
+    run_summary_path = route_root / "stage_e_runtime_summary.json"
+    run_summary = {
+        "schema_version": "tools.issue120.stage_e_full_pipeline.runtime_summary.v1",
+        "total_duration_sec": time.perf_counter() - run_started_at,
+        "dense_route_execution_summary": route_artifacts.execution_summary,
+        "image_copy": {
+            "duration_sec": image_copy_duration_sec,
+            "image_count": len(route_artifacts.image_paths),
+            "output_dir": str(route_images_dir),
+        },
+        "pipeline": {
+            "duration_sec": pipeline_duration_sec,
+            "config_path": str(temp_config_path),
+            "run_id": "stage_e_full_pipeline",
+            "output_root": str(args.output_root),
+        },
+    }
+    run_summary_path.write_text(json.dumps(run_summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    logger.info("Stage E runtime summary written to %s", run_summary_path)
     logger.info("Stage E full pipeline run completed.")
 
 

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -29,6 +29,12 @@ def _cpu_seconds(usage: resource.struct_rusage) -> float:
     return float(usage.ru_utime) + float(usage.ru_stime)
 
 
+def _load_optional_json(path: Path) -> Any | None:
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def _read_gpu_sample() -> list[dict[str, Any]]:
     """Return a best-effort nvidia-smi sample. Empty when NVIDIA tooling is unavailable."""
     if shutil.which("nvidia-smi") is None:
@@ -419,6 +425,8 @@ def main():
             resource_summary = resource_sampler.stop()
     pipeline_duration_sec = time.perf_counter() - pipeline_started_at
 
+    pipeline_phase_summary_path = route_root / "pipeline_phase_summary.json"
+    pipeline_phase_summary = _load_optional_json(pipeline_phase_summary_path)
     pipeline_console_log_summary = _summarize_console_log(pipeline_console_log)
     run_summary_path = route_root / "stage_e_runtime_summary.json"
     run_summary = {
@@ -435,6 +443,8 @@ def main():
             "config_path": str(temp_config_path),
             "run_id": "stage_e_full_pipeline",
             "output_root": str(args.output_root),
+            "phase_summary_path": str(pipeline_phase_summary_path),
+            "phase_summary": pipeline_phase_summary,
             "stdout_stderr_log": str(pipeline_console_log),
             "stdout_stderr_log_size_bytes": pipeline_console_log_summary["size_bytes"],
             "stdout_stderr_log_summary": pipeline_console_log_summary,

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -1,10 +1,16 @@
 import argparse
+import contextlib
 import json
 import logging
+import os
+import resource
 import shutil
+import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
+from typing import Any
 
 from src.pipeline.core.config import load_yaml
 from src.pipeline.detector_routes.dense_full_pipeline import reconstruct_dense_full_pipeline_route
@@ -12,6 +18,213 @@ from src.pipeline.main import run_pipeline
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
 logger = logging.getLogger(__name__)
+
+
+def _linux_maxrss_bytes(maxrss: int) -> int:
+    """Convert Linux resource.ru_maxrss KiB units to bytes."""
+    return maxrss * 1024
+
+
+def _read_gpu_sample() -> list[dict[str, Any]]:
+    """Return a best-effort nvidia-smi sample. Empty when NVIDIA tooling is unavailable."""
+    if shutil.which("nvidia-smi") is None:
+        return []
+    cmd = [
+        "nvidia-smi",
+        "--query-gpu=uuid,index,name,memory.used,utilization.gpu",
+        "--format=csv,noheader,nounits",
+    ]
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return []
+
+    samples: list[dict[str, Any]] = []
+    for line in result.stdout.splitlines():
+        parts = [part.strip() for part in line.split(",")]
+        if len(parts) != 5:
+            continue
+        uuid, index, name, memory_used_mb, utilization_gpu_pct = parts
+        try:
+            memory_used_mb_value = int(memory_used_mb)
+            utilization_gpu_pct_value = int(utilization_gpu_pct)
+        except ValueError:
+            continue
+        samples.append(
+            {
+                "uuid": uuid,
+                "index": int(index) if index.isdigit() else index,
+                "name": name,
+                "memory_used_mb": memory_used_mb_value,
+                "utilization_gpu_pct": utilization_gpu_pct_value,
+            }
+        )
+    return samples
+
+
+class ResourceSampler:
+    """Best-effort process/GPU resource sampler for long Stage E runs."""
+
+    def __init__(self, *, output_path: Path, interval_sec: float) -> None:
+        self.output_path = output_path
+        self.interval_sec = interval_sec
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._sample_count = 0
+        self._peak_self_maxrss_bytes = 0
+        self._peak_children_maxrss_bytes = 0
+        self._peak_psutil_rss_bytes = 0
+        self._peak_psutil_children_rss_bytes = 0
+        self._peak_gpu_memory_mb_by_uuid: dict[str, int] = {}
+        self._peak_gpu_utilization_pct_by_uuid: dict[str, int] = {}
+        self._psutil_available: bool | None = None
+        self._nvidia_smi_seen = False
+        self._started_at: float | None = None
+        self._finished_at: float | None = None
+
+    def start(self) -> None:
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        self._started_at = time.perf_counter()
+        self._thread = threading.Thread(target=self._run, name="stage-e-resource-sampler", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> dict[str, Any]:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=max(self.interval_sec * 2, 1.0))
+        self._finished_at = time.perf_counter()
+        summary = self.summary()
+        summary_path = self.output_path.with_suffix(".summary.json")
+        summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+        summary["summary_path"] = str(summary_path)
+        return summary
+
+    def _sample_process_tree(self) -> dict[str, Any]:
+        self_rusage = resource.getrusage(resource.RUSAGE_SELF)
+        children_rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
+        self_maxrss_bytes = _linux_maxrss_bytes(self_rusage.ru_maxrss)
+        children_maxrss_bytes = _linux_maxrss_bytes(children_rusage.ru_maxrss)
+        self._peak_self_maxrss_bytes = max(self._peak_self_maxrss_bytes, self_maxrss_bytes)
+        self._peak_children_maxrss_bytes = max(self._peak_children_maxrss_bytes, children_maxrss_bytes)
+
+        sample: dict[str, Any] = {
+            "self_maxrss_bytes": self_maxrss_bytes,
+            "children_maxrss_bytes": children_maxrss_bytes,
+            "psutil_available": False,
+        }
+
+        try:
+            import psutil  # type: ignore[import-not-found]
+        except Exception:
+            self._psutil_available = False
+            return sample
+
+        self._psutil_available = True
+        proc = psutil.Process(os.getpid())
+        processes = [proc]
+        try:
+            processes.extend(proc.children(recursive=True))
+        except psutil.Error:
+            pass
+
+        rss_bytes = 0
+        children_rss_bytes = 0
+        cpu_percent = 0.0
+        process_count = 0
+        for idx, child in enumerate(processes):
+            try:
+                memory = child.memory_info()
+                rss_bytes += int(memory.rss)
+                if idx > 0:
+                    children_rss_bytes += int(memory.rss)
+                cpu_percent += float(child.cpu_percent(interval=None))
+                process_count += 1
+            except psutil.Error:
+                continue
+
+        self._peak_psutil_rss_bytes = max(self._peak_psutil_rss_bytes, rss_bytes)
+        self._peak_psutil_children_rss_bytes = max(self._peak_psutil_children_rss_bytes, children_rss_bytes)
+        sample.update(
+            {
+                "psutil_available": True,
+                "process_tree_rss_bytes": rss_bytes,
+                "children_rss_bytes": children_rss_bytes,
+                "process_count": process_count,
+                "process_tree_cpu_percent": cpu_percent,
+            }
+        )
+        return sample
+
+    def _record_gpu_peaks(self, gpu_samples: list[dict[str, Any]]) -> None:
+        if gpu_samples:
+            self._nvidia_smi_seen = True
+        for sample in gpu_samples:
+            uuid = str(sample.get("uuid"))
+            memory = int(sample.get("memory_used_mb", 0))
+            utilization = int(sample.get("utilization_gpu_pct", 0))
+            self._peak_gpu_memory_mb_by_uuid[uuid] = max(
+                self._peak_gpu_memory_mb_by_uuid.get(uuid, 0), memory
+            )
+            self._peak_gpu_utilization_pct_by_uuid[uuid] = max(
+                self._peak_gpu_utilization_pct_by_uuid.get(uuid, 0), utilization
+            )
+
+    def _run(self) -> None:
+        with self.output_path.open("w", encoding="utf-8") as f:
+            while not self._stop.is_set():
+                sample = {
+                    "timestamp_monotonic_sec": time.perf_counter(),
+                    "process": self._sample_process_tree(),
+                    "gpu": _read_gpu_sample(),
+                }
+                self._record_gpu_peaks(sample["gpu"])
+                f.write(json.dumps(sample, ensure_ascii=False) + "\n")
+                f.flush()
+                self._sample_count += 1
+                self._stop.wait(self.interval_sec)
+
+    def summary(self) -> dict[str, Any]:
+        duration_sec = None
+        if self._started_at is not None:
+            end = self._finished_at if self._finished_at is not None else time.perf_counter()
+            duration_sec = end - self._started_at
+        return {
+            "schema_version": "tools.issue120.stage_e_resource_summary.v1",
+            "samples_path": str(self.output_path),
+            "sample_count": self._sample_count,
+            "sample_interval_sec": self.interval_sec,
+            "duration_sec": duration_sec,
+            "psutil_available": self._psutil_available,
+            "nvidia_smi_seen": self._nvidia_smi_seen,
+            "peak_self_maxrss_bytes": self._peak_self_maxrss_bytes,
+            "peak_children_maxrss_bytes": self._peak_children_maxrss_bytes,
+            "peak_process_tree_rss_bytes": self._peak_psutil_rss_bytes,
+            "peak_process_tree_children_rss_bytes": self._peak_psutil_children_rss_bytes,
+            "peak_gpu_memory_mb_by_uuid": self._peak_gpu_memory_mb_by_uuid,
+            "peak_gpu_utilization_pct_by_uuid": self._peak_gpu_utilization_pct_by_uuid,
+        }
+
+
+@contextlib.contextmanager
+def _redirect_stdout_stderr_to_file(path: Path):
+    """Redirect fd-level stdout/stderr so subprocess-heavy logs are kept in a file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sys.stdout.flush()
+    sys.stderr.flush()
+    original_stdout_fd = os.dup(1)
+    original_stderr_fd = os.dup(2)
+    with path.open("w", encoding="utf-8", buffering=1) as log_file:
+        os.dup2(log_file.fileno(), 1)
+        os.dup2(log_file.fileno(), 2)
+        try:
+            yield
+        finally:
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os.dup2(original_stdout_fd, 1)
+            os.dup2(original_stderr_fd, 2)
+            os.close(original_stdout_fd)
+            os.close(original_stderr_fd)
 
 
 def main():
@@ -24,6 +237,23 @@ def main():
         "--dense-route-verbose-logs",
         action="store_true",
         help="Write full subprocess logs for dense-route reconstruction. Defaults to compact bounded logs.",
+    )
+    parser.add_argument(
+        "--resource-sample-interval-sec",
+        type=float,
+        default=5.0,
+        help="Sampling interval for Stage E process/GPU resource usage.",
+    )
+    parser.add_argument(
+        "--no-resource-sampling",
+        action="store_true",
+        help="Disable Stage E process/GPU resource sampling.",
+    )
+    parser.add_argument(
+        "--pipeline-console-log",
+        type=Path,
+        default=None,
+        help="File for stdout/stderr emitted by full pipeline execution. Defaults under the Stage E run directory.",
     )
     args = parser.parse_args()
 
@@ -79,16 +309,34 @@ def main():
     with open(temp_config_path, "w") as f:
         yaml.dump(config, f, sort_keys=False)
 
+    pipeline_console_log = args.pipeline_console_log or route_root / "pipeline_stdout_stderr.log"
+    resource_sampler = None
+    resource_summary: dict[str, Any] | None = None
+    if not args.no_resource_sampling:
+        resource_sampler = ResourceSampler(
+            output_path=route_root / "stage_e_resource_samples.jsonl",
+            interval_sec=args.resource_sample_interval_sec,
+        )
+
     logger.info(f"Starting pipeline using config: {temp_config_path}")
+    logger.info("Pipeline stdout/stderr will be captured to %s", pipeline_console_log)
 
     pipeline_started_at = time.perf_counter()
-    run_pipeline(
-        config_path=temp_config_path,
-        run_id="stage_e_full_pipeline",
-        output_root=args.output_root,
-    )
+    try:
+        if resource_sampler is not None:
+            resource_sampler.start()
+        with _redirect_stdout_stderr_to_file(pipeline_console_log):
+            run_pipeline(
+                config_path=temp_config_path,
+                run_id="stage_e_full_pipeline",
+                output_root=args.output_root,
+            )
+    finally:
+        if resource_sampler is not None:
+            resource_summary = resource_sampler.stop()
     pipeline_duration_sec = time.perf_counter() - pipeline_started_at
 
+    pipeline_console_log_size = pipeline_console_log.stat().st_size if pipeline_console_log.exists() else 0
     run_summary_path = route_root / "stage_e_runtime_summary.json"
     run_summary = {
         "schema_version": "tools.issue120.stage_e_full_pipeline.runtime_summary.v1",
@@ -104,7 +352,10 @@ def main():
             "config_path": str(temp_config_path),
             "run_id": "stage_e_full_pipeline",
             "output_root": str(args.output_root),
+            "stdout_stderr_log": str(pipeline_console_log),
+            "stdout_stderr_log_size_bytes": pipeline_console_log_size,
         },
+        "resource_monitor": resource_summary,
     }
     run_summary_path.write_text(json.dumps(run_summary, indent=2, ensure_ascii=False), encoding="utf-8")
     logger.info("Stage E runtime summary written to %s", run_summary_path)

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -125,6 +125,8 @@ class ResourceSampler:
     """Best-effort process/GPU resource sampler for long Stage E runs."""
 
     def __init__(self, *, output_path: Path, interval_sec: float) -> None:
+        if interval_sec <= 0:
+            raise ValueError("Resource sample interval must be positive.")
         self.output_path = output_path
         self.interval_sec = interval_sec
         self._stop = threading.Event()
@@ -144,6 +146,8 @@ class ResourceSampler:
         self._finished_at: float | None = None
         self._previous_sample_time: float | None = None
         self._previous_rusage_cpu_sec: float | None = None
+        self._previous_process_tree_sample_time: float | None = None
+        self._previous_process_tree_cpu_sec: float | None = None
 
     def start(self) -> None:
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -209,7 +213,7 @@ class ResourceSampler:
         rss_bytes = 0
         children_rss_bytes = 0
         process_count = 0
-        process_cpu_times_sec = 0.0
+        process_tree_cpu_times_sec = 0.0
         for idx, child in enumerate(processes):
             try:
                 memory = child.memory_info()
@@ -217,25 +221,34 @@ class ResourceSampler:
                 rss_bytes += int(memory.rss)
                 if idx > 0:
                     children_rss_bytes += int(memory.rss)
-                process_cpu_times_sec += float(cpu_times.user) + float(cpu_times.system)
+                process_tree_cpu_times_sec += float(cpu_times.user) + float(cpu_times.system)
                 process_count += 1
             except psutil.Error:
                 continue
 
+        process_tree_cpu_percent = None
+        if (
+            self._previous_process_tree_sample_time is not None
+            and self._previous_process_tree_cpu_sec is not None
+        ):
+            elapsed = max(sample_time - self._previous_process_tree_sample_time, 1e-9)
+            cpu_delta = max(process_tree_cpu_times_sec - self._previous_process_tree_cpu_sec, 0.0)
+            process_tree_cpu_percent = (cpu_delta / elapsed) * 100.0
+            self._peak_process_tree_cpu_percent = max(
+                self._peak_process_tree_cpu_percent, process_tree_cpu_percent
+            )
+        self._previous_process_tree_sample_time = sample_time
+        self._previous_process_tree_cpu_sec = process_tree_cpu_times_sec
+
         self._peak_psutil_rss_bytes = max(self._peak_psutil_rss_bytes, rss_bytes)
         self._peak_psutil_children_rss_bytes = max(self._peak_psutil_children_rss_bytes, children_rss_bytes)
-        process_tree_cpu_percent = sample.get("rusage_cpu_percent_since_previous_sample")
-        if isinstance(process_tree_cpu_percent, (int, float)):
-            self._peak_process_tree_cpu_percent = max(
-                self._peak_process_tree_cpu_percent, float(process_tree_cpu_percent)
-            )
         sample.update(
             {
                 "psutil_available": True,
                 "process_tree_rss_bytes": rss_bytes,
                 "children_rss_bytes": children_rss_bytes,
                 "process_count": process_count,
-                "process_tree_cpu_times_sec": process_cpu_times_sec,
+                "process_tree_cpu_times_sec": process_tree_cpu_times_sec,
                 "process_tree_cpu_percent_since_previous_sample": process_tree_cpu_percent,
             }
         )
@@ -276,7 +289,7 @@ class ResourceSampler:
             end = self._finished_at if self._finished_at is not None else time.perf_counter()
             duration_sec = end - self._started_at
         return {
-            "schema_version": "tools.issue120.stage_e_resource_summary.v2",
+            "schema_version": "tools.issue120.stage_e_resource_summary.v3",
             "samples_path": str(self.output_path),
             "sample_count": self._sample_count,
             "sample_interval_sec": self.interval_sec,
@@ -352,6 +365,8 @@ def main():
     if not args.exclude.exists():
         logger.error(f"Exclude file not found: {args.exclude}")
         sys.exit(1)
+    if not args.no_resource_sampling and args.resource_sample_interval_sec <= 0:
+        parser.error("--resource-sample-interval-sec must be positive when resource sampling is enabled.")
 
     route_root = args.output_root / "stage_e_full_pipeline"
     if route_root.exists():


### PR DESCRIPTION
## Summary

Issue #159 のため、Stage E dense-route validation の runtime/resource/log observability を追加します。

- dense-route reconstruction の phase summary と compact subprocess logs を追加
- Stage E runtime summary を追加
- full-pipeline stdout/stderr capture と compact summary を追加
- CPU/RSS/GPU resource sampling を追加
- live process-tree CPU は psutil process-tree `cpu_times()` delta から算出
- non-positive `--resource-sample-interval-sec` を reject
- `make run-issue120-stage-e-full` から runner 追加引数を渡せる `ISSUE120_STAGE_E_EXTRA_ARGS` を追加
- docs に #159 の runtime/resource/log surface を追記

## Scope decisions

この PR は Stage E runner と dense route 周辺の観測基盤までを扱います。

- HOMR/SR 並列化実験は #163/#166 に切り出し
- logging taxonomy / default noisy-log policy は #162/#164 に切り出し
- MMR per-hit log level の ad hoc 変更は行わない
- 通常 pipeline 実行へ新しい phase timing artifact を常時追加しない
- pipeline 本体側の detector/HOMR subphase timing 実装はこの PR から外す

## Latest evidence

Review 対応後の再実行で detector contract は維持されています。

- expected_pages=68 / evaluated_pages=68
- TP=3580 / FP=0 / FN=1
- FN_det=0 / FN_cnn=1
- cnn_apply_nms=false
- target_met.detector=true

Runtime/resource/log findings from the latest Stage E run:

- total runtime: about 7611.6 sec
- dense route reconstruction: about 57.3 sec
- full pipeline: about 7554.2 sec
- resource samples: 6847 samples at 1.0 sec interval
- peak live process-tree CPU: about 803.1%
- peak GPU memory: 4776 MB
- peak GPU utilization: 100%
- captured stdout/stderr: 501411 bytes / 17184 lines

## Related

- #159
- #162 / #164
- #163 / #166
