### PR TITLE
[codex] Add local automation validation workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,42 +6,56 @@ Repository-specific guidance for Codex, ChatGPT, Gemini, and human-assisted loca
 
 - Keep changes inside the assigned issue scope. If investigation discovers extra work, report it separately.
 - Prefer existing code, Makefile targets, scripts, configs, and documentation before adding new structure.
-- Do not commit directly to `main`. Use a topic branch and open a pull request linked to the issue.
+- Use a topic branch and open a pull request linked to the issue. Do not merge to `main` automatically.
 - Do not perform destructive git, filesystem, dataset, model, or log operations without explicit user approval.
+- Dependency, CI, Docker, build configuration, release policy, and branch policy changes must be explicitly in scope.
 - Do not add, remove, or upgrade dependencies unless the issue explicitly asks for it.
 
 ## Runtime Authority
 
 - The authoritative runtime is the user's local WSL/Linux environment with the project GPU setup.
 - Cloud containers, web-based GitHub edits, and static reviews are useful for inspection and lightweight checks, but they are not final validation for GPU, Docker, dataset, or full pipeline behavior.
-- Read `docs/ENVIRONMENTS.md`, `docs/MANIFEST.md`, and `docs/LOG_MANAGEMENT.md` before running environment-sensitive commands.
+- Read `docs/ENVIRONMENTS.md`, `docs/MANIFEST.md`, `docs/LOG_MANAGEMENT.md`, and `docs/dev/VALIDATION_POLICY.md` before running environment-sensitive commands.
 - The current primary pipeline environment is the unified Docker image/container `pdfscore_pipeline_gpu` with Python at `/opt/venv_pipeline/bin/python`.
 
 ## Validation Expectations
 
+- Follow `docs/dev/VALIDATION_POLICY.md`; it is the validation contract for both manual and automated local work.
 - Match validation weight to the change. Docs-only, comments-only, and small type or formatting updates do not require GPU smoke or full evaluation.
 - Use lightweight checks first, such as `make test-fast`, targeted pytest commands, `bash -n` for shell scripts, or static review of docs.
 - Use `make verify-pipeline-smoke` or `make verify-gpu-smoke` when a change can affect pipeline execution, Docker/GPU behavior, model loading, dataset access, or evaluation flow.
-- Full evaluation is opt-in. Do not require it for every PR; start it only when the user, issue workflow, or an explicit command such as `make verify-full-eval` authorizes the long run.
+- Full evaluation is not mandatory for every PR, but evaluation-sensitive changes require full evaluation artifacts or an explicit human skip/defer decision.
+- Local full evaluation may be started automatically when user, issue, or PR context has already authorized it.
 - If GPU, Docker, dataset, model, or sandbox constraints prevent validation, report the skipped command and exact reason rather than treating it as a successful check.
 
-## Evaluation and Data Rules
+## Scope and Sensitive Changes
 
-- Do not change filter logic, thresholds, seeds, dataset selection, metric calculation, or evaluation parameters casually.
+- Do not implement outside the assigned issue's goal, scope, or acceptance criteria. Suggest unrelated improvements in an issue or comment instead.
+- If the instruction is only investigation or root-cause analysis, present findings before making code changes.
+- Evaluation-sensitive areas include filter logic, thresholds, seeds, dataset selection, metric calculation, evaluation configs, baseline/canonical artifacts, detector routing, and generated evaluation outputs.
 - If those areas must change, keep the diff minimal and report the reason, affected files, reproduction command, target commit, and log path.
 - When updating experimental values or accuracy/performance claims, include the command, commit hash, environment, input config/data, and log path needed to reproduce the result.
 - Keep large datasets, caches, generated logs, and model artifacts out of git. Use symlinks or environment variables for local-only data.
+
+## Testing and Quality Gates
+
+- Add or update tests when behavior changes. For docs-only or workflow-only changes, document why code tests are not applicable.
+- Run the minimum validation required by `docs/dev/VALIDATION_POLICY.md` before opening or updating a PR.
+- For shell scripts and Makefile changes, run `bash -n` on touched scripts, `make help`, and the relevant script `--help` or metadata-only command.
+- For Python behavior changes, run targeted tests and `make test-fast` when applicable.
+- For pipeline, detector, Docker/GPU, model-loading, evaluation config, metric, threshold, seed, dataset-selection, baseline, or canonical-artifact changes, report whether GPU smoke and full evaluation were run, skipped, or deferred and why.
 
 ## Worktree and Local Data
 
 - Use a dedicated git worktree for issue work when the main clone may contain unrelated work.
 - Do not edit another issue's active working tree. Use the original clone only as a worktree manager when requested.
 - For local-only assets, prefer `scripts/setup_local_worktree_links.sh` and document the source paths through environment variables instead of committing machine-specific paths.
-- Keep worktree run outputs isolated under ignored log/artifact paths unless a small tracked doc update is intentionally part of the PR.
+- Keep worktree run outputs isolated under ignored log/artifact paths unless a tracked doc update is intentionally part of the PR.
 
 ## Automation Boundaries
 
 - Automation scripts are optional helpers. Normal manual development with `python`, `pytest`, `make`, Docker, and `gh` must continue to work without them.
+- Automation must not weaken validation. It should make required validation, skipped validation, scope-sensitive changes, and remaining risks more visible.
 - Local automation may run lightweight checks and, when authorized, GPU smoke or evaluation commands. It must not merge to `main`.
 - `gh auth login` is required before scripts can post PR comments. If `gh` is missing, unauthenticated, or network-restricted, scripts should skip posting with a clear reason.
 - Codex app sandbox approvals are controlled by the app session. Repository scripts can document required commands, but they cannot grant automatic sandbox-outside execution by themselves.
@@ -53,6 +67,7 @@ For non-trivial work, final reports and PR bodies should include:
 - Issue or PR link.
 - Summary of changed files and intent.
 - Commands run, pass/fail status, and log paths.
-- Validation skipped and why.
-- Any changes to filters, thresholds, seeds, dataset selection, metrics, or evaluation behavior.
+- Validation skipped, failed, or deferred and the exact reason.
+- Detected validation categories from `docs/dev/VALIDATION_POLICY.md`.
+- Any changes to filters, thresholds, seeds, dataset selection, metrics, evaluation configs, baseline/canonical artifacts, or evaluation behavior.
 - Remaining risks and any human decisions still required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,206 +1,58 @@
-# AGENTS.md - Rules for AI Agents
+# AGENTS.md
 
-## 1. Purpose
+Repository-specific guidance for Codex, ChatGPT, Gemini, and human-assisted local work.
 
-This document provides a set of rules and guidelines for AI agents (such as Jules, Gemini, or Codex) contributing to this repository. The goal is to ensure all contributions are safe, consistent, and aligned with the project's standards. This file serves as the "constitution" for AI agents.
+## Operating Principles
 
-## 2. Do's and Don'ts
+- Keep changes inside the assigned issue scope. If investigation discovers extra work, report it separately.
+- Prefer existing code, Makefile targets, scripts, configs, and documentation before adding new structure.
+- Do not commit directly to `main`. Use a topic branch and open a pull request linked to the issue.
+- Do not perform destructive git, filesystem, dataset, model, or log operations without explicit user approval.
+- Do not add, remove, or upgrade dependencies unless the issue explicitly asks for it.
 
-### Do
-- **Adhere to the Issue Scope**: Implement only what is explicitly defined in the `Goal`, `Scope`, and `Acceptance Criteria` of the assigned issue.
-- **Follow Established Patterns**: Use existing code patterns, conventions, and architectural styles.
-- **Write Necessary Tests**: Provide lightweight tests to validate your implementation, as specified in the issue.
-- **Use Standard Labels**: Apply labels as defined in `docs/ai-workflow/LABELS.md`.
-- **Update Documentation**: If your changes affect user-facing behavior or system design, indicate that the README or other documentation needs to be updated.
+## Runtime Authority
 
-### Don't
-- **Do Not Add Unauthorized Dependencies**: Do not add, remove, or update any dependencies unless explicitly instructed to do so in the issue.
-- **Do Not Implement Outside Scope**: Do not introduce any functionality or fixes that are not part of the assigned issue. If you identify a potential improvement, suggest it in a comment.
-- **Do Not Change Build Configurations**: Do not modify build scripts, CI/CD pipelines, or any other repository configuration files without explicit permission.
-- **Do Not Commit Directly**: All changes must be submitted through a pull request linked to the corresponding issue. *Exception: Direct commits are allowed only when explicitly instructed by the user in a local interactive session (e.g., using CLI agents).*
-- **Do Not Modify During Investigation**: If the instruction is only for investigation, analysis, or root cause identification, **Do Not** modify any files. Always present findings first and wait for approval before proceeding to implementation.
+- The authoritative runtime is the user's local WSL/Linux environment with the project GPU setup.
+- Cloud containers, web-based GitHub edits, and static reviews are useful for inspection and lightweight checks, but they are not final validation for GPU, Docker, dataset, or full pipeline behavior.
+- Read `docs/ENVIRONMENTS.md`, `docs/MANIFEST.md`, and `docs/LOG_MANAGEMENT.md` before running environment-sensitive commands.
+- The current primary pipeline environment is the unified Docker image/container `pdfscore_pipeline_gpu` with Python at `/opt/venv_pipeline/bin/python`.
 
-## 3. Change Policy
+## Validation Expectations
 
-- **Propose Before Execute**: For any non-trivial changes or when the fix approach is not explicitly defined, agents must provide a brief summary of the proposed modification and wait for confirmation before execution.
-- **Destructive Changes**: Any change that is destructive (e.g., removing a file, altering a public API) must be explicitly approved in the issue description or chat context.
-- **Large-Scale Refactoring**: Do not perform large-scale refactoring unless it is the primary goal of the assigned task. Small, localized refactoring for clarity is acceptable.
-- **Data Schema Changes**: Any modifications to data schemas or database structures require explicit sign-off from the project maintainers.
+- Match validation weight to the change. Docs-only, comments-only, and small type or formatting updates do not require GPU smoke or full evaluation.
+- Use lightweight checks first, such as `make test-fast`, targeted pytest commands, `bash -n` for shell scripts, or static review of docs.
+- Use `make verify-pipeline-smoke` or `make verify-gpu-smoke` when a change can affect pipeline execution, Docker/GPU behavior, model loading, dataset access, or evaluation flow.
+- Full evaluation is opt-in. Do not require it for every PR; start it only when the user, issue workflow, or an explicit command such as `make verify-full-eval` authorizes the long run.
+- If GPU, Docker, dataset, model, or sandbox constraints prevent validation, report the skipped command and exact reason rather than treating it as a successful check.
 
