### PR TITLE
docs: define repository branch policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,12 @@ This document provides a set of rules and guidelines for AI agents (such as Jule
     - `make format`: Auto-format code.
 - **Maintenance**: Developers and Agents should update the `Makefile` and this document when new standard workflows are introduced.
 
+### Branch Policy
+- **Read Branch Policy Before Issue Work**: Before starting issue work or opening a PR, read `docs/BRANCH_POLICY.md`.
+- **Default Base**: For normal feature, fix, refactor, documentation, and performance work, use `develop` as both the base branch and PR base unless the issue explicitly states that the work is release, hotfix, or promotion work.
+- **Stable Branch**: Treat `main` as the stable/release branch. Changes move from `develop` to `main` only through a dedicated promotion PR.
+- **Stale Issue Text**: Older issues may still say `Base branch: main` or `PR base: main`. Treat those fields as stale unless the issue is explicitly release, hotfix, or promotion-related; restate the effective branch decision when picking up such an issue.
+
 ### Design Principles (Barline Detection)
 - **Resolution Independence (Unit-based Scaling)**:
     - **Rule**: NEVER use fixed pixel (px) thresholds for distance or geometry calculations in the barline detection/numbering layers.
@@ -96,9 +102,10 @@ This document provides a set of rules and guidelines for AI agents (such as Jule
 - **Prompt/Log Documentation**: Standard prompts and conversation log format for multi-LLM collaboration must be maintained under `docs/ai-workflow/` (see the dedicated collaboration doc) and updated as the workflow evolves.
 - **Operational Entry Points (Must Read Order)**:
   1. `docs/ai-workflow/WORKFLOW.md` (general workflow baseline)
-  2. `docs/ai-workflow/CODEX_GEMINI_COLLAB.md` (Codex/Gemini collaboration protocol)
-  3. `docs/ai-workflow/LESSONS.md` (known anti-patterns and heuristics)
-  4. This `AGENTS.md` (repository-specific overrides, highest priority inside repo)
+  2. `docs/BRANCH_POLICY.md` (branch roles, default base/PR base, and promotion rules)
+  3. `docs/ai-workflow/CODEX_GEMINI_COLLAB.md` (Codex/Gemini collaboration protocol)
+  4. `docs/ai-workflow/LESSONS.md` (known anti-patterns and heuristics)
+  5. This `AGENTS.md` (repository-specific overrides, highest priority inside repo)
 - **Codex -> Gemini Call Stability Rule**:
   - For this repository, run Gemini consultations with network-enabled execution from the start (outside sandbox when required), not as a fallback after a known-failing step.
   - Prefer longer timeouts (e.g., `timeout 180s gemini -p "<prompt>"`) to allow deeper reasoning.
@@ -181,5 +188,5 @@ This document provides a set of rules and guidelines for AI agents (such as Jule
 ### Multi-LLM Role Specialization
 - **Gemini CLI**: Architect, Multi-modal Reasoner, Web Researcher. Leads planning and reasoning.
 - **Codex**: Implementation Specialist, Repository Navigator, Verification Lead. Leads focused edits and sandbox validation.
-- **Consultation Mandate**: Gemini should proactively consult Codex (via \`codex exec --sandbox read-only\`) for second opinions on complex logic, type safety, or architectural impacts.
+- **Consultation Mandate**: Gemini should proactively consult Codex (via `codex exec --sandbox read-only`) for second opinions on complex logic, type safety, or architectural impacts.
 - **Knowledge Synthesis Mandate**: Both agents must document newly discovered heuristics, anti-patterns, or visual failure modes in `docs/ai-workflow/LESSONS.md` to prevent regressions in future sessions.

--- a/docs/BRANCH_POLICY.md
+++ b/docs/BRANCH_POLICY.md
@@ -1,62 +1,40 @@
 # Branch Policy
 
-This document records the repository branch policy decided in Issue #168 after the Issue #120 canonical rebuild was merged through PR #167.
+This document defines the repository-wide branch policy. It is a standing rule for new work and release promotion; issue-specific decisions should be recorded in the relevant issue or PR by applying this policy, not by changing the general rule.
 
 ## Branch roles
 
 - `develop` is the active integration branch.
 - `main` is the stable/release branch.
-- Normal feature, fix, refactor, and performance work must branch from `develop` and open PRs against `develop`, unless the issue explicitly states otherwise.
-- `develop -> main` must be done through a dedicated promotion PR, not through incidental feature PRs.
+- Normal feature, fix, refactor, documentation, and performance work must branch from `develop` and open PRs against `develop`, unless the issue explicitly states that the work is a release, hotfix, or promotion task.
+- `develop -> main` must be done through a dedicated promotion PR. Do not promote changes to `main` through incidental feature PRs.
 
 ## Default issue and PR base
 
-For new work:
+For normal work, use:
 
 - Base branch: `develop`
 - PR base: `develop`
 
-Older open issues may still contain stale text such as `Base branch: main` or `PR base: main`. Treat those fields as stale unless the issue is explicitly about release/promotion work.
+If an older issue says `Base branch: main` or `PR base: main`, treat that text as stale unless the issue is explicitly about release, hotfix, or promotion work.
 
-When starting an older issue, restate the effective branch policy in the working session or issue comment:
+When starting older work, restate the effective branch decision in the working session or issue comment. Edit the issue body only when the stale branch text is likely to cause execution mistakes.
 
-- Base branch: `develop`
-- PR base: `develop`
+## Release, hotfix, and promotion exceptions
 
-Only edit the old issue body when the issue is actively picked up and the stale branch text is likely to cause confusion.
+Use `main` directly only when the issue explicitly requires release-branch work, hotfix work, or promotion management.
 
-## Promotion from `develop` to `main`
+For a `develop -> main` promotion PR, include at minimum:
 
-A promotion PR from `develop` to `main` is required for release/stable promotion.
+- the normal compile, lint, test, or smoke checks relevant to the included changes
+- the current canonical regression contract for the promoted scope
+- a clear statement of which metrics are promotion gates and which metrics are reported as informational only
+- links or references to the issues and PRs whose accepted changes are being promoted
 
-The promotion PR must include, at minimum:
+Do not embed one issue's acceptance numbers as a permanent repository-wide rule. If a specific issue defines a canonical contract, apply that contract in the promotion PR for the relevant promotion cycle and cite the issue or PR where the contract was accepted.
 
-- normal compile/test checks relevant to the included changes
-- confirmation of the Issue #120 canonical detector contract:
-  - `expected_pages=68`
-  - `evaluated_pages=68`
-  - `missing_pages=[]`
-  - `TP=3580`
-  - `FP=0`
-  - `FN=1`
-  - `FN_det=0`
-  - `FN_cnn=1`
-  - `cnn_apply_nms=false`
-  - `target_met.detector=true`
-- an explicit note that downstream measure-count metrics are not part of the Issue #120 detector acceptance gate unless a separate canonical comparator is introduced.
+## Documentation precedence
 
-## Issue #163 timing
+`AGENTS.md` is the operational entry point for AI agents. Agents must read this document through the `AGENTS.md` reference before starting issue work or opening PRs.
 
-Issue #163 should proceed from `develop` before the first `develop -> main` promotion.
-
-Issue #163 is a HOMR/SR route parallelization runtime experiment and must remain opt-in unless safety is proven. Its output may be one of:
-
-- no production behavior change
-- an opt-in mode only
-- a later default change only after detector contract and resource safety are confirmed
-
-Whether #163 is included in the first `main` promotion must be decided after #163 acceptance results are available.
-
-## Rationale
-
-Issue #120 has been completed and integrated into `develop`. The accepted post-merge detector contract is the current canonical detector baseline. `main` may not represent that latest validated state until a dedicated promotion PR is performed.
+If an issue body, older comment, or ad-hoc instruction conflicts with this document, use this document as the default policy and call out the conflict before modifying files or opening a PR.


### PR DESCRIPTION
## Summary

- Generalize `docs/BRANCH_POLICY.md` as a standing repository-wide rule instead of an Issue #168 / #120 / #163-specific record.
- Add `AGENTS.md` references so agents must read the branch policy before issue work or PR creation.
- Add `docs/BRANCH_POLICY.md` to the operational entry point list.

## Policy shape

- `develop` is the active integration branch for normal work.
- `main` is the stable/release branch.
- Normal feature/fix/refactor/documentation/performance work uses `develop` as both base branch and PR base.
- Release, hotfix, and promotion work may use `main` only when explicitly scoped that way.
- `develop -> main` promotion must be done through a dedicated promotion PR.
- Promotion PRs must cite the current canonical regression contract for the promoted scope, rather than embedding one issue's acceptance numbers as a permanent repository-wide rule.

## Consistency check

- `AGENTS.md` already requires issue bodies to include `Base branch` and `PR base`; this PR keeps that requirement and defines the default value through `docs/BRANCH_POLICY.md`.
- Repository code search did not find another standing document defining a conflicting `develop` / `main` branch policy.
- Older issue bodies may still mention `main`; this PR documents that such text is stale unless the issue is explicitly release, hotfix, or promotion-related.

## Notes

- This PR addresses #168.
- Earlier, `docs/BRANCH_POLICY.md` was accidentally created directly on `develop`. This PR limits further changes to the `docs/issue168-branch-policy` branch and corrects that document into a general, durable policy.

## Verification

Documentation-only change. Reviewed the updated branch policy and `AGENTS.md` references for consistency.