-## 4. Quality Bar
+## Evaluation and Data Rules
 
-- **Testing**: All code must be accompanied by tests sufficient to prove it meets the `Acceptance Criteria`. The "How to test" section of the issue should be followed precisely.
-- **Linting**: Code must adhere to the project's linting standards. Always run `make format` to fix style issues and `make lint` to verify compliance before submitting changes.
-- **Pre-Commit / Pre-PR Verification (Mandatory)**: Before creating a commit or opening a PR, you **MUST** run (1) behavior verification (actual execution path relevant to the change, e.g. smoke run), (2) tests/lint checks, and (3) `make check-consistency` (as a health check to identify major drift or missing mainline assets), then report the results. 
-  - **Handling Consistency Errors (`make check-consistency`)**:
-    - `[BROKEN]`: A file is listed in an inventory but doesn't exist on disk. **Causes CI failure (`exit code 2`)**. Action: Remove it from the inventory or restore the file. *Note: Empty directories must have a `.gitkeep` to be tracked by Git.*
-    - `[CRITICAL]`: A core asset defined in `MANIFEST.md` is missing. **Causes CI failure**. Action: Restore the asset or update the manifest if intentionally deleted.
-    - `[UNTRACKED] / [MISSING]`: Informational. A file exists but isn't in the relevant inventory. Action: Add to inventory if it's a core asset, otherwise ignore.
-    - `[STALE!!]`: Informational warning. A core document hasn't been updated in 30+ days. Action: If its contents are still valid, refresh its timestamp by adding a note (e.g., `> [!NOTE] Status (Mar 2026): This remains active...`).
-  - Regression workflow reference: `docs/REGRESSION_TEST_WORKFLOW.md`
-- **Maintenance of Tools Inventory**: When adding, renaming, or significantly modifying tools in the `tools/` root directory, you **MUST** update `docs/TOOLS_INVENTORY.md` to reflect the change, documenting the purpose, status (Active/Legacy), and context.
-- **Logging**: Add clear and concise logging for errors and important events. Avoid noisy or verbose logging.
-- **PR Descriptions**: Pull request descriptions must be filled out completely, following the `.github/pull_request_template.md`. The `Related Issue` field is mandatory.
+- Do not change filter logic, thresholds, seeds, dataset selection, metric calculation, or evaluation parameters casually.
+- If those areas must change, keep the diff minimal and report the reason, affected files, reproduction command, target commit, and log path.
+- When updating experimental values or accuracy/performance claims, include the command, commit hash, environment, input config/data, and log path needed to reproduce the result.
+- Keep large datasets, caches, generated logs, and model artifacts out of git. Use symlinks or environment variables for local-only data.
 
-## 5. Security
+## Worktree and Local Data
 
-- **No Secrets in Code**: Never hardcode secrets, API keys, or any other sensitive credentials in the source code. Use environment variables or a designated secrets management system.
-- **Data Transmission**: Do not transmit any user data or sensitive information to external services unless it is a documented and approved part of the functionality.
-- **Input Validation**: Always sanitize and validate user-provided input to prevent common vulnerabilities (e.g., XSS, SQL injection).
+- Use a dedicated git worktree for issue work when the main clone may contain unrelated work.
+- Do not edit another issue's active working tree. Use the original clone only as a worktree manager when requested.
+- For local-only assets, prefer `scripts/setup_local_worktree_links.sh` and document the source paths through environment variables instead of committing machine-specific paths.
+- Keep worktree run outputs isolated under ignored log/artifact paths unless a small tracked doc update is intentionally part of the PR.
 
-## 6. Project-Specific Overrides
+## Automation Boundaries
 
-### Environment & Execution
-- **Check Environments First**: Before executing any code, you **MUST** read `docs/ENVIRONMENTS.md`. This project uses a mix of Docker containers (`pdf_score_dev_gpu`, `homr_eval_gpu`, etc.) and host-based virtual environments (`.venv_pdf`, etc.). Identify the correct environment for your task.
-- **Docker Preference**: Prefer running tasks inside the appropriate Docker container whenever possible to ensure reproducibility.
-- **Host Execution**: Some tools (e.g., `gui_helper`) are designed to run on the host. Follow the specific instructions in `docs/ENVIRONMENTS.md`.
-- **Environment and Build Operations**:
-    - **Log Management**: When executing long-running or verbose operations like `docker build` or complex tests, **always redirect output to an artifact** (e.g., `> artifacts/build.log 2>&1`) and use targeted reads (`tail` or `cat` combined with line limits) to monitor progress. Do not dump full logs to the terminal, as it pollutes the context window.
-    - **Clean Checkout Resilience**: When writing Dockerfiles, do not rely on untracked local directories (e.g., `external/`) via `COPY` instructions. Instead, install these dependencies directly from source (e.g., `git+https://`) during the build step to ensure the image builds cleanly on fresh environments.
-    - **Volume Mount Shadowing**: Be aware that `docker run -v $(pwd):/workspace` will overwrite the container's `/workspace`. If the Docker build downloads model weights or artifacts, place them in a safe system directory (e.g., `/opt/weights/`) and reference them there to avoid them being masked by the host volume.
+- Automation scripts are optional helpers. Normal manual development with `python`, `pytest`, `make`, Docker, and `gh` must continue to work without them.
+- Local automation may run lightweight checks and, when authorized, GPU smoke or evaluation commands. It must not merge to `main`.
+- `gh auth login` is required before scripts can post PR comments. If `gh` is missing, unauthenticated, or network-restricted, scripts should skip posting with a clear reason.
+- Codex app sandbox approvals are controlled by the app session. Repository scripts can document required commands, but they cannot grant automatic sandbox-outside execution by themselves.
 
-### Standard Commands
-- **Makefile as Source of Truth**: The `Makefile` in the project root defines the standard commands for development tasks (linting, formatting, etc.).
-- **Usage**:
-    - `make help`: Check this first to see available commands and their descriptions.
-    - `make lint`: Run static analysis.
-    - `make format`: Auto-format code.
-    - `make check-consistency`: Check repository consistency (Asset existence, doc freshness, orphan files).
-- **Maintenance**: Developers and Agents should update the `Makefile` and this document when new standard workflows are introduced.
+## Completion Reports
 
-### Design Principles (Barline Detection)
-- **Resolution Independence (Unit-based Scaling)**:
-    - **Rule**: NEVER use fixed pixel (px) thresholds for distance or geometry calculations in the barline detection/numbering layers.
-    - **Implementation**: Always use `unit_size` (staff line spacing) as the base unit for dynamic scaling.
-    - **Current Targets**: Deduplication Threshold (`1.2 * unit_size`), Implicit Start Assumption (`4.0 * unit_size`).
-    - **Documentation**: See `docs/GT_PREPARATION_POLICY.md` and `docs/archive/BARLINE_MATCHER.md`.
-- **GT Labeling Consistency**:
-    - Use specific labels for complex barlines: `double_barline`, `end_barline`, `repeat`.
-    - Treat multi-line barlines as a **single logical event** with a single encompassing BBox.
+For non-trivial work, final reports and PR bodies should include:
 
-### Issue Template Conformance
-- **Template-First Issue Bodies**: When creating or updating GitHub Issues, always align the body with the corresponding file in `.github/ISSUE_TEMPLATE/`.
-- **Required Headers Must Exist**: For `Task` issues, do not omit `Base branch`, `Branch name`, `PR base`, `Goal`, and `Done` in the issue body.
-- **Project Extensions Are Additive**: Sections like `Background`, `Scope`, `Acceptance Criteria`, and `How to test` may be added, but only in addition to (not instead of) required template headers.
-
-### Logs & Artifacts
-- **Output Directory**: All experiment logs, metrics, and generated artifacts must be saved under the `logs/` directory. Use structured subdirectories (e.g., `logs/<category>/<task_id>_<timestamp>/`) as defined in `docs/LOG_MANAGEMENT.md`.
-- **Cleanup**: Do not leave temporary files in the project root. Use `make clean-artifacts` or follow the `clean-logs` rules in the management guide.
-- **Dataset Staging Rule (Required)**: For CNN retraining/evaluation jobs, place working datasets under `datasets/` in this repository before any bulk file operation. Do not run iterative copy/split generation directly on `/mnt/*`.
-- **Preflight Check (Required)**: Before launching long training/eval, explicitly verify: `pwd` is repo root, input dataset root is under `datasets/`, and output path is under `logs/`.
-
-### Dependencies
-- **Strict Control**: Do not modify `requirements.txt`, `pyproject.toml`, or `Dockerfile` unless the task explicitly requires dependency updates.
-- **No Unauthorized Libraries**: Do not install new libraries without user approval.
-
-### Dataset I/O Performance Rule (WSL)
-- **Avoid `/mnt/*` for bulk small-file operations**: On this repository, `/mnt/c` `/mnt/d` is mounted via `drvfs/9p`, and metadata-heavy operations (`copytree`, many `cp/stat`, split rebuilds) become extremely slow.
-- **Working copy first**: For dataset editing/augmentation/relabel tasks, first copy the working dataset under repository `datasets/` (ext4 side), then perform all file operations there.
-- **Use `/mnt/*` as source/archive only**: Treat `/mnt/*` dataset paths as read-mostly source or backup locations, not active scratch space for iterative retraining loops.
-
-### Multi-LLM Collaboration (Codex + gemini-cli)
-- **Flexible Primary/Secondary Roles**: In interactive local work, either `Codex` or `gemini-cli` may be the primary driver depending on the task. The primary agent leads planning and decision flow; the secondary agent provides alternative designs, debugging hypotheses, or review feedback.
-- **Implementation Delegation is Allowed**: A valid pattern is `gemini-cli` as primary for exploration/reasoning and `Codex` for focused repository edits and verification. The reverse (Codex primary, gemini-cli second opinion) is also valid.
-- **Optimize While Working**: Do not limit multi-LLM usage to pre-PR review only. Use it during implementation when helpful, and refine the collaboration pattern based on actual outcomes (speed, bug detection, usefulness).
-- **Single Writer Rule**: To avoid conflicts, keep one active file editor at a time in the session. Explicitly choose a single writer before file edits.
-- **Evidence-First Adoption**: Suggestions from either agent are hypotheses until validated by local code inspection, tests, or runtime behavior.
-- **Prompt/Log Documentation**: Standard prompts and conversation log format for multi-LLM collaboration must be maintained under `docs/ai-workflow/` (see the dedicated collaboration doc) and updated as the workflow evolves.
-- **Operational Entry Points (Must Read Order)**:
-  1. `docs/ai-workflow/WORKFLOW.md` (general workflow baseline)
-  2. `docs/ai-workflow/CODEX_GEMINI_COLLAB.md` (Codex/Gemini collaboration protocol)
-  3. `docs/ai-workflow/LESSONS.md` (known anti-patterns and heuristics)
-  4. This `AGENTS.md` (repository-specific overrides, highest priority inside repo)
-- **Codex -> Gemini Call Stability Rule**:
-  - For this repository, run Gemini consultations with network-enabled execution from the start (outside sandbox when required), not as a fallback after a known-failing step.
-  - Prefer longer timeouts (e.g., `timeout 180s gemini -p "<prompt>"`) to allow deeper reasoning.
-  - For long contexts, pass summarized inputs and split questions to reduce timeout risk.
-
-## 7. Skills
-
-- 共通スキルは `skills/` に配置する
-- リポジトリ固有の最適化は `.agents/skills` に追加する
-- 各スキルは「目的 / 入力 / 出力 / 手順 / 必要なコマンド」を明記する
-- **利用可能なスキル一覧**:
-    - `issue-creation`: Issue の下書き作成
-    - `problem-investigation`: バグ調査・原因究明
-    - `issue-solver`: Issue の自律解決（実装・検証）
-    - `pr-explanation`: PR の説明文生成
-    - `pr-review`: PR の自動レビュー
-    - `pr-refinement`: レビュー指摘の修正適用
-    - `status-check`: 現在の作業状況の要約
-    - `change-summary`: 最終的な変更内容の要約
-    - `doc-updater`: ドキュメントの自動更新
-    - `dependency-management`: 依存関係の管理
-    - `test-generation`: テストコードの生成・更新
-    - `long-horizon-task`: 長期タスクの状態管理
-    - `doc-consistency-manager`: リポジトリの整合性チェックと解決（Orphan, Broken, Stale の管理）
-    - `gemini-consultation`: Gemini への標準化された相談。`.agents/skills/gemini-consultation/SKILL.md` を利用し、相談時の入力整理・実行手順・記録方法を統一します。
-    - `codex-delegation`: Codex への実装・検証タスクの委譲。`.agents/skills/codex-delegation/SKILL.md` を利用し、コンテキスト消費を抑えつつ精緻な実装と検証を行います。
-
-詳細は `docs/ai-workflow/WORKFLOW.md` を参照。
-
-## 8. インタラクティブ・プロトコル（対話型セッション専用ルール）
-
-ユーザーとの直接対話において、AIエージェントは透明性と制御性を確保するため、以下の手順を「絶対」として遵守しなければならない。
-
-1. **確認の徹底 (Confirmation Loop)**:
-   - Git操作（merge/rebase等）、GitHub Issue作成、ファイルの新規作成・削除など、状態を変更する操作の前には、必ず実行計画を提示し、ユーザーの承諾を得ること。
-   - 「〜しますか？」という問いかけに対し、ユーザーが「OK」や「進めて」と回答した後にのみ実行する。
-
-2. **選択肢の提示 (Option Rule)**:
-   - 手法が複数存在する場合（例：rebaseかmergeか）、それぞれのメリット・デメリットを簡潔に示し、ユーザーに判断を仰ぐこと。独断で手法を選択してはならない。
-
-3. **実行直前のナレーション (Pre-Call Narration)**:
-   - 全てのツール呼び出し（コマンド実行等）の直前には、その意図を説明する1文を必ず添えること。ツールを「無言」で実行してはならない。
-
-4. **逸脱時の自己修正**:
-   - もし確認や説明をスキップしてしまったことに気づいた場合、即座に中断し、謝罪した上で不足していた説明を行い、改めて指示を仰ぐこと。
-
-5. **GitHubコメント投稿時の安全な書式**:
-   - `gh pr comment` / `gh issue comment` で本文にバッククォート（`` ` ``）や `$` を含む場合、シェル展開を避けるため `--body-file` + シングルクォートheredoc（`<<'EOF'`）を使うこと。
-   - `--body "..."` へ直接埋め込む方法は原則禁止（コマンド置換や変数展開で本文が破損するため）。
-
-6. **`gh` 実行時のネットワーク制限切り分け（Codex / sandbox）**:
-   - `gh issue comment` / `gh pr comment` / `gh api` 実行時に `error connecting to api.github.com` が出た場合、まず **認証エラーと断定しない**。Codex セッションの sandbox が `network_access=false` の場合、GitHub API に到達できず同様のエラーになる。
-   - `gh auth status` の結果だけで判断せず、必要に応じて `gh api user` や `gh issue view <number>` などの**読み取り系コマンド**で到達性と認証を切り分けること。
-   - GitHub への投稿/更新操作（コメント投稿、Issue/PR 更新など）は、sandbox 内で通信不可のときは **権限昇格（sandbox外）で実行**すること。
-   - エージェントは実行前に「ネットワーク制限回避のため権限昇格が必要」である旨を明示し、ユーザー承認を得ること。
-
-7. **GPU/CUDA 実行時の sandbox 切り分け（PyTorch）**:
-   - `nvidia-smi` は成功するのに `torch.cuda.is_available()==False` や `cudaGetDeviceCount` 系エラー（例: `Error 304: OS call failed or operation not supported on this OS`）が出る場合、まず **ドライバ/venv破損と断定しない**。Codex の sandbox 内実行では CUDA 初期化が失敗することがある。
-   - まず sandbox 内で `torch.__version__`, `torch.version.cuda`, `torch.cuda.is_available()`, `torch.cuda.device_count()` を確認し、OS 側は `nvidia-smi` で切り分けること。
-   - `nvidia-smi` 成功かつ PyTorch の CUDA build（例 `+cuXXX`）なのに sandbox 内だけ失敗する場合、**GPUを使う推論/学習コマンドは権限昇格（sandbox外）で実行**すること。
-   - 実行前に「sandbox 内では CUDA 初期化が失敗するため、GPU利用のため権限昇格が必要」である旨を明示し、ユーザー承認を得ること。
-
-8. **長時間学習ジョブの sandbox 制約（multiprocessing/semlock）**:
-   - `experiments/cnn_classifier/train.py` のような DataLoader 複数worker学習は、sandbox 内だと `PermissionError: [Errno 13]`（`multiprocessing` の `SemLock`）で失敗することがある。
-   - この系統の学習ジョブは、最初から **権限昇格（sandbox外）** で実行すること。
-   - 失敗後のリトライではなく、初回実行時点で「sandbox制約回避のため権限昇格が必要」と明示して承認を得ること。
-   - 学習データ更新は先に `datasets/`（repo ext4側）で完了させ、学習ジョブはその作業用datasetを参照して実行すること。
-
-9. **自律的ピアレビュー（セカンドオピニオンの取得）**:
-   - **トリガー条件**: 以下の「高難易度」状況を検知した場合、エージェントは自律的に別エージェント（Codex等）に意見を照会することを検討する。
-     - 性能のトレードオフ（Precision向上によりRecallが低下するなど）が発生し、最適解が見えない場合。
-     - `barline_matcher.py` や `measure_numbering` 等、システムのコアロジックに破壊的変更を加える場合。
-     - 2回以上の試行でバグが修正できない、または原因の仮説が3つ以上並立する場合。
-     - アーキテクチャの大きな分岐（A案・B案）において、客観的なリスク評価が必要な場合。
-   - **照会手順**:
-     - `codex exec --sandbox read-only` を使用し、現在の設計案に対する批判的レビューや代替案を求める。
-     - 照会前にユーザーに「Codexに意見を聞いてみます」と宣言する（詳細な承認を待たず、思考プロセスの一環として実行して良い）。
-   - **結果の統合**:
-     - 照会結果をそのまま採用せず、自分の案と比較した「統合案」をユーザーに提示し、なぜその結論に至ったかの論拠（Rational）を説明する。
-
-10. **現状把握のプロトコル (Onboarding Protocol for Agents)**:
-
-エージェントは、静的なドキュメントが最新のコードベースと乖離している可能性（Stale docs）を常に考慮し、以下の手順で現状を把握してください。
-
-1. **Check Freshness with Git**: 発見したドキュメント（特に `docs/` 内）が 1 ヶ月以上更新されていない場合、その内容を鵜呑みにせず、必ず `git log -n 1 -- <path>` で最終更新日時を確認してください。
-2. **Prioritize Git History**: 最新の作業状況と「真実」は `git log -n 10` および現在の branch 状況から判断してください。
-3. **Consult Asset Registry**: モデルパスや推奨設定ファイルについては、`README.md` や個別のドキュメントの記述よりも、`docs/MANIFEST.md` の情報を優先してください。
-4. **Update on Discovery**: **調査や実験の過程でドキュメントの記述と実態の乖離（パスの間違い、古い仕様など）を発見した場合は、直ちにそのドキュメントを最新の情報に更新してください。** 後のセッションで他のエージェントや人間が同じ罠に嵌まるのを防ぐことは、エージェントの重要な義務です。
-
-### Multi-LLM Role Specialization
-- **Gemini CLI**: Architect, Multi-modal Reasoner, Web Researcher. Leads planning and reasoning.
-- **Codex**: Implementation Specialist, Repository Navigator, Verification Lead. Leads focused edits and sandbox validation.
-- **Consultation Mandate**: Gemini should proactively consult Codex (via \`codex exec --sandbox read-only\`) for second opinions on complex logic, type safety, or architectural impacts.
-- **Knowledge Synthesis Mandate**: Both agents must document newly discovered heuristics, anti-patterns, or visual failure modes in `docs/ai-workflow/LESSONS.md` to prevent regressions in future sessions.
+- Issue or PR link.
+- Summary of changed files and intent.
+- Commands run, pass/fail status, and log paths.
+- Validation skipped and why.
+- Any changes to filters, thresholds, seeds, dataset selection, metrics, or evaluation behavior.
+- Remaining risks and any human decisions still required.

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,6 @@ test-fast: ## Run maintained lightweight tests without GPU or real-data requirem
 	@PYTHON_BIN="$(PYTHON)"; \
 	if [ -x .venv_pdf/bin/python ]; then \
 		PYTHON_BIN=.venv_pdf/bin/python; \
-	elif [ -x ../ws_PDFScoreBar/.venv_pdf/bin/python ]; then \
-		PYTHON_BIN=../ws_PDFScoreBar/.venv_pdf/bin/python; \
 	fi; \
 	echo "Running fast tests with $$PYTHON_BIN..."; \
 	PYTHONPATH=. "$$PYTHON_BIN" -m pytest $(FAST_TESTS) > artifacts/test_fast.log 2>&1 || \
@@ -137,5 +135,3 @@ api-explore: ## Extract API info from a Python file (usage: make api-explore FIL
 
 artifact-summary: ## Summarize all artifacts
 	./.agents/skills/artifact-clerk/run.sh
-
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: help lint format
+.PHONY: help lint format test-fast verify-pipeline-smoke verify-gpu-smoke verify-full-eval local-pr-validation setup-local-worktree-links
+
+PYTHON ?= python3
+FULL_EVAL_CONFIG ?= configs/evaluation2_e2e_verification_full.yaml
+FULL_EVAL_TIMEOUT ?= 8h
+FAST_TESTS ?= tests/test_numbering_overrides.py tests/test_pipeline_detection.py tests/test_probe_bands.py tests/test_subprocess_utils.py
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -57,6 +62,38 @@ run-smoke: ## Run smoke test inside pdfscore_pipeline_gpu container
 	@echo "Smoke test complete successfully. See artifacts/smoke_test.log"
 
 run-smoke-sr: run-smoke ## Alias for run-smoke (deprecated)
+
+test-fast: ## Run maintained lightweight tests without GPU or real-data requirements
+	@mkdir -p artifacts
+	@PYTHON_BIN="$(PYTHON)"; \
+	if [ -x .venv_pdf/bin/python ]; then \
+		PYTHON_BIN=.venv_pdf/bin/python; \
+	elif [ -x ../ws_PDFScoreBar/.venv_pdf/bin/python ]; then \
+		PYTHON_BIN=../ws_PDFScoreBar/.venv_pdf/bin/python; \
+	fi; \
+	echo "Running fast tests with $$PYTHON_BIN..."; \
+	PYTHONPATH=. "$$PYTHON_BIN" -m pytest $(FAST_TESTS) > artifacts/test_fast.log 2>&1 || \
+		(EXIT_CODE=$$?; echo "Fast tests failed with exit code $$EXIT_CODE. See artifacts/test_fast.log"; exit $$EXIT_CODE)
+	@echo "Fast tests passed. See artifacts/test_fast.log"
+
+verify-pipeline-smoke: run-smoke ## Run the configured pipeline smoke check
+
+verify-gpu-smoke: ## Run GPU smoke wrapper with metadata and timeout logging
+	@scripts/gpu_smoke.sh
+
+verify-full-eval: ## Run opt-in full evaluation entrypoint (long-running)
+	@scripts/gpu_smoke.sh --timeout "$(FULL_EVAL_TIMEOUT)" --command "make run-pipeline CONFIG=$(FULL_EVAL_CONFIG)"
+
+local-pr-validation: ## Run local PR validation (usage: make local-pr-validation PR=123 WITH_GPU=1 POST_COMMENT=1)
+	@scripts/local_pr_validation.sh $(if $(PR),--pr $(PR),) $(if $(WITH_GPU),--with-gpu,) $(if $(POST_COMMENT),--post-comment,)
+
+setup-local-worktree-links: ## Link local-only data into this worktree (usage: make setup-local-worktree-links LOCAL_DATA_ROOT=/path/to/assets)
+	@if [ -z "$(LOCAL_DATA_ROOT)" ]; then \
+		echo "Error: LOCAL_DATA_ROOT is required."; \
+		echo "Usage: make setup-local-worktree-links LOCAL_DATA_ROOT=/path/to/assets"; \
+		exit 1; \
+	fi
+	@scripts/setup_local_worktree_links.sh --source "$(LOCAL_DATA_ROOT)"
 
 run-pipeline: ## Run the pipeline with a custom config (usage: make run-pipeline CONFIG=path/to/config.yaml)
 	@if [ -z "$(CONFIG)" ]; then echo "Error: CONFIG is required. Usage: make run-pipeline CONFIG=path/to/config.yaml"; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PYTHON ?= python3
 FULL_EVAL_CONFIG ?= configs/evaluation2_e2e_verification_full.yaml
 FULL_EVAL_TIMEOUT ?= 8h
 FAST_TESTS ?= tests/test_numbering_overrides.py tests/test_pipeline_detection.py tests/test_probe_bands.py tests/test_subprocess_utils.py
+DOCKER_EXTRA_ARGS ?=
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -56,7 +57,7 @@ promote-log: ## Promote a log from worktree to permanent logs (usage: make promo
 run-smoke: ## Run smoke test inside pdfscore_pipeline_gpu container
 	@mkdir -p artifacts
 	@echo "Running smoke test..."
-	@docker run --rm --gpus all -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_gpu \
+	@docker run --rm --gpus all $(DOCKER_EXTRA_ARGS) -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_gpu \
 		/opt/venv_pipeline/bin/python src/pipeline/main.py --config "configs/smoke_test.yaml" > artifacts/smoke_test.log 2>&1 || \
 		(EXIT_CODE=$$?; echo "Smoke test failed with exit code $$EXIT_CODE. See artifacts/smoke_test.log"; exit $$EXIT_CODE)
 	@echo "Smoke test complete successfully. See artifacts/smoke_test.log"
@@ -82,8 +83,8 @@ verify-gpu-smoke: ## Run GPU smoke wrapper with metadata and timeout logging
 verify-full-eval: ## Run opt-in full evaluation entrypoint (long-running)
 	@scripts/gpu_smoke.sh --timeout "$(FULL_EVAL_TIMEOUT)" --command "make run-pipeline CONFIG=$(FULL_EVAL_CONFIG)"
 
-local-pr-validation: ## Run local PR validation (usage: make local-pr-validation PR=123 WITH_GPU=1 POST_COMMENT=1)
-	@scripts/local_pr_validation.sh $(if $(PR),--pr $(PR),) $(if $(WITH_GPU),--with-gpu,) $(if $(POST_COMMENT),--post-comment,)
+local-pr-validation: ## Run local PR validation (usage: make local-pr-validation PR=123 WITH_GPU=1 WITH_FULL_EVAL=1 POST_COMMENT=1)
+	@scripts/local_pr_validation.sh $(if $(PR),--pr $(PR),) $(if $(WITH_GPU),--with-gpu,) $(if $(WITH_FULL_EVAL),--with-full-eval,) $(if $(POST_COMMENT),--post-comment,)
 
 setup-local-worktree-links: ## Link local-only data into this worktree (usage: make setup-local-worktree-links LOCAL_DATA_ROOT=/path/to/assets)
 	@if [ -z "$(LOCAL_DATA_ROOT)" ]; then \
@@ -98,9 +99,9 @@ run-pipeline: ## Run the pipeline with a custom config (usage: make run-pipeline
 	@mkdir -p artifacts
 	@LOG_FILE="artifacts/$$(basename "$(CONFIG)" .yaml)_$$(date +%Y%m%d_%H%M%S).log"; \
 	echo "Running pipeline with $(CONFIG). Logging to $$LOG_FILE..."; \
-	docker run --rm --gpus all -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_gpu \
+	docker run --rm --gpus all $(DOCKER_EXTRA_ARGS) -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_gpu \
 		/opt/venv_pipeline/bin/python src/pipeline/main.py --config "$(CONFIG)" --skip-existing > "$$LOG_FILE" 2>&1 || \
-		(EXIT_CODE=$$?; echo "Pipeline failed with exit code $$EXIT_CODE. See $$LOG_FILE"; exit $$EXIT_CODE); \
+		{ EXIT_CODE=$$?; echo "Pipeline failed with exit code $$EXIT_CODE. See $$LOG_FILE"; exit $$EXIT_CODE; }; \
 	echo "Pipeline execution finished successfully. See $$LOG_FILE"
 repo-tree: ## Generate a repository directory overview
 	tree -L 3 -I "artifacts|logs|temp|datasets|.git|__pycache__|.venv*" > artifacts/repo_tree.txt

--- a/docs/dev/VALIDATION_POLICY.md
+++ b/docs/dev/VALIDATION_POLICY.md
@@ -1,0 +1,56 @@
+# Validation Policy
+
+This document defines how to choose validation for local automation and manual PR work. It is intentionally stricter than a simple optional helper script: automation should make skipped validation visible and should detect scope drift early.
+
+## Principles
+
+- Match validation to the changed behavior, not to the convenience of the runner.
+- Start with lightweight checks, then add smoke or full evaluation when the diff can affect runtime behavior.
+- A skipped check is acceptable only when the reason is recorded.
+- Evaluation-sensitive changes require either supporting evaluation artifacts or an explicit human decision to skip or defer evaluation.
+- Web or cloud-only edits are not final validation for GPU, Docker, dataset, or full pipeline behavior.
+
+## Change type matrix
+
+| Change type | Minimum validation | GPU smoke | Full evaluation | Required report fields |
+| --- | --- | --- | --- | --- |
+| Docs only | `git diff --check` and local review of touched links/commands | Not required | Not required | Changed docs, reason, skipped checks |
+| Shell scripts / Makefile | `bash -n` for touched scripts, `make help`, relevant `--help` or metadata-only command | Required if Docker/GPU/pipeline commands are invoked or changed | Not required unless evaluation flow changes | Command, exit code, log path |
+| Python utility | Targeted pytest or import/compile check plus `make test-fast` when applicable | Required if the utility loads models, data, Docker, GPU, or pipeline code | Usually not required | Test list and skipped checks |
+| Pipeline / detector / orchestrator | `make test-fast` plus targeted tests | Required | Required when behavior, candidate generation, routing, or outputs can change; otherwise explicitly skip with reason | Commit, config, input data, log path, risk |
+| Docker / GPU / model loading | Syntax/build check where practical plus `make verify-gpu-smoke` | Required | Required if runtime output or evaluation behavior may change | Environment, image/container, command, log path |
+| Evaluation config / metric / threshold / seed / dataset selection | Static diff review plus targeted command that reads the config | Required when local pipeline is affected | Required by default, or human-approved skip/defer | Config/data, metric impact, commit, log path |
+| Baseline / canonical target | Reproduction command plus comparison artifact | Required when pipeline is involved | Required by default | Baseline, new result, delta, contract/log path |
+| Dependency / build configuration | Relevant install/build/smoke check | Required if GPU/Docker/runtime stack is affected | Depends on affected behavior; document decision | Changed files, environment, failure mode risk |
+
+## Sensitive change detection
+
+Local validation scripts should inspect the diff and report categories. At minimum, the following paths or terms are sensitive:
+
+- `configs/`
+- `src/pipeline/`
+- `tools/issue120/`
+- `experiments/`
+- `Dockerfile`
+- `requirements.txt`
+- `pyproject.toml`
+- `Makefile`
+- files or diffs mentioning `threshold`, `seed`, `dataset`, `metric`, `evaluation`, `baseline`, `canonical`, `filter`, `detector`, `orchestrator`, or `route`
+
+A sensitive match does not always mean the PR is wrong. It means the report must explain which stronger checks were run or why they were skipped.
+
+## Local full evaluation authorization
+
+Full evaluation remains a human-controlled validation level, but once the user or issue explicitly authorizes it, local automation may start it without asking again for that PR. The resulting report must include the command, commit, config/data inputs, exit status, and log path.
+
+## PR summary expectations
+
+A non-trivial PR or validation comment should include:
+
+- Changed files and intent.
+- Detected change categories.
+- Required validation according to this policy.
+- Commands actually run.
+- Log paths and exit codes.
+- Required or recommended checks that were skipped, with exact reason.
+- Remaining risks and any human decisions still needed.

--- a/docs/dev/codex_local_automation.md
+++ b/docs/dev/codex_local_automation.md
@@ -1,0 +1,115 @@
+# Codex Local Automation
+
+Issue #173 adds optional local automation entrypoints for Codex app, Codex CLI, WSL, and GitHub CLI work. These helpers are intended to make local validation repeatable without replacing normal manual development.
+
+## Roles
+
+- Codex app: local implementation, file edits, lightweight command execution, PR and issue context.
+- WSL/Linux shell: authoritative local runtime for Docker, GPU, datasets, and long-running validation.
+- Codex CLI: optional focused review or fix loop through `codex exec`.
+- GitHub CLI: PR comments, review context collection, and authenticated GitHub operations.
+- GitHub/web ChatGPT/Codex Cloud: static review and small GitHub edits. Treat those results as non-final for GPU and pipeline behavior.
+- Human: final full evaluation decision, result interpretation, and merge to `main`.
+
+## Baseline Workflow
+
+1. Keep the existing main clone on its current work. If it is already serving another issue, do not checkout branches or edit files there.
+2. Fetch from the main clone, then create a dedicated issue worktree:
+
+   ```bash
+   cd /home/masaki_muramatsu/ws_PDFScoreBar
+   git fetch origin
+   git worktree add ../ws_PDFScoreBar_issue173 -b issue-173-codex-local-automation origin/main
+   cd ../ws_PDFScoreBar_issue173
+   ```
+
+3. If local-only assets are needed, link them into the worktree:
+
+   ```bash
+   make setup-local-worktree-links LOCAL_DATA_ROOT=/path/to/pdfscore-local-assets
+   ```
+
+4. Implement changes using the usual repository commands. The automation scripts are optional.
+5. Run the lightest relevant validation first:
+
+   ```bash
+   make test-fast
+   ```
+
+6. For pipeline or GPU-sensitive changes, run:
+
+   ```bash
+   make verify-gpu-smoke
+   ```
+
+7. If full evaluation should start early, use the explicit long-running entrypoint:
+
+   ```bash
+   make verify-full-eval
+   ```
+
+8. For PR validation and optional posting:
+
+   ```bash
+   scripts/local_pr_validation.sh --pr 123 --with-gpu --post-comment
+   ```
+
+## Local Actions for Codex App
+
+Useful commands to expose or run from Codex app:
+
+- `make test-fast`
+- `make verify-pipeline-smoke`
+- `make verify-gpu-smoke`
+- `make verify-full-eval`
+- `scripts/gpu_smoke.sh --metadata-only`
+- `scripts/local_pr_validation.sh --pr <number> --with-gpu --with-full-eval --post-comment`
+- `scripts/respond_to_pr_review.sh --pr <number>`
+- `scripts/setup_local_worktree_links.sh --source <path>`
+
+Codex app sandbox approvals are session-level behavior. The repository cannot grant automatic sandbox-outside execution for only one script. If GPU, Docker, `gh`, or network access requires approval, run the command with the app's normal approval flow and document the command and log path.
+
+## Validation Levels
+
+- Fast tests: `make test-fast`. Intended for ordinary code and docs-adjacent changes; it runs no-real-data unit tests and intentionally excludes the real-data integration test. In a worktree, it uses local `.venv_pdf` when present and falls back to the sibling manager clone's `.venv_pdf` if available.
+- Pipeline smoke: `make verify-pipeline-smoke`. Wraps the existing `make run-smoke`.
+- GPU smoke: `make verify-gpu-smoke`. Records branch, commit, Python version, GPU info, command, exit code, and log path under `logs/system/`.
+- Full evaluation: opt-in long run through `make verify-full-eval` or `scripts/local_pr_validation.sh --with-full-eval`. Start it early when the change clearly needs long evaluation, but do not make it a default PR requirement.
+
+## GitHub CLI Requirements
+
+Run once in the local environment:
+
+```bash
+gh auth login
+gh auth status
+```
+
+Scripts that post comments use `gh pr comment --body-file`. If `gh` is missing, unauthenticated, or blocked by network/sandbox limits, the scripts should leave a local summary and report the skipped posting reason.
+
+## Review Comment Loop
+
+Use the PR review entrypoint to collect context:
+
+```bash
+scripts/respond_to_pr_review.sh --pr <number>
+```
+
+This writes artifacts under `artifacts/`. A human or Codex app can read the artifact, apply only actionable requested fixes, run targeted validation, and post a summary. Use `--codex` only when `codex exec` is installed and the checkout is clean enough for review planning.
+
+## Web ChatGPT or GitHub Edits
+
+Web-based edits are acceptable for small docs or code changes, but they do not have local dataset, Docker, or GPU context. After web edits:
+
+1. Pull the branch into a dedicated local worktree.
+2. Inspect the diff locally.
+3. Run `make test-fast` or stronger validation as appropriate.
+4. Post local validation results to the PR.
+
+## Safety Boundaries
+
+- These scripts do not merge to `main`.
+- They do not require GPU smoke for docs-only or trivial changes.
+- They do not update evaluation values, thresholds, filters, seeds, dataset selection, or metrics.
+- They do not move or delete local datasets, logs, models, or caches.
+- Normal manual development remains valid without using these scripts.

--- a/docs/dev/codex_local_automation.md
+++ b/docs/dev/codex_local_automation.md
@@ -2,6 +2,8 @@
 
 Issue #173 adds optional local automation entrypoints for Codex app, Codex CLI, WSL, and GitHub CLI work. These helpers are intended to make local validation repeatable without replacing normal manual development.
 
+Validation strength is governed by `docs/dev/VALIDATION_POLICY.md`. The scripts are helpers for applying that policy; they are not a reason to weaken required checks or ignore scope boundaries.
+
 ## Roles
 
 - Codex app: local implementation, file edits, lightweight command execution, PR and issue context.
@@ -9,7 +11,7 @@ Issue #173 adds optional local automation entrypoints for Codex app, Codex CLI, 
 - Codex CLI: optional focused review or fix loop through `codex exec`.
 - GitHub CLI: PR comments, review context collection, and authenticated GitHub operations.
 - GitHub/web ChatGPT/Codex Cloud: static review and small GitHub edits. Treat those results as non-final for GPU and pipeline behavior.
-- Human: final full evaluation decision, result interpretation, and merge to `main`.
+- Human: final result interpretation and merge to `main`.
 
 ## Baseline Workflow
 
@@ -42,7 +44,7 @@ Issue #173 adds optional local automation entrypoints for Codex app, Codex CLI, 
    make verify-gpu-smoke
    ```
 
-7. If full evaluation should start early, use the explicit long-running entrypoint:
+7. For evaluation-sensitive changes, run full evaluation when authorized by the user, issue, or PR context:
 
    ```bash
    make verify-full-eval
@@ -51,7 +53,7 @@ Issue #173 adds optional local automation entrypoints for Codex app, Codex CLI, 
 8. For PR validation and optional posting:
 
    ```bash
-   scripts/local_pr_validation.sh --pr 123 --with-gpu --post-comment
+   scripts/local_pr_validation.sh --pr 123 --with-gpu --with-full-eval --post-comment
    ```
 
 ## Local Actions for Codex App
@@ -71,10 +73,10 @@ Codex app sandbox approvals are session-level behavior. The repository cannot gr
 
 ## Validation Levels
 
-- Fast tests: `make test-fast`. Intended for ordinary code and docs-adjacent changes; it runs no-real-data unit tests and intentionally excludes the real-data integration test. In a worktree, it uses local `.venv_pdf` when present and falls back to the sibling manager clone's `.venv_pdf` if available.
+- Fast tests: `make test-fast`. Intended for ordinary code and docs-adjacent changes; it runs no-real-data unit tests and intentionally excludes the real-data integration test. In a worktree, it uses local `.venv_pdf` when present; otherwise it uses `PYTHON`.
 - Pipeline smoke: `make verify-pipeline-smoke`. Wraps the existing `make run-smoke`.
 - GPU smoke: `make verify-gpu-smoke`. Records branch, commit, Python version, GPU info, command, exit code, and log path under `logs/system/`.
-- Full evaluation: opt-in long run through `make verify-full-eval` or `scripts/local_pr_validation.sh --with-full-eval`. Start it early when the change clearly needs long evaluation, but do not make it a default PR requirement.
+- Full evaluation: long run through `make verify-full-eval` or `scripts/local_pr_validation.sh --with-full-eval`. It is not a default PR requirement, but evaluation-sensitive changes need either results or an explicit human skip/defer decision under `docs/dev/VALIDATION_POLICY.md`.
 
 ## GitHub CLI Requirements
 
@@ -103,7 +105,7 @@ Web-based edits are acceptable for small docs or code changes, but they do not h
 
 1. Pull the branch into a dedicated local worktree.
 2. Inspect the diff locally.
-3. Run `make test-fast` or stronger validation as appropriate.
+3. Run `make test-fast` or stronger validation as required by `docs/dev/VALIDATION_POLICY.md`.
 4. Post local validation results to the PR.
 
 ## Safety Boundaries

--- a/docs/dev/local_worktree_data.md
+++ b/docs/dev/local_worktree_data.md
@@ -1,0 +1,50 @@
+# Local Worktree Data Links
+
+Worktrees often need local-only data that is intentionally not tracked by git: datasets, generated logs, model artifacts, and caches. Do not copy or commit those assets just to make a worktree run.
+
+## Recommended Layout
+
+Keep a local asset root outside issue worktrees, for example:
+
+```bash
+/home/masaki_muramatsu/pdfscore-local-assets/
+  datasets/
+  logs/models/
+  cache/
+```
+
+Then link selected items into the issue worktree:
+
+```bash
+cd /home/masaki_muramatsu/ws_PDFScoreBar_issue173
+scripts/setup_local_worktree_links.sh --source /home/masaki_muramatsu/pdfscore-local-assets
+```
+
+Equivalent Makefile wrapper:
+
+```bash
+make setup-local-worktree-links LOCAL_DATA_ROOT=/home/masaki_muramatsu/pdfscore-local-assets
+```
+
+## Custom Items
+
+By default the helper tries:
+
+- `datasets`
+- `logs/models`
+- `cache`
+
+Override the list with an environment variable:
+
+```bash
+PDFSCORE_LINK_ITEMS="datasets logs/models external/homr external/omr_dln cache" \
+  scripts/setup_local_worktree_links.sh --source /home/masaki_muramatsu/pdfscore-local-assets
+```
+
+The script skips missing sources and existing destinations. It does not overwrite, move, or delete files.
+
+## Notes
+
+- Avoid linking the whole `data/` directory unless you know it will not hide tracked placeholders and metadata.
+- Keep secrets, private tokens, paid API keys, and large generated files out of git.
+- Record machine-specific paths in local shell history, `.env` files ignored by git, or PR comments when relevant. Do not commit those paths into reusable configs.

--- a/docs/dev/local_worktree_data.md
+++ b/docs/dev/local_worktree_data.md
@@ -43,6 +43,19 @@ PDFSCORE_LINK_ITEMS="datasets logs/models external/homr external/omr_dln cache" 
 
 The script skips missing sources and existing destinations. It does not overwrite, move, or delete files.
 
+## Docker Mounts
+
+Symlinks that point outside the worktree are useful on the WSL host, but Docker only sees paths mounted into the container. If a pipeline command runs inside Docker and follows a symlink to `/home/...` or another host-only path, the target may be missing inside `/workspace`.
+
+For Docker-based validation, pass an explicit bind mount instead of relying on the symlink alone:
+
+```bash
+DOCKER_EXTRA_ARGS="-v /home/masaki_muramatsu/ws_PDFScoreBar/data/evaluation2/pdfs:/workspace/data/evaluation2/pdfs:ro" \
+  make run-pipeline CONFIG=configs/evaluation2_e2e_verification_full.yaml
+```
+
+Keep machine-specific paths in local commands or PR comments, not in committed configs.
+
 ## Notes
 
 - Avoid linking the whole `data/` directory unless you know it will not hide tracked placeholders and metadata.

--- a/scripts/gpu_smoke.sh
+++ b/scripts/gpu_smoke.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/gpu_smoke.sh [--timeout DURATION] [--command COMMAND] [--metadata-only]
+
+Runs a bounded GPU/pipeline smoke command and records reproducibility metadata.
+
+Environment:
+  GPU_SMOKE_TIMEOUT   Default timeout duration. Default: 45m
+  GPU_SMOKE_CMD       Command to run. Default: make run-smoke
+USAGE
+}
+
+timeout_duration="${GPU_SMOKE_TIMEOUT:-45m}"
+smoke_cmd="${GPU_SMOKE_CMD:-make run-smoke}"
+metadata_only=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --timeout)
+      timeout_duration="${2:?missing timeout value}"
+      shift 2
+      ;;
+    --command)
+      smoke_cmd="${2:?missing command value}"
+      shift 2
+      ;;
+    --metadata-only)
+      metadata_only=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+log_dir="logs/system/gpu_smoke_${timestamp}"
+log_file="${log_dir}/gpu_smoke.log"
+mkdir -p "$log_dir"
+
+branch="$(git branch --show-current 2>/dev/null || echo unknown)"
+commit="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+
+{
+  echo "timestamp_utc=${timestamp}"
+  echo "branch=${branch}"
+  echo "commit=${commit}"
+  echo "pwd=$(pwd)"
+  echo "python_version=$({ python3 --version || python --version; } 2>&1 | head -n 1)"
+  echo "timeout=${timeout_duration}"
+  echo "command=${smoke_cmd}"
+  echo
+  echo "git_status:"
+  git status --short || true
+  echo
+  echo "gpu_info:"
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi || true
+  else
+    echo "nvidia-smi not found"
+  fi
+  echo
+} | tee "$log_file"
+
+if [[ "$metadata_only" -eq 1 ]]; then
+  echo "metadata_only=1" | tee -a "$log_file"
+  echo "GPU smoke metadata written to $log_file"
+  exit 0
+fi
+
+if ! command -v timeout >/dev/null 2>&1; then
+  echo "timeout command is required for GPU smoke" | tee -a "$log_file" >&2
+  exit 2
+fi
+
+echo "Running GPU smoke command..." | tee -a "$log_file"
+set +e
+timeout "$timeout_duration" bash -lc "$smoke_cmd" >>"$log_file" 2>&1
+status=$?
+set -e
+
+{
+  echo
+  echo "exit_code=${status}"
+  echo "log_path=${log_file}"
+} | tee -a "$log_file"
+
+exit "$status"

--- a/scripts/gpu_smoke.sh
+++ b/scripts/gpu_smoke.sh
@@ -85,7 +85,7 @@ fi
 
 echo "Running GPU smoke command..." | tee -a "$log_file"
 set +e
-timeout "$timeout_duration" bash -lc "$smoke_cmd" >>"$log_file" 2>&1
+timeout "$timeout_duration" bash -c "$smoke_cmd" >>"$log_file" 2>&1
 status=$?
 set -e
 

--- a/scripts/local_pr_validation.sh
+++ b/scripts/local_pr_validation.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/local_pr_validation.sh [--pr NUMBER] [--with-gpu] [--with-full-eval] [--pull] [--post-comment]
+
+Runs lightweight local PR validation and writes a reproducible summary.
+GPU smoke is opt-in because it depends on local WSL/GPU/Docker availability.
+
+Environment:
+  FULL_EVAL_CMD       Default: make run-pipeline CONFIG=configs/evaluation2_e2e_verification_full.yaml
+  FULL_EVAL_TIMEOUT   Default: 8h
+USAGE
+}
+
+pr_number=""
+with_gpu=0
+pull_first=0
+post_comment=0
+with_full_eval=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      pr_number="${2:?missing PR number}"
+      shift 2
+      ;;
+    --with-gpu)
+      with_gpu=1
+      shift
+      ;;
+    --with-full-eval)
+      with_full_eval=1
+      shift
+      ;;
+    --pull)
+      pull_first=1
+      shift
+      ;;
+    --post-comment)
+      post_comment=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+log_dir="logs/system/local_pr_validation_${timestamp}"
+mkdir -p "$log_dir"
+
+branch="$(git branch --show-current 2>/dev/null || echo unknown)"
+commit="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+summary_file="${log_dir}/summary.md"
+test_log="${log_dir}/test_fast.log"
+gpu_log="${log_dir}/gpu_smoke_launcher.log"
+full_eval_log="${log_dir}/full_eval_launcher.log"
+
+overall_status=0
+test_status="not-run"
+gpu_status="not-run"
+full_eval_status="not-run"
+post_status="not-requested"
+
+run_and_capture() {
+  local label="$1"
+  local outfile="$2"
+  shift 2
+
+  echo "Running ${label}: $*" | tee -a "$outfile"
+  set +e
+  "$@" >>"$outfile" 2>&1
+  local status=$?
+  set -e
+  echo "${label}_exit_code=${status}" | tee -a "$outfile"
+  return "$status"
+}
+
+{
+  echo "timestamp_utc=${timestamp}"
+  echo "branch=${branch}"
+  echo "commit=${commit}"
+  echo "pwd=$(pwd)"
+  echo "python_version=$({ python3 --version || python --version; } 2>&1 | head -n 1)"
+  echo
+  echo "git_status:"
+  git status --short || true
+} >"${log_dir}/metadata.txt"
+
+if [[ "$pull_first" -eq 1 ]]; then
+  run_and_capture "git_pull_ff_only" "${log_dir}/git_pull.log" git pull --ff-only || overall_status=$?
+fi
+
+if run_and_capture "make_test_fast" "$test_log" make test-fast; then
+  test_status="passed"
+else
+  test_status="failed"
+  overall_status=1
+fi
+
+if [[ "$with_gpu" -eq 1 ]]; then
+  if run_and_capture "gpu_smoke" "$gpu_log" scripts/gpu_smoke.sh; then
+    gpu_status="passed"
+  else
+    gpu_status="failed"
+    overall_status=1
+  fi
+else
+  gpu_status="skipped: --with-gpu was not set"
+fi
+
+if [[ "$with_full_eval" -eq 1 ]]; then
+  full_eval_cmd="${FULL_EVAL_CMD:-make run-pipeline CONFIG=configs/evaluation2_e2e_verification_full.yaml}"
+  full_eval_timeout="${FULL_EVAL_TIMEOUT:-8h}"
+  if run_and_capture "full_eval" "$full_eval_log" scripts/gpu_smoke.sh --timeout "$full_eval_timeout" --command "$full_eval_cmd"; then
+    full_eval_status="passed"
+  else
+    full_eval_status="failed"
+    overall_status=1
+  fi
+else
+  full_eval_status="skipped: --with-full-eval was not set"
+fi
+
+cat >"$summary_file" <<EOF_SUMMARY
+## Local PR validation
+
+- Branch: \`${branch}\`
+- Commit: \`${commit}\`
+- Test fast: ${test_status}
+- GPU smoke: ${gpu_status}
+- Full evaluation: ${full_eval_status}
+- Log path: \`${log_dir}\`
+- Overall exit code: ${overall_status}
+
+### Commands
+
+- \`make test-fast\`
+$(if [[ "$with_gpu" -eq 1 ]]; then echo "- \`scripts/gpu_smoke.sh\`"; else echo "- GPU smoke not requested"; fi)
+$(if [[ "$with_full_eval" -eq 1 ]]; then echo "- \`scripts/gpu_smoke.sh --timeout \"${FULL_EVAL_TIMEOUT:-8h}\" --command \"${FULL_EVAL_CMD:-make run-pipeline CONFIG=configs/evaluation2_e2e_verification_full.yaml}\"\`"; else echo "- Full evaluation not requested"; fi)
+
+### Notes
+
+$(if [[ "$with_full_eval" -eq 1 ]]; then echo "- Full evaluation was explicitly requested for this run."; else echo "- Full evaluation was not run by this script. It remains opt-in."; fi)
+- If GitHub posting is requested, this script uses \`gh pr comment --body-file\`.
+EOF_SUMMARY
+
+if [[ "$post_comment" -eq 1 ]]; then
+  if [[ -z "$pr_number" ]]; then
+    post_status="skipped: --pr was not provided"
+  elif ! command -v gh >/dev/null 2>&1; then
+    post_status="skipped: gh not found"
+  elif ! gh auth status >/dev/null 2>&1; then
+    post_status="skipped: gh is not authenticated or cannot reach GitHub"
+  else
+    if gh pr comment "$pr_number" --body-file "$summary_file"; then
+      post_status="posted"
+    else
+      post_status="failed"
+      overall_status=1
+    fi
+  fi
+fi
+
+{
+  echo
+  echo "- GitHub post: ${post_status}"
+} >>"$summary_file"
+
+cat "$summary_file"
+exit "$overall_status"

--- a/scripts/local_pr_validation.sh
+++ b/scripts/local_pr_validation.sh
@@ -5,8 +5,9 @@ usage() {
   cat <<'USAGE'
 Usage: scripts/local_pr_validation.sh [--pr NUMBER] [--with-gpu] [--with-full-eval] [--pull] [--post-comment]
 
-Runs lightweight local PR validation and writes a reproducible summary.
-GPU smoke is opt-in because it depends on local WSL/GPU/Docker availability.
+Runs local PR validation and writes a reproducible summary.
+The script also inspects changed paths and reports validation that may be required
+by docs/dev/VALIDATION_POLICY.md.
 
 Environment:
   FULL_EVAL_CMD       Default: make run-pipeline CONFIG=configs/evaluation2_e2e_verification_full.yaml
@@ -64,6 +65,10 @@ summary_file="${log_dir}/summary.md"
 test_log="${log_dir}/test_fast.log"
 gpu_log="${log_dir}/gpu_smoke_launcher.log"
 full_eval_log="${log_dir}/full_eval_launcher.log"
+changed_files_file="${log_dir}/changed_files.txt"
+change_categories_file="${log_dir}/change_categories.txt"
+required_validation_file="${log_dir}/required_validation.txt"
+validation_warnings_file="${log_dir}/validation_warnings.txt"
 
 overall_status=0
 test_status="not-run"
@@ -84,6 +89,102 @@ run_and_capture() {
   echo "${label}_exit_code=${status}" | tee -a "$outfile"
   return "$status"
 }
+
+add_unique_line() {
+  local file="$1"
+  local line="$2"
+  grep -Fxq "$line" "$file" 2>/dev/null || echo "$line" >>"$file"
+}
+
+collect_changed_files() {
+  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    git diff --name-only origin/main...HEAD >"$changed_files_file" || true
+  else
+    git diff --name-only HEAD~1...HEAD >"$changed_files_file" || true
+  fi
+
+  if [[ ! -s "$changed_files_file" ]]; then
+    git status --short | awk '{print $2}' >"$changed_files_file" || true
+  fi
+}
+
+classify_changes() {
+  : >"$change_categories_file"
+  : >"$required_validation_file"
+  : >"$validation_warnings_file"
+
+  if [[ ! -s "$changed_files_file" ]]; then
+    add_unique_line "$change_categories_file" "no changed files detected"
+    add_unique_line "$required_validation_file" "manual inspection"
+    return
+  fi
+
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+
+    case "$path" in
+      *.md|docs/*)
+        add_unique_line "$change_categories_file" "docs"
+        add_unique_line "$required_validation_file" "git diff --check and local doc review"
+        ;;
+    esac
+
+    case "$path" in
+      Makefile|scripts/*.sh)
+        add_unique_line "$change_categories_file" "shell-or-makefile"
+        add_unique_line "$required_validation_file" "bash -n for touched scripts, make help, relevant help/dry-run"
+        ;;
+    esac
+
+    case "$path" in
+      *.py|tests/*.py|tools/*.py|tools/**/*.py)
+        add_unique_line "$change_categories_file" "python"
+        add_unique_line "$required_validation_file" "targeted pytest or import/compile check plus make test-fast when applicable"
+        ;;
+    esac
+
+    case "$path" in
+      src/pipeline/*|src/pipeline/**/*|tools/issue120/*|tools/issue120/**/*)
+        add_unique_line "$change_categories_file" "pipeline-sensitive"
+        add_unique_line "$required_validation_file" "make test-fast plus verify-pipeline-smoke or verify-gpu-smoke"
+        ;;
+    esac
+
+    case "$path" in
+      configs/*|configs/**/*|experiments/*|experiments/**/*)
+        add_unique_line "$change_categories_file" "evaluation-sensitive"
+        add_unique_line "$required_validation_file" "evaluation-sensitive review plus full evaluation or explicit human skip/defer decision"
+        ;;
+    esac
+
+    case "$path" in
+      Dockerfile|requirements.txt|pyproject.toml|uv.lock)
+        add_unique_line "$change_categories_file" "environment-sensitive"
+        add_unique_line "$required_validation_file" "environment/build validation plus GPU smoke when runtime stack is affected"
+        ;;
+    esac
+  done <"$changed_files_file"
+
+  if git diff --unified=0 origin/main...HEAD 2>/dev/null | grep -Eiq 'threshold|seed|dataset|metric|evaluation|baseline|canonical|filter|detector|orchestrator|route'; then
+    add_unique_line "$change_categories_file" "keyword-sensitive"
+    add_unique_line "$required_validation_file" "explain sensitive diff terms and run or explicitly skip stronger validation"
+  fi
+
+  if grep -Eq 'pipeline-sensitive|evaluation-sensitive|environment-sensitive|keyword-sensitive' "$change_categories_file"; then
+    if [[ "$with_gpu" -ne 1 ]]; then
+      add_unique_line "$validation_warnings_file" "GPU or pipeline-sensitive changes detected, but --with-gpu was not set."
+    fi
+  fi
+
+  if grep -Eq 'evaluation-sensitive|keyword-sensitive' "$change_categories_file"; then
+    if [[ "$with_full_eval" -ne 1 ]]; then
+      add_unique_line "$validation_warnings_file" "Evaluation-sensitive changes detected, but --with-full-eval was not set. Record human skip/defer decision if this is intentional."
+    fi
+  fi
+}
+
+collect_changed_files
+classify_changes
 
 {
   echo "timestamp_utc=${timestamp}"
@@ -142,6 +243,22 @@ cat >"$summary_file" <<EOF_SUMMARY
 - Log path: \`${log_dir}\`
 - Overall exit code: ${overall_status}
 
+### Detected change categories
+
+$(sed 's/^/- /' "$change_categories_file")
+
+### Required or recommended validation
+
+$(sed 's/^/- /' "$required_validation_file")
+
+### Validation warnings
+
+$(if [[ -s "$validation_warnings_file" ]]; then sed 's/^/- WARNING: /' "$validation_warnings_file"; else echo "- None"; fi)
+
+### Changed files
+
+$(if [[ -s "$changed_files_file" ]]; then sed 's/^/- /' "$changed_files_file"; else echo "- No changed files detected"; fi)
+
 ### Commands
 
 - \`make test-fast\`
@@ -150,7 +267,7 @@ $(if [[ "$with_full_eval" -eq 1 ]]; then echo "- \`scripts/gpu_smoke.sh --timeou
 
 ### Notes
 
-$(if [[ "$with_full_eval" -eq 1 ]]; then echo "- Full evaluation was explicitly requested for this run."; else echo "- Full evaluation was not run by this script. It remains opt-in."; fi)
+$(if [[ "$with_full_eval" -eq 1 ]]; then echo "- Full evaluation was explicitly requested for this run."; else echo "- Full evaluation was not run by this script. It remains governed by docs/dev/VALIDATION_POLICY.md."; fi)
 - If GitHub posting is requested, this script uses \`gh pr comment --body-file\`.
 EOF_SUMMARY
 

--- a/scripts/local_pr_validation.sh
+++ b/scripts/local_pr_validation.sh
@@ -96,16 +96,33 @@ add_unique_line() {
   grep -Fxq "$line" "$file" 2>/dev/null || echo "$line" >>"$file"
 }
 
-collect_changed_files() {
+determine_base_ref() {
   if git rev-parse --verify origin/main >/dev/null 2>&1; then
-    git diff --name-only origin/main...HEAD >"$changed_files_file" || true
+    echo "origin/main"
+  elif git rev-parse --verify main >/dev/null 2>&1; then
+    echo "main"
+  elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    echo "HEAD~1"
   else
-    git diff --name-only HEAD~1...HEAD >"$changed_files_file" || true
+    echo ""
+  fi
+}
+
+base_ref="$(determine_base_ref)"
+diff_args=()
+if [[ -n "$base_ref" ]]; then
+  diff_args=("${base_ref}...HEAD")
+fi
+
+collect_changed_files() {
+  if [[ "${#diff_args[@]}" -gt 0 ]]; then
+    git diff --name-only "${diff_args[@]}" >"$changed_files_file" || true
+  else
+    : >"$changed_files_file"
   fi
 
-  if [[ ! -s "$changed_files_file" ]]; then
-    git status --short | awk '{print $2}' >"$changed_files_file" || true
-  fi
+  git status --short | awk '{print $2}' >>"$changed_files_file" || true
+  sort -u "$changed_files_file" -o "$changed_files_file"
 }
 
 classify_changes() {
@@ -165,7 +182,7 @@ classify_changes() {
     esac
   done <"$changed_files_file"
 
-  if git diff --unified=0 origin/main...HEAD 2>/dev/null | grep -Eiq 'threshold|seed|dataset|metric|evaluation|baseline|canonical|filter|detector|orchestrator|route'; then
+  if [[ "${#diff_args[@]}" -gt 0 ]] && git diff --unified=0 "${diff_args[@]}" 2>/dev/null | grep -Eiq 'threshold|seed|dataset|metric|evaluation|baseline|canonical|filter|detector|orchestrator|route'; then
     add_unique_line "$change_categories_file" "keyword-sensitive"
     add_unique_line "$required_validation_file" "explain sensitive diff terms and run or explicitly skip stronger validation"
   fi
@@ -242,6 +259,7 @@ cat >"$summary_file" <<EOF_SUMMARY
 - Full evaluation: ${full_eval_status}
 - Log path: \`${log_dir}\`
 - Overall exit code: ${overall_status}
+- Diff base: \`${base_ref:-none}\`
 
 ### Detected change categories
 

--- a/scripts/respond_to_pr_review.sh
+++ b/scripts/respond_to_pr_review.sh
@@ -48,21 +48,15 @@ fi
 mkdir -p artifacts
 context_file="artifacts/pr_${pr_number}_review_context.json"
 plan_file="artifacts/pr_${pr_number}_review_response_plan.md"
-inline_comments_file="artifacts/pr_${pr_number}_review_inline_comments.json"
 
 gh pr view "$pr_number" \
   --json title,body,state,headRefName,baseRefName,comments,reviews \
   >"$context_file"
 
-if ! gh api "repos/{owner}/{repo}/pulls/${pr_number}/comments" >"$inline_comments_file"; then
-  echo "[]" >"$inline_comments_file"
-  echo "Could not fetch inline review comments; wrote empty list to $inline_comments_file" >&2
-fi
-
 cat >"$plan_file" <<EOF_PLAN
 # PR #${pr_number} review response entrypoint
 
-Collected context: \`${context_file}\` and \`${inline_comments_file}\`
+Collected context: \`${context_file}\`
 
 Suggested manual loop:
 
@@ -76,12 +70,11 @@ EOF_PLAN
 
 if [[ "$run_codex" -eq 1 ]]; then
   if ! command -v codex >/dev/null 2>&1; then
-    echo "codex CLI not found; wrote $plan_file only" >&2
-    exit 0
+    echo "codex CLI not found; skipping codex execution" >&2
+  else
+    codex exec --sandbox read-only "Review ${context_file} and list only actionable PR review items. Do not edit files." >>"$plan_file" 2>&1
   fi
-  codex exec --sandbox read-only "Review ${context_file} and list only actionable PR review items. Do not edit files." >>"$plan_file" 2>&1
 fi
 
 echo "Wrote $context_file"
-echo "Wrote $inline_comments_file"
 echo "Wrote $plan_file"

--- a/scripts/respond_to_pr_review.sh
+++ b/scripts/respond_to_pr_review.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/respond_to_pr_review.sh --pr NUMBER [--codex]
+
+Collects PR comments/reviews with gh and writes an artifact that can be passed to
+Codex CLI. With --codex, runs a read-only planning prompt through codex exec.
+USAGE
+}
+
+pr_number=""
+run_codex=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      pr_number="${2:?missing PR number}"
+      shift 2
+      ;;
+    --codex)
+      run_codex=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$pr_number" ]]; then
+  echo "--pr is required" >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required to collect PR review context" >&2
+  exit 2
+fi
+
+mkdir -p artifacts
+context_file="artifacts/pr_${pr_number}_review_context.json"
+plan_file="artifacts/pr_${pr_number}_review_response_plan.md"
+inline_comments_file="artifacts/pr_${pr_number}_review_inline_comments.json"
+
+gh pr view "$pr_number" \
+  --json title,body,state,headRefName,baseRefName,comments,reviews \
+  >"$context_file"
+
+if ! gh api "repos/{owner}/{repo}/pulls/${pr_number}/comments" >"$inline_comments_file"; then
+  echo "[]" >"$inline_comments_file"
+  echo "Could not fetch inline review comments; wrote empty list to $inline_comments_file" >&2
+fi
+
+cat >"$plan_file" <<EOF_PLAN
+# PR #${pr_number} review response entrypoint
+
+Collected context: \`${context_file}\` and \`${inline_comments_file}\`
+
+Suggested manual loop:
+
+1. Read unresolved or actionable comments from \`${context_file}\`.
+2. Implement only those requested changes.
+3. Run \`make test-fast\` and any targeted smoke command required by the diff.
+4. Post a PR comment with changed files, commands, log paths, skipped validation, and remaining risks.
+
+Use \`codex exec\` only when the local checkout is clean enough to avoid unrelated edits.
+EOF_PLAN
+
+if [[ "$run_codex" -eq 1 ]]; then
+  if ! command -v codex >/dev/null 2>&1; then
+    echo "codex CLI not found; wrote $plan_file only" >&2
+    exit 0
+  fi
+  codex exec --sandbox read-only "Review ${context_file} and list only actionable PR review items. Do not edit files." >>"$plan_file" 2>&1
+fi
+
+echo "Wrote $context_file"
+echo "Wrote $inline_comments_file"
+echo "Wrote $plan_file"

--- a/scripts/setup_local_worktree_links.sh
+++ b/scripts/setup_local_worktree_links.sh
@@ -49,6 +49,8 @@ if [[ ! -d "$source_root" ]]; then
   exit 2
 fi
 
+source_root="$(cd "$source_root" && pwd -P)"
+
 echo "source_root=$source_root"
 echo "items=$items"
 

--- a/scripts/setup_local_worktree_links.sh
+++ b/scripts/setup_local_worktree_links.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/setup_local_worktree_links.sh --source PATH [--items "datasets logs/models cache"]
+
+Creates symlinks from this worktree to local-only assets without moving or deleting data.
+
+Environment:
+  PDFSCORE_LOCAL_DATA_ROOT  Source root if --source is omitted.
+  PDFSCORE_LINK_ITEMS       Space-separated items to link.
+                            Default: datasets logs/models cache
+USAGE
+}
+
+source_root="${PDFSCORE_LOCAL_DATA_ROOT:-}"
+items="${PDFSCORE_LINK_ITEMS:-datasets logs/models cache}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source)
+      source_root="${2:?missing source path}"
+      shift 2
+      ;;
+    --items)
+      items="${2:?missing items list}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$source_root" ]]; then
+  echo "Source root is required. Use --source or PDFSCORE_LOCAL_DATA_ROOT." >&2
+  exit 2
+fi
+
+if [[ ! -d "$source_root" ]]; then
+  echo "Source root does not exist: $source_root" >&2
+  exit 2
+fi
+
+echo "source_root=$source_root"
+echo "items=$items"
+
+for item in $items; do
+  src="${source_root%/}/$item"
+  dest="$item"
+
+  if [[ ! -e "$src" ]]; then
+    echo "skip: source missing: $src"
+    continue
+  fi
+
+  if [[ -L "$dest" ]]; then
+    current="$(readlink "$dest")"
+    if [[ "$current" == "$src" ]]; then
+      echo "ok: $dest already links to $src"
+      continue
+    fi
+    echo "skip: $dest is already a symlink to $current"
+    continue
+  fi
+
+  if [[ -e "$dest" ]]; then
+    echo "skip: destination exists and will not be replaced: $dest"
+    continue
+  fi
+
+  mkdir -p "$(dirname "$dest")"
+  ln -s "$src" "$dest"
+  echo "linked: $dest -> $src"
+done


### PR DESCRIPTION
## Related Issue

- Closes #173
- Issue: https://github.com/M763468/PDFScoreBar/issues/173

## Summary

- Replaced the oversized/stale `AGENTS.md` with a shorter operational guide for local WSL/GPU authority, validation scope, evaluation data changes, worktrees, and automation boundaries.
- Added staged Makefile entrypoints: `test-fast`, `verify-pipeline-smoke`, `verify-gpu-smoke`, `verify-full-eval`, `local-pr-validation`, and `setup-local-worktree-links`.
- Added local automation scripts for GPU smoke logging, PR validation/comment summaries, local worktree data symlinks, and PR review-response context collection.
- Added docs for Codex app / WSL / Codex CLI / GitHub CLI workflow and local worktree data links.

## Automation Loop

1. Create a dedicated WSL worktree from the existing local clone.
2. Implement and run `make test-fast` first.
3. Run `make verify-gpu-smoke` for GPU/pipeline-sensitive changes.
4. Start long evaluation explicitly with `make verify-full-eval` or `scripts/local_pr_validation.sh --with-full-eval` when the issue/user authorizes it.
5. Use `scripts/local_pr_validation.sh --pr <number> --post-comment` to record branch, commit, commands, log path, and skipped validation.
6. Use `scripts/respond_to_pr_review.sh --pr <number>` to collect PR comments/reviews for a focused Codex CLI or manual response loop.

## Normal Development Impact

The new scripts are optional helpers. Existing direct `python`, `pytest`, `make`, Docker, and `gh` workflows remain usable. Docs-only and small code changes do not require GPU smoke or full evaluation by default.

## GPU Smoke, Full Eval, and Sandbox Handling

- `scripts/gpu_smoke.sh` records timestamp, branch, commit, Python version, GPU info, command, exit code, and log path under `logs/system/`.
- GPU smoke uses `timeout` to avoid unbounded execution.
- Full evaluation is opt-in through `make verify-full-eval` or `--with-full-eval`; it is not a default PR requirement.
- Repository scripts document required commands but cannot grant Codex app sandbox-outside auto-approval. Sandbox/network/GPU approvals still depend on the app session.

## Worktree Symlink Handling

- `scripts/setup_local_worktree_links.sh` links local-only assets from an environment-specific source root.
- Defaults cover `datasets`, `logs/models`, and `cache`; `PDFSCORE_LINK_ITEMS` can add paths such as `data/evaluation2/pdfs` when needed.
- The helper skips missing sources and existing destinations, and does not move/delete local data.
- No secrets, datasets, model artifacts, caches, or generated logs are added to git.

## WSL Worktree Note

All implementation, validation, commit, and push work for this PR was done in the dedicated WSL worktree:

- `/home/masaki_muramatsu/ws_PDFScoreBar_issue173`

The existing clone was used only as the worktree manager/local environment source and remained on its original branch:

- `/home/masaki_muramatsu/ws_PDFScoreBar`

## Web ChatGPT / GitHub Editing

The docs include a safe flow for web-based GitHub edits: pull the branch into a dedicated local worktree, inspect the diff locally, run the relevant local checks, and post validation results before relying on the change.

## Validation

- `bash -n scripts/gpu_smoke.sh scripts/local_pr_validation.sh scripts/respond_to_pr_review.sh scripts/setup_local_worktree_links.sh` - passed.
- `make help` - passed; confirmed new targets are discoverable.
- `make test-fast` - passed using the WSL sibling `.venv_pdf`; log: `artifacts/test_fast.log`.
- `scripts/gpu_smoke.sh --metadata-only` - passed; log: `logs/system/gpu_smoke_20260531T024250Z/gpu_smoke.log`.
- `make local-pr-validation` - passed without GPU/full-eval; summary: `logs/system/local_pr_validation_20260531T024711Z/summary.md`.
- `scripts/setup_local_worktree_links.sh --help` and `scripts/respond_to_pr_review.sh --help` - passed.
- `git diff --check` - passed.

## Not Run

- Full GPU pipeline smoke (`make verify-gpu-smoke`) was not run because it starts the Docker pipeline smoke and was not necessary for these docs/script changes.
- Full evaluation (`make verify-full-eval` / `--with-full-eval`) was not run because it is long-running and opt-in.

## Residual Risk

- `scripts/respond_to_pr_review.sh` depends on `gh` API access for inline review comments; it degrades to an empty inline-comment artifact if that API call fails.
- Worktree asset links are environment-specific and must be configured per machine.
- The first run in a fresh worktree may need a local Python environment or the sibling `.venv_pdf` fallback used here.