### PR TITLE
Design Stage E pipeline logging taxonomy

### DIFF
--- a/docs/ISSUE162_PIPELINE_LOGGING_TAXONOMY.md
+++ b/docs/ISSUE162_PIPELINE_LOGGING_TAXONOMY.md
@@ -1,0 +1,180 @@
+# Issue 162 Pipeline Logging Taxonomy
+
+This document defines the default logging contract for full-pipeline and Stage E
+runs. The goal is to keep default logs bounded and reviewable while preserving
+diagnostic evidence under `logs/` when explicitly requested.
+
+## Categories
+
+| Category | Default console output | Artifact capture | Diagnostic enablement | Current examples |
+| --- | --- | --- | --- | --- |
+| Acceptance-critical summary | Yes | Yes | Always on | Stage E detector eval output, `evaluation_contract.json`, `stage_e_runtime_summary.json`, `pipeline_stdout_stderr.summary.json` |
+| Operational progress | Yes, bounded summaries only | Yes | Full step chatter via `--pipeline-diagnostic-logs` or `PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1` | Stage E start/end lines, image copy count, runtime/resource summary paths, pipeline phase summary |
+| Diagnostic per-item detail | No | Yes | `pipeline.log`; include in captured stdout/stderr with `--pipeline-diagnostic-logs` or `PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1` | per-page tqdm loops, probe scale-aware parameter lines, MMR per-hit `[FOUND]` / `[RESCUE]` messages |
+| External-tool raw output | No by default, except warnings/errors | Yes, in raw stdout/stderr artifacts | `pipeline_stdout_stderr.raw.log`; captured stdout/stderr can be made verbose with `--pipeline-diagnostic-logs` or `PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1` | HOMR eprint/info output, Real-ESRGAN initialization/inference lines, OMR-DLN subprocess output |
+| Warning/error | Yes | Yes | Always on | missing component warnings, failed image reads, Real-ESRGAN import/init/inference failures, subprocess failures |
+
+## Stage E Default Policy
+
+`tools/issue120/run_stage_e_full_pipeline.py` uses `default_quiet` logging unless
+diagnostic verbosity is requested.
+
+- Pipeline stream handler level: `WARNING`
+- Progress bars: disabled through `TQDM_DISABLE=1`
+- Captured stream artifact: `logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.log`
+- Raw captured stream artifact: `logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log`
+- Captured stream summary: `pipeline_stdout_stderr.summary.json`
+- Detailed diagnostic file log: `pipeline.log`
+
+The Stage E runner still records the stdout/stderr artifact and summary under
+`logs/`. In default mode, the raw file preserves fd-level external output while
+the default `pipeline_stdout_stderr.log` is filtered to warnings/errors and any
+unexpected direct stream output rather than routine per-page progress.
+
+## Existing Log Source Evaluation
+
+Issue #162 audited the Stage E / full-pipeline log stream after Issue #159 added
+stdout/stderr capture. The default stream mixed acceptance summaries, operational
+progress, per-page diagnostics, external tool output, progress bars, and warnings.
+
+The following policy is now applied:
+
+| Source | Observed noise / value | Category | Default handling | Diagnostic handling |
+| --- | --- | --- | --- | --- |
+| Stage E runner logs | Run start/end, config path, capture path, runtime summary path | Operational progress | Kept on console as bounded runner messages | Same |
+| Stage E detector eval | Page count, TP/FP/FN, FN attribution, canonical target result | Acceptance-critical summary | Kept in eval command output and `evaluation_contract.json` | Same |
+| `src.pipeline.main` logger | Pipeline run path and step-level INFO messages | Operational progress / diagnostic detail | Stream handler is raised to `WARNING` during Stage E default capture | Full INFO stream with `--pipeline-diagnostic-logs` |
+| `pipeline.log` file handler | DEBUG+ Python logging from pipeline modules | Diagnostic per-item detail | Always written as a diagnostic artifact; not treated as default console output | Same |
+| HOMR fd-level output / `eprint` | Model download progress, per-page inference chatter, HOMR messages | External-tool raw output | Captured first to `pipeline_stdout_stderr.raw.log`, then filtered out of default log unless warning/error-like | Preserved directly in `pipeline_stdout_stderr.log` |
+| Real-ESRGAN prints | Initialization/inference status and failures | External-tool raw output / warning/error | Routine messages moved to logger INFO; failures remain logger ERROR | INFO/errors available through `pipeline.log` and diagnostic captured stream |
+| `tqdm` progress bars | Per-page progress lines such as `SR/Preparation: 10%...` | Operational progress / diagnostic per-item detail | `TQDM_DISABLE=1` is set and any remaining progress-like fd output is filtered | Preserved directly in diagnostic captured stream |
+| `src.measure_numbering.mmr` per-hit logs | `[FOUND]` / `[RESCUE]` per-measure evidence | Diagnostic per-item detail | Hidden from default captured stream by `WARNING` stream level; retained in `pipeline.log` | Visible in diagnostic captured stream |
+| Warning/error lines | RapidOCR empty detections, missing files, subprocess failures, tracebacks | Warning/error | Kept in default `pipeline_stdout_stderr.log` and counted in summary | Same |
+
+The Stage E validation run used for this issue produced these default-mode
+observability numbers after filtering:
+
+| Field | Value |
+| --- | ---: |
+| Raw stdout/stderr lines | 16,164 |
+| Default stdout/stderr lines kept | 6 |
+| Raw stdout/stderr size | 395,646 bytes |
+| Default stdout/stderr size | 612 bytes |
+| Dropped progress-like lines | 809 |
+| Dropped other external raw lines | 15,349 |
+| Default marker counts | `homr=0`, `real_esrgan=0`, `measure_numbering=0`, `progress_bar=0`, `warning_or_error=6` |
+
+These numbers are observability evidence only. They are not detector acceptance
+metrics.
+
+## Final Stage E Log Artifacts
+
+Default Stage E runs write the following log-related artifacts under
+`logs/issue120_e2e_recovery/stage_e_full_pipeline/`.
+
+| Artifact | Format | Purpose | Default content |
+| --- | --- | --- | --- |
+| `pipeline_stdout_stderr.log` | Plain text | Bounded default captured stream | Warning/error-like fd output only |
+| `pipeline_stdout_stderr.raw.log` | Plain text | Raw stdout/stderr evidence | Unfiltered external tool output, progress bars, and direct fd output |
+| `pipeline_stdout_stderr.summary.json` | JSON object | Machine-readable summary of `pipeline_stdout_stderr.log` | Line count, byte size, logger counts, marker counts |
+| `pipeline.log` | Plain text logging format | Diagnostic Python logger evidence | DEBUG+ pipeline logging, including routine INFO/detail |
+| `stage_e_runtime_summary.json` | JSON object | Runtime, resource, and log policy summary | Pipeline duration, log artifact paths, filter summary, resource summary |
+| `stage_e_resource_samples.jsonl` | JSON Lines | Periodic resource samples | Process/RSS/rusage/GPU samples |
+| `stage_e_resource_samples.summary.json` | JSON object | Resource sample aggregate | Peak memory/CPU/GPU values |
+| `eval_detector/evaluation_contract.json` | JSON object | Acceptance-critical detector contract | Expected/evaluated page counts, TP/FP/FN, FN attribution, `target_met` |
+
+In diagnostic mode, `pipeline_stdout_stderr.log` is intentionally verbose and
+`pipeline_stdout_stderr.raw.log` is not created by the runner. In that mode,
+`stage_e_runtime_summary.json` records `stdout_stderr_raw_log: null` and
+`stdout_stderr_filter_summary: null`.
+
+### `pipeline_stdout_stderr.summary.json`
+
+The summary JSON has this shape:
+
+```json
+{
+  "path": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.log",
+  "exists": true,
+  "size_bytes": 612,
+  "line_count": 6,
+  "logger_counts": {},
+  "marker_counts": {
+    "homr": 0,
+    "real_esrgan": 0,
+    "measure_numbering": 0,
+    "progress_bar": 0,
+    "warning_or_error": 6
+  },
+  "summary_path": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.summary.json"
+}
+```
+
+`marker_counts` are intentionally coarse. They are used to evaluate log
+taxonomy behavior, not detector correctness.
+
+### `stage_e_runtime_summary.json` log fields
+
+The `pipeline` object records the log policy and filtering result:
+
+```json
+{
+  "pipeline": {
+    "stdout_stderr_log": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.log",
+    "stdout_stderr_raw_log": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log",
+    "stdout_stderr_raw_log_size_bytes": 395646,
+    "stdout_stderr_log_size_bytes": 612,
+    "stdout_stderr_log_summary": {
+      "line_count": 6,
+      "marker_counts": {
+        "homr": 0,
+        "real_esrgan": 0,
+        "measure_numbering": 0,
+        "progress_bar": 0,
+        "warning_or_error": 6
+      }
+    },
+    "stdout_stderr_filter_summary": {
+      "schema_version": "tools.issue120.stage_e_console_filter.v1",
+      "raw_path": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log",
+      "filtered_path": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.log",
+      "raw_line_count": 16164,
+      "kept_line_count": 6,
+      "dropped_line_count": 16158,
+      "dropped_progress_line_count": 809,
+      "dropped_external_raw_line_count": 15349
+    },
+    "logging_policy": {
+      "schema_version": "tools.issue120.stage_e_pipeline_logging_policy.v1",
+      "mode": "default_quiet",
+      "console_log_level": "WARNING",
+      "progress_bars_disabled": true,
+      "detail_artifact": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline.log",
+      "raw_stdout_stderr_artifact": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log",
+      "diagnostic_enable": "--pipeline-diagnostic-logs or PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1"
+    }
+  }
+}
+```
+
+The default filtered log should remain small enough to inspect directly. When
+debugging a pipeline failure or reproducing external tool behavior, inspect
+`pipeline_stdout_stderr.raw.log` and `pipeline.log` together.
+
+Use either form to restore verbose captured output for diagnosis:
+
+```bash
+make run-issue120-stage-e-full ISSUE120_STAGE_E_EXTRA_ARGS="--pipeline-diagnostic-logs"
+```
+
+```bash
+PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1 make run-issue120-stage-e-full
+```
+
+## Non-Metric Boundary
+
+This taxonomy does not define new acceptance metrics. Detector metrics remain in
+the Stage E detector evaluation artifacts, while downstream measure-count status
+remains separate in the evaluation contract. Log marker counts such as
+`homr`, `real_esrgan`, `measure_numbering`, `progress_bar`, and
+`warning_or_error` are observability fields only.

--- a/docs/ISSUE162_PIPELINE_LOGGING_TAXONOMY.md
+++ b/docs/ISSUE162_PIPELINE_LOGGING_TAXONOMY.md
@@ -25,6 +25,9 @@ diagnostic verbosity is requested.
 - Raw captured stream artifact: `logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log`
 - Captured stream summary: `pipeline_stdout_stderr.summary.json`
 - Detailed diagnostic file log: `pipeline.log`
+- `make run-issue120-stage-e-full` forwards `PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS`,
+  `PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS`, and `PDFSCORE_SR_TILE_LOGS` into the
+  Docker container.
 
 The Stage E runner still records the stdout/stderr artifact and summary under
 `logs/`. In default mode, the raw file preserves fd-level external output while
@@ -85,6 +88,9 @@ largest offenders were:
 
 The HOMR internal suppressor keeps warning/error-like lines. Use
 `PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS=1` only when diagnosing HOMR internals.
+Even when these lines are removed from the default raw artifact, the runner
+records marker counts such as `onnxruntime_fallback`, `homr_dewarping_staff`,
+and `realesrgan_tile` in `stage_e_runtime_summary.json`.
 
 ## Final Stage E Log Artifacts
 
@@ -169,7 +175,21 @@ uses the same 1-page smoke run as above:
       "input_line_count": 64,
       "output_line_count": 36,
       "suppressed_line_count": 28,
-      "sanitized_progress_line_count": 1
+      "sanitized_progress_line_count": 1,
+      "low_value_marker_counts": {
+        "homr_download_progress": 303,
+        "homr_tromr_timing": 19,
+        "onnxruntime_fallback": 18,
+        "onnxruntime_warning": 20,
+        "rapidocr_info": 9
+      },
+      "suppressed_marker_counts": {
+        "homr_download_progress": 303,
+        "homr_tromr_timing": 19,
+        "onnxruntime_fallback": 18,
+        "onnxruntime_warning": 20,
+        "rapidocr_info": 9
+      }
     },
     "stdout_stderr_filter_summary": {
       "schema_version": "tools.issue120.stage_e_console_filter.v1",
@@ -237,6 +257,10 @@ focused HOMR investigation:
 ```bash
 PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS=1 make run-issue120-stage-e-full
 ```
+
+These environment variables are forwarded by
+`tools/issue120/Makefile.stage_e.mk` to the container used by
+`make run-issue120-stage-e-full`.
 
 Use either form to restore verbose captured output for diagnosis:
 

--- a/docs/ISSUE162_PIPELINE_LOGGING_TAXONOMY.md
+++ b/docs/ISSUE162_PIPELINE_LOGGING_TAXONOMY.md
@@ -48,7 +48,9 @@ The following policy is now applied:
 | `src.pipeline.main` logger | Pipeline run path and step-level INFO messages | Operational progress / diagnostic detail | Stream handler is raised to `WARNING` during Stage E default capture | Full INFO stream with `--pipeline-diagnostic-logs` |
 | `pipeline.log` file handler | DEBUG+ Python logging from pipeline modules | Diagnostic per-item detail | Always written as a diagnostic artifact; not treated as default console output | Same |
 | HOMR fd-level output / `eprint` | Model download progress, per-page inference chatter, HOMR messages | External-tool raw output | Captured first to `pipeline_stdout_stderr.raw.log`, then filtered out of default log unless warning/error-like | Preserved directly in `pipeline_stdout_stderr.log` |
+| HOMR repetitive internals | `Dewarping staff`, `Running TrOmr inference`, `Creating bounds for`, cache notices, download percentage lines, per-page symbol/staff counts, TrOMR timing, tuple cleanup chatter, RapidOCR/ORT startup noise | Suppressed low-value external detail | Dropped around in-process HOMR initialization/prediction unless warning/error-like | Restore with `PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS=1` only when debugging HOMR internals |
 | Real-ESRGAN prints | Initialization/inference status and failures | External-tool raw output / warning/error | Routine messages moved to logger INFO; failures remain logger ERROR | INFO/errors available through `pipeline.log` and diagnostic captured stream |
+| Real-ESRGAN tile prints | Per-tile stdout lines such as `Tile 1/130` | Suppressed low-value external progress | Dropped at the SR wrapper before raw stdout/stderr capture | Restore with `PDFSCORE_SR_TILE_LOGS=1` only when debugging Real-ESRGAN tiling internals |
 | `tqdm` progress bars | Per-page progress lines such as `SR/Preparation: 10%...` | Operational progress | Mirrored live to the console, preserved in raw stdout/stderr, filtered out of default final log | Preserved directly in diagnostic captured stream |
 | `src.measure_numbering.mmr` per-hit logs | `[FOUND]` / `[RESCUE]` per-measure evidence | Diagnostic per-item detail | Hidden from default captured stream by `WARNING` stream level; retained in `pipeline.log` | Visible in diagnostic captured stream |
 | Warning/error lines | RapidOCR empty detections, missing files, subprocess failures, tracebacks | Warning/error | Kept in default `pipeline_stdout_stderr.log` and counted in summary | Same |
@@ -69,6 +71,21 @@ observability numbers after filtering:
 These numbers are observability evidence only. They are not detector acceptance
 metrics.
 
+The raw log was also reviewed for repeated low-value external messages. The
+largest offenders were:
+
+| Raw pattern | Observed lines | Decision |
+| --- | ---: | --- |
+| `Tile N/M` | 7,564 | Suppress in the SR wrapper; page-level SR `tqdm` remains visible |
+| `Dewarping staff` | 2,556 | Suppress around in-process HOMR prediction |
+| `Running TrOmr inference on staff image` | 1,278 | Suppress around in-process HOMR prediction |
+| `Creating bounds for ...` | 680 | Suppress around in-process HOMR prediction |
+| `Downloaded ... (%)` | 303 | Suppress around in-process HOMR initialization; model download start lines may remain, but percentage spam is not retained |
+| `Inference Time Tromr`, `Removing tuplets`, RapidOCR INFO, known ORT fallback chatter | observed in 1-page smoke raw log | Suppress around in-process HOMR prediction; these are not page-level progress or actionable acceptance evidence |
+
+The HOMR internal suppressor keeps warning/error-like lines. Use
+`PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS=1` only when diagnosing HOMR internals.
+
 ## Final Stage E Log Artifacts
 
 Default Stage E runs write the following log-related artifacts under
@@ -76,10 +93,10 @@ Default Stage E runs write the following log-related artifacts under
 
 | Artifact | Format | Purpose | Default content |
 | --- | --- | --- | --- |
-| `pipeline_stdout_stderr.log` | Plain text | Bounded default captured stream | Warning/error-like fd output only |
-| `pipeline_stdout_stderr.raw.log` | Plain text | Raw stdout/stderr evidence | Unfiltered external tool output, progress bars, and direct fd output |
-| `pipeline_stdout_stderr.summary.json` | JSON object | Machine-readable summary of `pipeline_stdout_stderr.log` | Line count, byte size, logger counts, marker counts |
-| `pipeline.log` | Plain text logging format | Diagnostic Python logger evidence | DEBUG+ pipeline logging, including routine INFO/detail |
+| `pipeline_stdout_stderr.log` | Plain text | Bounded default captured stream | Created only when warning/error-like fd output exists |
+| `pipeline_stdout_stderr.raw.log` | Plain text | Detailed stdout/stderr evidence | Progress bars and direct fd output after removing known low-value repeated external chatter |
+| `pipeline_stdout_stderr.summary.json` | JSON object | Machine-readable summary of the bounded default stream | Whether `pipeline_stdout_stderr.log` exists, line count, byte size, marker counts |
+| `pipeline.log` | Plain text logging format | Diagnostic Python logger timeline from the in-process pipeline | DEBUG+ pipeline logging, including config, step boundaries, phase summaries, and subprocess wrapper records |
 | `stage_e_runtime_summary.json` | JSON object | Runtime, resource, and log policy summary | Pipeline duration, log artifact paths, filter summary, progress mirror summary, resource summary |
 | `stage_e_resource_samples.jsonl` | JSON Lines | Periodic resource samples | Process/RSS/rusage/GPU samples |
 | `stage_e_resource_samples.summary.json` | JSON object | Resource sample aggregate | Peak memory/CPU/GPU values |
@@ -87,26 +104,28 @@ Default Stage E runs write the following log-related artifacts under
 
 In diagnostic mode, `pipeline_stdout_stderr.log` is intentionally verbose and
 `pipeline_stdout_stderr.raw.log` is not created by the runner. In that mode,
-`stage_e_runtime_summary.json` records `stdout_stderr_raw_log: null` and
+`stage_e_runtime_summary.json` records `stdout_stderr_raw_log: null`,
+`stdout_stderr_low_value_raw_suppression_summary: null`, and
 `stdout_stderr_filter_summary: null`.
 
 ### `pipeline_stdout_stderr.summary.json`
 
-The summary JSON has this shape:
+The summary JSON has this shape. This example is from a 1-page smoke run with
+no warning/error output:
 
 ```json
 {
   "path": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.log",
-  "exists": true,
-  "size_bytes": 612,
-  "line_count": 6,
+  "exists": false,
+  "size_bytes": 0,
+  "line_count": 0,
   "logger_counts": {},
   "marker_counts": {
     "homr": 0,
     "real_esrgan": 0,
     "measure_numbering": 0,
     "progress_bar": 0,
-    "warning_or_error": 6
+    "warning_or_error": 0
   },
   "summary_path": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.summary.json"
 }
@@ -115,43 +134,60 @@ The summary JSON has this shape:
 `marker_counts` are intentionally coarse. They are used to evaluate log
 taxonomy behavior, not detector correctness.
 
+When no warning/error-like fd output is present, the runner does not create an
+empty `pipeline_stdout_stderr.log`. The summary JSON remains present so tooling
+can distinguish "no default log was needed" from "summary was not generated".
+
 ### `stage_e_runtime_summary.json` log fields
 
-The `pipeline` object records the log policy and filtering result:
+The `pipeline` object records the log policy and filtering result. This example
+uses the same 1-page smoke run as above:
 
 ```json
 {
   "pipeline": {
     "stdout_stderr_log": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.log",
     "stdout_stderr_raw_log": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log",
-    "stdout_stderr_raw_log_size_bytes": 395646,
-    "stdout_stderr_log_size_bytes": 612,
+    "stdout_stderr_raw_log_size_bytes": 2056,
+    "stdout_stderr_log_size_bytes": 0,
     "stdout_stderr_log_summary": {
-      "line_count": 6,
+      "exists": false,
+      "line_count": 0,
       "marker_counts": {
         "homr": 0,
         "real_esrgan": 0,
         "measure_numbering": 0,
         "progress_bar": 0,
-        "warning_or_error": 6
+        "warning_or_error": 0
       }
+    },
+    "stdout_stderr_low_value_raw_suppression_summary": {
+      "schema_version": "tools.issue120.stage_e_low_value_raw_suppression.v1",
+      "path": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log",
+      "preserve_homr_internal": false,
+      "preserve_sr_tile_logs": false,
+      "input_line_count": 64,
+      "output_line_count": 36,
+      "suppressed_line_count": 28,
+      "sanitized_progress_line_count": 1
     },
     "stdout_stderr_filter_summary": {
       "schema_version": "tools.issue120.stage_e_console_filter.v1",
       "raw_path": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log",
       "filtered_path": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.log",
-      "raw_line_count": 16164,
-      "kept_line_count": 6,
-      "dropped_line_count": 16158,
-      "dropped_progress_line_count": 809,
-      "dropped_external_raw_line_count": 15349
+      "raw_line_count": 36,
+      "kept_line_count": 0,
+      "dropped_line_count": 36,
+      "dropped_progress_line_count": 23,
+      "dropped_external_raw_line_count": 13,
+      "filtered_log_written": false
     },
     "stdout_stderr_progress_mirror_summary": {
       "schema_version": "tools.issue120.stage_e_console_progress_mirror.v1",
       "capture_path": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log",
       "mirror_progress": true,
-      "mirrored_progress_line_count": 809,
-      "mirrored_warning_or_error_line_count": 6
+      "mirrored_progress_line_count": 23,
+      "mirrored_warning_or_error_line_count": 0
     },
     "logging_policy": {
       "schema_version": "tools.issue120.stage_e_pipeline_logging_policy.v1",
@@ -166,9 +202,41 @@ The `pipeline` object records the log policy and filtering result:
 }
 ```
 
-The default filtered log should remain small enough to inspect directly. When
-debugging a pipeline failure or reproducing external tool behavior, inspect
-`pipeline_stdout_stderr.raw.log` and `pipeline.log` together.
+The default filtered log should remain small enough to inspect directly. The
+default raw log is still detailed evidence, but it is no longer a dump of every
+repetitive external print. When debugging a pipeline failure, inspect
+`pipeline_stdout_stderr.raw.log` and `pipeline.log` together. When reproducing
+external tool behavior line-for-line, enable diagnostic mode.
+
+`pipeline.log` is not the default console log. It is the pipeline's Python
+logging timeline, written by the file logger. It is useful for reconstructing
+which configured steps ran, which subprocess wrapper commands were launched,
+and what phase summaries were emitted. It should not be used as an
+acceptance-critical metric source, and it intentionally does not contain every
+fd-level print from external tools; those belong to `pipeline_stdout_stderr.raw.log`.
+
+Real-ESRGAN tile-level stdout (`Tile N/M`) is intentionally suppressed before
+raw stdout/stderr capture. It produces thousands of lines per Stage E run and
+does not identify the current page or a failure condition. Page-level SR
+progress remains visible through `tqdm`. To inspect Real-ESRGAN tiling internals
+for a focused diagnosis, run with:
+
+```bash
+PDFSCORE_SR_TILE_LOGS=1 make run-issue120-stage-e-full
+```
+
+HOMR internals such as `Dewarping staff`,
+`Running TrOmr inference on staff image`, `Creating bounds for ...`,
+download percentage lines, TrOMR timing, tuple cleanup chatter, RapidOCR INFO,
+known ORT fallback chatter, and per-page staff/symbol counts are also
+suppressed by default for the same reason: they produce many lines without
+indicating the current score/page or an actionable state. Page-level
+`Homr Inference` progress remains visible. To restore those internals for a
+focused HOMR investigation:
+
+```bash
+PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS=1 make run-issue120-stage-e-full
+```
 
 Use either form to restore verbose captured output for diagnosis:
 

--- a/docs/ISSUE162_PIPELINE_LOGGING_TAXONOMY.md
+++ b/docs/ISSUE162_PIPELINE_LOGGING_TAXONOMY.md
@@ -9,8 +9,8 @@ diagnostic evidence under `logs/` when explicitly requested.
 | Category | Default console output | Artifact capture | Diagnostic enablement | Current examples |
 | --- | --- | --- | --- | --- |
 | Acceptance-critical summary | Yes | Yes | Always on | Stage E detector eval output, `evaluation_contract.json`, `stage_e_runtime_summary.json`, `pipeline_stdout_stderr.summary.json` |
-| Operational progress | Yes, bounded summaries only | Yes | Full step chatter via `--pipeline-diagnostic-logs` or `PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1` | Stage E start/end lines, image copy count, runtime/resource summary paths, pipeline phase summary |
-| Diagnostic per-item detail | No | Yes | `pipeline.log`; include in captured stdout/stderr with `--pipeline-diagnostic-logs` or `PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1` | per-page tqdm loops, probe scale-aware parameter lines, MMR per-hit `[FOUND]` / `[RESCUE]` messages |
+| Operational progress | Yes, bounded summaries plus live tqdm-style progress | Yes | Full step chatter via `--pipeline-diagnostic-logs` or `PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1` | Stage E start/end lines, image copy count, runtime/resource summary paths, pipeline phase summary, live `tqdm` progress |
+| Diagnostic per-item detail | No | Yes | `pipeline.log`; include in captured stdout/stderr with `--pipeline-diagnostic-logs` or `PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1` | probe scale-aware parameter lines, MMR per-hit `[FOUND]` / `[RESCUE]` messages |
 | External-tool raw output | No by default, except warnings/errors | Yes, in raw stdout/stderr artifacts | `pipeline_stdout_stderr.raw.log`; captured stdout/stderr can be made verbose with `--pipeline-diagnostic-logs` or `PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1` | HOMR eprint/info output, Real-ESRGAN initialization/inference lines, OMR-DLN subprocess output |
 | Warning/error | Yes | Yes | Always on | missing component warnings, failed image reads, Real-ESRGAN import/init/inference failures, subprocess failures |
 
@@ -20,7 +20,7 @@ diagnostic evidence under `logs/` when explicitly requested.
 diagnostic verbosity is requested.
 
 - Pipeline stream handler level: `WARNING`
-- Progress bars: disabled through `TQDM_DISABLE=1`
+- Progress bars: mirrored to the live console from the raw captured stream
 - Captured stream artifact: `logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.log`
 - Raw captured stream artifact: `logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log`
 - Captured stream summary: `pipeline_stdout_stderr.summary.json`
@@ -29,7 +29,9 @@ diagnostic verbosity is requested.
 The Stage E runner still records the stdout/stderr artifact and summary under
 `logs/`. In default mode, the raw file preserves fd-level external output while
 the default `pipeline_stdout_stderr.log` is filtered to warnings/errors and any
-unexpected direct stream output rather than routine per-page progress.
+unexpected direct stream output rather than routine per-page progress. During
+the run, progress-like `tqdm` lines are mirrored from the raw capture back to
+the console so a long Stage E run still shows liveness and phase progress.
 
 ## Existing Log Source Evaluation
 
@@ -47,7 +49,7 @@ The following policy is now applied:
 | `pipeline.log` file handler | DEBUG+ Python logging from pipeline modules | Diagnostic per-item detail | Always written as a diagnostic artifact; not treated as default console output | Same |
 | HOMR fd-level output / `eprint` | Model download progress, per-page inference chatter, HOMR messages | External-tool raw output | Captured first to `pipeline_stdout_stderr.raw.log`, then filtered out of default log unless warning/error-like | Preserved directly in `pipeline_stdout_stderr.log` |
 | Real-ESRGAN prints | Initialization/inference status and failures | External-tool raw output / warning/error | Routine messages moved to logger INFO; failures remain logger ERROR | INFO/errors available through `pipeline.log` and diagnostic captured stream |
-| `tqdm` progress bars | Per-page progress lines such as `SR/Preparation: 10%...` | Operational progress / diagnostic per-item detail | `TQDM_DISABLE=1` is set and any remaining progress-like fd output is filtered | Preserved directly in diagnostic captured stream |
+| `tqdm` progress bars | Per-page progress lines such as `SR/Preparation: 10%...` | Operational progress | Mirrored live to the console, preserved in raw stdout/stderr, filtered out of default final log | Preserved directly in diagnostic captured stream |
 | `src.measure_numbering.mmr` per-hit logs | `[FOUND]` / `[RESCUE]` per-measure evidence | Diagnostic per-item detail | Hidden from default captured stream by `WARNING` stream level; retained in `pipeline.log` | Visible in diagnostic captured stream |
 | Warning/error lines | RapidOCR empty detections, missing files, subprocess failures, tracebacks | Warning/error | Kept in default `pipeline_stdout_stderr.log` and counted in summary | Same |
 
@@ -78,7 +80,7 @@ Default Stage E runs write the following log-related artifacts under
 | `pipeline_stdout_stderr.raw.log` | Plain text | Raw stdout/stderr evidence | Unfiltered external tool output, progress bars, and direct fd output |
 | `pipeline_stdout_stderr.summary.json` | JSON object | Machine-readable summary of `pipeline_stdout_stderr.log` | Line count, byte size, logger counts, marker counts |
 | `pipeline.log` | Plain text logging format | Diagnostic Python logger evidence | DEBUG+ pipeline logging, including routine INFO/detail |
-| `stage_e_runtime_summary.json` | JSON object | Runtime, resource, and log policy summary | Pipeline duration, log artifact paths, filter summary, resource summary |
+| `stage_e_runtime_summary.json` | JSON object | Runtime, resource, and log policy summary | Pipeline duration, log artifact paths, filter summary, progress mirror summary, resource summary |
 | `stage_e_resource_samples.jsonl` | JSON Lines | Periodic resource samples | Process/RSS/rusage/GPU samples |
 | `stage_e_resource_samples.summary.json` | JSON object | Resource sample aggregate | Peak memory/CPU/GPU values |
 | `eval_detector/evaluation_contract.json` | JSON object | Acceptance-critical detector contract | Expected/evaluated page counts, TP/FP/FN, FN attribution, `target_met` |
@@ -144,11 +146,18 @@ The `pipeline` object records the log policy and filtering result:
       "dropped_progress_line_count": 809,
       "dropped_external_raw_line_count": 15349
     },
+    "stdout_stderr_progress_mirror_summary": {
+      "schema_version": "tools.issue120.stage_e_console_progress_mirror.v1",
+      "capture_path": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log",
+      "mirror_progress": true,
+      "mirrored_progress_line_count": 809,
+      "mirrored_warning_or_error_line_count": 6
+    },
     "logging_policy": {
       "schema_version": "tools.issue120.stage_e_pipeline_logging_policy.v1",
       "mode": "default_quiet",
       "console_log_level": "WARNING",
-      "progress_bars_disabled": true,
+      "progress_bars_console_mirrored": true,
       "detail_artifact": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline.log",
       "raw_stdout_stderr_artifact": "logs/issue120_e2e_recovery/stage_e_full_pipeline/pipeline_stdout_stderr.raw.log",
       "diagnostic_enable": "--pipeline-diagnostic-logs or PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1"

--- a/src/common/preprocessing.py
+++ b/src/common/preprocessing.py
@@ -1,8 +1,11 @@
+import logging
 import os
 from typing import Any, Optional
 
 import cv2
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 IMAGE_SIZE_THRESHOLD_FOR_TILING = 1000
 DEFAULT_TILE_SIZE = 400
@@ -92,12 +95,12 @@ def apply_super_resolution(
     sr.setModel(model_name, scale)
 
     if image.ndim != 3 or image.shape[2] != 3:
-        print("Input image is not 3-channel, converting to BGR for super-resolution.")
+        logger.info("Input image is not 3-channel, converting to BGR for super-resolution.")
         image = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
 
-    print(f"Upscaling image by factor of {scale} using {model_name}...")
+    logger.info("Upscaling image by factor of %s using %s...", scale, model_name)
     result = sr.upsample(image)
-    print("Upscaling complete.")
+    logger.info("Upscaling complete.")
 
     return result
 
@@ -135,15 +138,15 @@ def apply_advanced_sr(
         from basicsr.archs.rrdbnet_arch import RRDBNet
         from realesrgan import RealESRGANer
     except ImportError as e:
-        print(f"Error importing Real-ESRGAN dependencies: {e}")
-        print("Please ensure you have installed the realesrgan package.")
+        logger.error("Error importing Real-ESRGAN dependencies: %s", e)
+        logger.error("Please ensure you have installed the realesrgan package.")
         return image, upsampler
 
     # Check device
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     if upsampler is None:
-        print(f"Initializing Real-ESRGAN ({model_name}) using device: {device}")
+        logger.info("Initializing Real-ESRGAN (%s) using device: %s", model_name, device)
         if model_name == "RealESRGAN_x4plus":
             model = RRDBNet(
                 num_in_ch=3, num_out_ch=3, num_feat=64, num_block=23, num_grow_ch=32, scale=4
@@ -157,7 +160,10 @@ def apply_advanced_sr(
             netscale = 2
             model_path = os.path.join(realesrgan_path, "weights", f"{model_name}.pth")
         else:
-            print(f"Model {model_name} not explicitly supported. A default (x2plus) will be used.")
+            logger.warning(
+                "Model %s not explicitly supported. A default (x2plus) will be used.",
+                model_name,
+            )
             model = RRDBNet(
                 num_in_ch=3, num_out_ch=3, num_feat=64, num_block=23, num_grow_ch=32, scale=2
             )
@@ -191,7 +197,7 @@ def apply_advanced_sr(
                 device=device,
             )
         except Exception as e:
-            print(f"Real-ESRGAN initialization failed: {e}")
+            logger.error("Real-ESRGAN initialization failed: %s", e)
             return image, upsampler
 
     try:
@@ -201,5 +207,5 @@ def apply_advanced_sr(
         output, _ = upsampler.enhance(image, outscale=scale)
         return output, upsampler
     except Exception as e:
-        print(f"Real-ESRGAN inference failed: {e}")
+        logger.error("Real-ESRGAN inference failed: %s", e)
         return image, upsampler

--- a/src/common/preprocessing.py
+++ b/src/common/preprocessing.py
@@ -1,5 +1,7 @@
+import contextlib
 import logging
 import os
+import sys
 from typing import Any, Optional
 
 import cv2
@@ -9,6 +11,50 @@ logger = logging.getLogger(__name__)
 
 IMAGE_SIZE_THRESHOLD_FOR_TILING = 1000
 DEFAULT_TILE_SIZE = 400
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+class _RealESRGANTileLogFilter:
+    """Drop Real-ESRGAN per-tile progress prints while forwarding other stdout."""
+
+    def __init__(self, stream: Any) -> None:
+        self.stream = stream
+        self._pending = ""
+
+    def write(self, text: str) -> int:
+        self._pending += text
+        while "\n" in self._pending:
+            line, self._pending = self._pending.split("\n", 1)
+            self._write_line(line + "\n")
+        return len(text)
+
+    def flush(self) -> None:
+        if self._pending:
+            self._write_line(self._pending)
+            self._pending = ""
+        self.stream.flush()
+
+    def _write_line(self, line: str) -> None:
+        stripped = line.strip()
+        if stripped.startswith("Tile ") and "/" in stripped:
+            return
+        self.stream.write(line)
+
+
+@contextlib.contextmanager
+def _suppress_realesrgan_tile_logs():
+    if _env_flag_enabled("PDFSCORE_SR_TILE_LOGS"):
+        yield
+        return
+    stream = _RealESRGANTileLogFilter(sys.stdout)
+    with contextlib.redirect_stdout(stream):
+        try:
+            yield
+        finally:
+            stream.flush()
 
 
 def apply_vertical_closing(
@@ -204,7 +250,8 @@ def apply_advanced_sr(
         if image.ndim != 3 or image.shape[2] != 3:
             image = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
 
-        output, _ = upsampler.enhance(image, outscale=scale)
+        with _suppress_realesrgan_tile_logs():
+            output, _ = upsampler.enhance(image, outscale=scale)
         return output, upsampler
     except Exception as e:
         logger.error("Real-ESRGAN inference failed: %s", e)

--- a/src/pipeline/core/run_ids.py
+++ b/src/pipeline/core/run_ids.py
@@ -27,5 +27,5 @@ def split_score_page_from_composite_stem(stem: str) -> tuple[str, str] | None:
     if idx < 0:
         return None
     score = stem[:idx]
-    page = f"page_{stem[idx + len(marker):]}"
+    page = f"page_{stem[idx + len(marker) :]}"
     return score, page

--- a/src/pipeline/detection/hybrid.py
+++ b/src/pipeline/detection/hybrid.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
 import gc
 import json
 import logging
 import os
 import shutil
+import sys
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -35,6 +37,96 @@ except ImportError:
     _HOMR_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+class _HomrInternalLogFilter:
+    """Drop repetitive HOMR internals while forwarding warnings/errors and useful output."""
+
+    _SUPPRESSED_PREFIXES = (
+        "Dewarping staff",
+        "Running TrOmr inference on staff image",
+        "Creating bounds for",
+        "Downloaded ",
+        "Found a cache",
+        "Loading from cache",
+        "Removing tuplets from measure",
+        "Saving cache",
+        "_check_choices_intelligently:",
+    )
+    _SUPPRESSED_CONTAINS = (
+        "[RapidOCR]",
+        "[W:onnxruntime",
+        " clefs",
+        " possible other clefs",
+        " staff anchors",
+        " staffs",
+        " bar lines",
+        " staff line fragments",
+        " noteheads",
+        "Average note head height:",
+        "Fallback mode. May be extremely slow.",
+        " notes during segmentation",
+        "Inference Time Tromr:",
+        "Segnet Inference time:",
+    )
+    _IMPORTANT_MARKERS = (
+        "warning",
+        "error",
+        "traceback",
+        "exception",
+        "failed",
+        "failure",
+    )
+
+    def __init__(self, stream: Any) -> None:
+        self.stream = stream
+        self._pending = ""
+
+    def write(self, text: str) -> int:
+        self._pending += text
+        while "\n" in self._pending:
+            line, self._pending = self._pending.split("\n", 1)
+            self._write_line(line + "\n")
+        return len(text)
+
+    def flush(self) -> None:
+        if self._pending:
+            self._write_line(self._pending)
+            self._pending = ""
+        self.stream.flush()
+
+    def _write_line(self, line: str) -> None:
+        if self._should_suppress(line):
+            return
+        self.stream.write(line)
+
+    def _should_suppress(self, line: str) -> bool:
+        stripped = line.strip()
+        lower = stripped.lower()
+        if any(marker in lower for marker in self._IMPORTANT_MARKERS):
+            return False
+        if stripped.startswith(self._SUPPRESSED_PREFIXES):
+            return True
+        return any(marker in stripped for marker in self._SUPPRESSED_CONTAINS)
+
+
+@contextlib.contextmanager
+def _suppress_homr_low_value_internal_logs():
+    if _env_flag_enabled("PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS"):
+        yield
+        return
+    stdout_filter = _HomrInternalLogFilter(sys.stdout)
+    stderr_filter = _HomrInternalLogFilter(sys.stderr)
+    with contextlib.redirect_stdout(stdout_filter), contextlib.redirect_stderr(stderr_filter):
+        try:
+            yield
+        finally:
+            stdout_filter.flush()
+            stderr_filter.flush()
 
 
 class HybridDetector:
@@ -261,7 +353,8 @@ class HybridDetector:
             }
         )
 
-        predictor = HomrPredictor(config, tuning, use_gpu_inference=torch.cuda.is_available())
+        with _suppress_homr_low_value_internal_logs():
+            predictor = HomrPredictor(config, tuning, use_gpu_inference=torch.cuda.is_available())
         xml_args = XmlGeneratorArguments(False, None, None)
 
         try:
@@ -313,9 +406,10 @@ class HybridDetector:
                 working_images, desc="Homr Inference", unit="page"
             ):
                 image_run_dir = output_root / "batch" / original_path.stem
-                predictions, _, _, _, notehead_mask, staff_mask, _, _ = predictor.predict(
-                    working_path, xml_args, sr_scale=scale, image_run_dir=image_run_dir
-                )
+                with _suppress_homr_low_value_internal_logs():
+                    predictions, _, _, _, notehead_mask, staff_mask, _, _ = predictor.predict(
+                        working_path, xml_args, sr_scale=scale, image_run_dir=image_run_dir
+                    )
 
                 metrics_predictions = [
                     BarlinePrediction(

--- a/src/pipeline/detection/orchestrator.py
+++ b/src/pipeline/detection/orchestrator.py
@@ -38,7 +38,9 @@ def _candidate_json_candidates(
 ) -> list[Path]:
     """Return supported locations for a precomputed probe candidate JSON."""
     candidates = [
-        root / build_probe_run_id(image_path, score_name=score_name) / "pipeline2_no_peak_candidates.json",
+        root
+        / build_probe_run_id(image_path, score_name=score_name)
+        / "pipeline2_no_peak_candidates.json",
         root / image_path.parent.name / image_path.stem / "pipeline2_no_peak_candidates.json",
     ]
     split = _split_score_page_from_stem(image_path.stem)
@@ -168,15 +170,35 @@ class DetectorOrchestrator:
                     ink_threshold=int(self.det_cfg.get("ink_threshold", 180)),
                     min_ratio=float(self.det_cfg.get("min_ratio", 0.50)),
                     min_height_ratio=float(self.det_cfg.get("min_height_ratio", 0.012)),
-                    min_width_ratio=(float(self.det_cfg.get("min_width_ratio")) if self.det_cfg.get("min_width_ratio") is not None else 0.0001),
+                    min_width_ratio=(
+                        float(self.det_cfg.get("min_width_ratio"))
+                        if self.det_cfg.get("min_width_ratio") is not None
+                        else 0.0001
+                    ),
                     score_name=effective_score_name,
-                    band_cluster_max_dist=(float(self.det_cfg.get("band_cluster_max_dist")) if self.det_cfg.get("band_cluster_max_dist") is not None else None),
+                    band_cluster_max_dist=(
+                        float(self.det_cfg.get("band_cluster_max_dist"))
+                        if self.det_cfg.get("band_cluster_max_dist") is not None
+                        else None
+                    ),
                     band_min_row_count=int(self.det_cfg.get("band_min_row_count", 1)),
                     vertical_closing=int(self.det_cfg.get("vertical_closing", 4)),
                     detect_probe_kwargs=detect_probe_kwargs,
-                    probe_row_filter_mode=(str(self.det_cfg.get("probe_row_filter_mode")) if self.det_cfg.get("probe_row_filter_mode") is not None else None),
-                    probe_endpoint_x_scale=(float(self.det_cfg.get("probe_endpoint_x_scale")) if self.det_cfg.get("probe_endpoint_x_scale") is not None else None),
-                    probe_endpoint_y_scale=(float(self.det_cfg.get("probe_endpoint_y_scale")) if self.det_cfg.get("probe_endpoint_y_scale") is not None else None),
+                    probe_row_filter_mode=(
+                        str(self.det_cfg.get("probe_row_filter_mode"))
+                        if self.det_cfg.get("probe_row_filter_mode") is not None
+                        else None
+                    ),
+                    probe_endpoint_x_scale=(
+                        float(self.det_cfg.get("probe_endpoint_x_scale"))
+                        if self.det_cfg.get("probe_endpoint_x_scale") is not None
+                        else None
+                    ),
+                    probe_endpoint_y_scale=(
+                        float(self.det_cfg.get("probe_endpoint_y_scale"))
+                        if self.det_cfg.get("probe_endpoint_y_scale") is not None
+                        else None
+                    ),
                     skip_existing=self.skip_existing,
                     input_image_scale=float(effective_sr_scale),
                     enable_heuristic_filters=self.det_cfg.get("enable_heuristic_filters", True),
@@ -184,10 +206,14 @@ class DetectorOrchestrator:
                 )
         cmd_probe = [
             "inprocess:probe_scan",
-            "--output-root", str(probe_output_root),
-            "--bands-from", str(self.hybrid_output_dir),
-            "--ink-threshold", str(self.det_cfg.get("ink_threshold", 230)),
-            "--min-ratio", str(self.det_cfg.get("min_ratio", 0.70)),
+            "--output-root",
+            str(probe_output_root),
+            "--bands-from",
+            str(self.hybrid_output_dir),
+            "--ink-threshold",
+            str(self.det_cfg.get("ink_threshold", 230)),
+            "--min-ratio",
+            str(self.det_cfg.get("min_ratio", 0.70)),
         ]
         if precomputed_candidates_root is not None:
             cmd_probe.extend(["--precomputed-candidates-root", str(precomputed_candidates_root)])
@@ -212,8 +238,12 @@ class DetectorOrchestrator:
                 model_path=Path(cnn_model),
                 threshold=float(self.det_cfg.get("cnn_threshold", 0.1)),
                 score_name=effective_score_name,
-                crop_recenter_on_bbox_ink=bool(self.det_cfg.get("crop_recenter_on_bbox_ink", False)),
-                crop_recenter_max_shift_unit_ratio=float(self.det_cfg.get("crop_recenter_max_shift_unit_ratio", 0.35)),
+                crop_recenter_on_bbox_ink=bool(
+                    self.det_cfg.get("crop_recenter_on_bbox_ink", False)
+                ),
+                crop_recenter_max_shift_unit_ratio=float(
+                    self.det_cfg.get("crop_recenter_max_shift_unit_ratio", 0.35)
+                ),
                 input_image_scale=float(effective_sr_scale),
                 bands_from=cnn_bands_from,
                 staff_vov_threshold=float(self.det_cfg.get("staff_vov_threshold", 0.5)),
@@ -222,10 +252,14 @@ class DetectorOrchestrator:
             )
         cmd_score = [
             "inprocess:cnn_scoring",
-            "--model", str(cnn_model),
-            "--logs", str(self.probe_output_dir),
-            "--threshold", str(self.det_cfg.get("cnn_threshold", 0.1)),
-            "--apply-nms", str(cnn_apply_nms),
+            "--model",
+            str(cnn_model),
+            "--logs",
+            str(self.probe_output_dir),
+            "--threshold",
+            str(self.det_cfg.get("cnn_threshold", 0.1)),
+            "--apply-nms",
+            str(cnn_apply_nms),
         ]
         if cnn_bands_from is not None and cnn_bands_from != self.hybrid_output_dir:
             cmd_score.extend(["--bands-from", str(cnn_bands_from)])
@@ -270,11 +304,22 @@ class DetectorOrchestrator:
         value = self.det_cfg.get("cnn_bands_from")
         return Path(value) if value else self.hybrid_output_dir
 
-    def _copy_precomputed_probe_candidates(self, *, root: Path, images: List[Path], output_root: Path, score_name: str | None) -> int:
+    def _copy_precomputed_probe_candidates(
+        self, *, root: Path, images: List[Path], output_root: Path, score_name: str | None
+    ) -> int:
         processed = 0
         missing: list[str] = []
         for img_path in images:
-            src = next((path for path in _candidate_json_candidates(root=root, image_path=img_path, score_name=score_name) if path.exists()), None)
+            src = next(
+                (
+                    path
+                    for path in _candidate_json_candidates(
+                        root=root, image_path=img_path, score_name=score_name
+                    )
+                    if path.exists()
+                ),
+                None,
+            )
             if src is None:
                 missing.append(str(img_path))
                 continue
@@ -283,7 +328,9 @@ class DetectorOrchestrator:
             shutil.copy2(src, dest_dir / "pipeline2_no_peak_candidates.json")
             processed += 1
         if missing:
-            raise FileNotFoundError("Missing precomputed probe candidates for images:\n" + "\n".join(missing))
+            raise FileNotFoundError(
+                "Missing precomputed probe candidates for images:\n" + "\n".join(missing)
+            )
         return processed
 
 

--- a/src/pipeline/detector_routes/dense_full_pipeline.py
+++ b/src/pipeline/detector_routes/dense_full_pipeline.py
@@ -128,7 +128,9 @@ def _write_compact_log(
 
     with log_path.open("w", encoding="utf-8") as log_file:
         log_file.write("# Compact command log\n")
-        log_file.write("# Full verbose logs are disabled by default for Issue #159 log-volume control.\n")
+        log_file.write(
+            "# Full verbose logs are disabled by default for Issue #159 log-volume control.\n"
+        )
         log_file.write("# Command: " + " ".join(str(part) for part in cmd) + "\n")
         log_file.write(f"# Return code: {returncode}\n")
         log_file.write(f"# Duration seconds: {duration_sec:.3f}\n")
@@ -156,7 +158,9 @@ def _write_compact_log(
     )
 
 
-def _run_command(cmd: list[str], *, log_path: Path, verbose_logs: bool = False) -> CommandLogSummary:
+def _run_command(
+    cmd: list[str], *, log_path: Path, verbose_logs: bool = False
+) -> CommandLogSummary:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     effective_log_path = log_path if verbose_logs else _compact_log_path(log_path)
     logger.info("+ %s > %s", " ".join(cmd), effective_log_path)
@@ -273,7 +277,11 @@ def regenerate_dense_candidates(
     ]
     _add_params(gen_cmd, GENERATION_PARAMS)
     command_summaries.append(
-        _run_command(gen_cmd, log_path=log_dir / "01_generate_probe_candidates.log", verbose_logs=verbose_logs)
+        _run_command(
+            gen_cmd,
+            log_path=log_dir / "01_generate_probe_candidates.log",
+            verbose_logs=verbose_logs,
+        )
     )
 
     filter_cmd = [
@@ -294,7 +302,11 @@ def regenerate_dense_candidates(
     ]
     _add_params(filter_cmd, FILTER_PARAMS)
     command_summaries.append(
-        _run_command(filter_cmd, log_path=log_dir / "02_apply_candidate_filter.log", verbose_logs=verbose_logs)
+        _run_command(
+            filter_cmd,
+            log_path=log_dir / "02_apply_candidate_filter.log",
+            verbose_logs=verbose_logs,
+        )
     )
 
     summary = json.loads(filter_summary.read_text())
@@ -359,7 +371,9 @@ def regenerate_probe_rescue_candidates(
     )
     expected_pages = len(image_paths)
     if processed != expected_pages:
-        raise RuntimeError(f"Probe-rescue candidate reconstruction processed {processed}/{expected_pages} pages")
+        raise RuntimeError(
+            f"Probe-rescue candidate reconstruction processed {processed}/{expected_pages} pages"
+        )
     if phase_summaries is not None:
         phase_summaries.append(
             _phase_summary(

--- a/src/pipeline/detector_routes/dense_probe_candidate.py
+++ b/src/pipeline/detector_routes/dense_probe_candidate.py
@@ -22,11 +22,15 @@ from tools.issue120.eval_full68_from_intermediates import iter_manifest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
-DEFAULT_MODEL = Path("logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth")
+DEFAULT_MODEL = Path(
+    "logs/cnn_barline_classification/issue44_iter7_final_rescue_v1/cnn_classifier_best.pth"
+)
 DEFAULT_OUTPUT_ROOT = Path("logs/issue120_e2e_recovery/dense_probe_candidate_route")
 DEFAULT_HISTORICAL_RAW = Path("logs/issue36_prep/probe_candidates_from_bench_v12")
 DEFAULT_HISTORICAL_FILTERED = Path("logs/issue36_prep/probe_candidates_filtered_v12")
-DEFAULT_HISTORICAL_SCORING_INPUT = Path("logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12")
+DEFAULT_HISTORICAL_SCORING_INPUT = Path(
+    "logs/cnn_barline_classification/issue44_baseline_v1/scoring_input_eval2_v12"
+)
 TARGET_DETECTOR = {"tp": 3580, "fp": 0, "fn": 1}
 REMOVED_CONFIG_KEYS = {"issue53_candidates_root": "probe_rescue_candidates_root"}
 REMOVED_WORKFLOW_KEYS = {
@@ -161,7 +165,9 @@ def require_under_logs(path: Path, *, label: str) -> None:
     try:
         path.resolve().relative_to(logs_root)
     except ValueError as exc:
-        raise ValueError(f"{label} must be under logs/ per repository log-management policy. Got: {path}") from exc
+        raise ValueError(
+            f"{label} must be under logs/ per repository log-management policy. Got: {path}"
+        ) from exc
 
 
 def _reject_removed_keys(config: dict[str, Any], removed: dict[str, str], *, section: str) -> None:
@@ -177,23 +183,33 @@ def resolve_paths(config: DenseProbeCandidateConfig) -> DenseProbeCandidatePaths
     root = config.output_root
     return DenseProbeCandidatePaths(
         raw_candidates_root=config.raw_candidates_root or root / "probe_candidates_from_bench_v12",
-        filtered_candidates_root=config.filtered_candidates_root or root / "probe_candidates_filtered_v12",
+        filtered_candidates_root=config.filtered_candidates_root
+        or root / "probe_candidates_filtered_v12",
         suggestions_root=config.suggestions_root or root / "filter_suggestions_v12",
-        generation_summary=config.generation_summary or root / "probe_generation_summary_v12_current.json",
+        generation_summary=config.generation_summary
+        or root / "probe_generation_summary_v12_current.json",
         filter_summary=config.filter_summary or root / "filter_apply_summary_v12_current.json",
         raw_compare_output_dir=config.raw_compare_output_dir or root / "raw_delta",
         filtered_compare_output_dir=config.filtered_compare_output_dir or root / "filtered_delta",
-        scoring_input_compare_output_dir=config.scoring_input_compare_output_dir or root / "scoring_input_delta",
-        probe_rescue_candidates_root=config.probe_rescue_candidates_root or root / "probe_rescue_candidates",
+        scoring_input_compare_output_dir=config.scoring_input_compare_output_dir
+        or root / "scoring_input_delta",
+        probe_rescue_candidates_root=config.probe_rescue_candidates_root
+        or root / "probe_rescue_candidates",
         scoring_output_dir=config.scoring_output_dir or root / "scoring",
         eval_output_dir=config.eval_output_dir or root / "eval",
         issue36_route_provenance=root / "issue36_dense_candidate_route_provenance.json",
-        route_provenance=config.route_provenance or root / "dense_probe_candidate_route_provenance.json",
+        route_provenance=config.route_provenance
+        or root / "dense_probe_candidate_route_provenance.json",
     )
 
 
-def validate_output_paths(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths) -> None:
-    output_paths = {"output_root": config.output_root, **{field: getattr(paths, field) for field in paths.__dataclass_fields__}}
+def validate_output_paths(
+    config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths
+) -> None:
+    output_paths = {
+        "output_root": config.output_root,
+        **{field: getattr(paths, field) for field in paths.__dataclass_fields__},
+    }
     for label, path in output_paths.items():
         require_under_logs(path, label=label)
 
@@ -209,28 +225,38 @@ def validate_workflow_config(config: DenseProbeCandidateConfig) -> None:
 
 def validate_inputs(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths) -> None:
     validate_workflow_config(config)
-    required = [config.inventory, config.exclude, config.image_root, config.gt_root, config.model_path]
+    required = [
+        config.inventory,
+        config.exclude,
+        config.image_root,
+        config.gt_root,
+        config.model_path,
+    ]
     missing = [str(path) for path in required if not path.exists()]
     if missing:
         raise FileNotFoundError("Missing required inputs:\n" + "\n".join(missing))
     validate_output_paths(config, paths)
 
 
-def cleanup_targets(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths) -> list[Path]:
+def cleanup_targets(
+    config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths
+) -> list[Path]:
     if config.no_clean_output:
         return []
     targets = [paths.scoring_output_dir, paths.eval_output_dir]
     if not config.skip_probe_rescue_regeneration:
         targets.append(paths.probe_rescue_candidates_root)
     if not config.skip_issue36_regeneration:
-        targets.extend([
-            paths.raw_candidates_root,
-            paths.filtered_candidates_root,
-            paths.suggestions_root,
-            paths.raw_compare_output_dir,
-            paths.filtered_compare_output_dir,
-            paths.scoring_input_compare_output_dir,
-        ])
+        targets.extend(
+            [
+                paths.raw_candidates_root,
+                paths.filtered_candidates_root,
+                paths.suggestions_root,
+                paths.raw_compare_output_dir,
+                paths.filtered_compare_output_dir,
+                paths.scoring_input_compare_output_dir,
+            ]
+        )
     return targets
 
 
@@ -251,7 +277,13 @@ def candidate_root_summary(root: Path) -> dict[str, int | str | bool]:
             continue
         if isinstance(payload, list):
             total += len(payload)
-    return {"root": str(root), "exists": root.exists(), "files": len(files), "total_candidates": total, "unreadable": unreadable}
+    return {
+        "root": str(root),
+        "exists": root.exists(),
+        "files": len(files),
+        "total_candidates": total,
+        "unreadable": unreadable,
+    }
 
 
 def load_optional_json(path: Path) -> Any | None:
@@ -296,7 +328,9 @@ def validate_detector_target(eval_output_dir: Path) -> None:
         raise FileNotFoundError(f"Detector metrics not found under {eval_output_dir}")
     observed = {"tp": summary.get("tp"), "fp": summary.get("fp"), "fn": summary.get("fn")}
     if observed != TARGET_DETECTOR:
-        raise RuntimeError(f"Detector target mismatch: observed={observed} target={TARGET_DETECTOR}")
+        raise RuntimeError(
+            f"Detector target mismatch: observed={observed} target={TARGET_DETECTOR}"
+        )
 
 
 def comparison_summary(path: Path) -> dict[str, Any] | None:
@@ -322,40 +356,102 @@ def assert_candidate_match(summary: dict[str, Any] | None, *, label: str) -> Non
         raise RuntimeError(f"{label} candidate-root mismatch: {checks}")
 
 
-def build_generation_command(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths) -> list[str]:
-    cmd = [sys.executable, "tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py", "--inventory", str(config.inventory), "--exclude", str(config.exclude), "--output-root", str(paths.raw_candidates_root), "--summary-out", str(paths.generation_summary)]
+def build_generation_command(
+    config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths
+) -> list[str]:
+    cmd = [
+        sys.executable,
+        "tools/verification/gt_preparation/generate_probe_candidates_from_inventory.py",
+        "--inventory",
+        str(config.inventory),
+        "--exclude",
+        str(config.exclude),
+        "--output-root",
+        str(paths.raw_candidates_root),
+        "--summary-out",
+        str(paths.generation_summary),
+    ]
     add_param_args(cmd, GENERATION_PARAMS)
     return cmd
 
 
-def build_filter_command(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths) -> list[str]:
-    cmd = [sys.executable, "tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py", "--inventory", str(config.inventory), "--exclude", str(config.exclude), "--candidates-root", str(paths.raw_candidates_root), "--output-root", str(paths.filtered_candidates_root), "--suggestions-root", str(paths.suggestions_root), "--summary-out", str(paths.filter_summary)]
+def build_filter_command(
+    config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths
+) -> list[str]:
+    cmd = [
+        sys.executable,
+        "tools/verification/gt_preparation/apply_candidate_filter_from_inventory.py",
+        "--inventory",
+        str(config.inventory),
+        "--exclude",
+        str(config.exclude),
+        "--candidates-root",
+        str(paths.raw_candidates_root),
+        "--output-root",
+        str(paths.filtered_candidates_root),
+        "--suggestions-root",
+        str(paths.suggestions_root),
+        "--summary-out",
+        str(paths.filter_summary),
+    ]
     add_param_args(cmd, FILTER_PARAMS)
     return cmd
 
 
 def build_compare_command(*, left: Path, right: Path, output_dir: Path) -> list[str]:
-    return [sys.executable, "tools/issue120/compare_filter_candidate_deltas.py", "--historical-dir", str(left), "--repro-dir", str(right), "--output-dir", str(output_dir)]
+    return [
+        sys.executable,
+        "tools/issue120/compare_filter_candidate_deltas.py",
+        "--historical-dir",
+        str(left),
+        "--repro-dir",
+        str(right),
+        "--output-dir",
+        str(output_dir),
+    ]
 
 
-def build_coverage_command(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths) -> list[str]:
-    return [sys.executable, "tools/issue120/compare_candidate_coverage.py", "--baseline-dir", str(config.baseline_dir), "--candidate-dir", str(paths.probe_rescue_candidates_root), "--output-dir", str(paths.eval_output_dir)]
+def build_coverage_command(
+    config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths
+) -> list[str]:
+    return [
+        sys.executable,
+        "tools/issue120/compare_candidate_coverage.py",
+        "--baseline-dir",
+        str(config.baseline_dir),
+        "--candidate-dir",
+        str(paths.probe_rescue_candidates_root),
+        "--output-dir",
+        str(paths.eval_output_dir),
+    ]
 
 
-def build_score_eval_command(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths) -> list[str]:
+def build_score_eval_command(
+    config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths
+) -> list[str]:
     cmd = [
         sys.executable,
         "tools/issue120/score_candidates_then_eval_full68.py",
-        "--scorer", config.scorer,
-        "--candidates-dir", str(paths.probe_rescue_candidates_root),
-        "--image-root", str(config.image_root),
-        "--gt-root", str(config.gt_root),
-        "--model-path", str(config.model_path),
-        "--scoring-output-dir", str(paths.scoring_output_dir),
-        "--eval-output-dir", str(paths.eval_output_dir),
-        "--score-threshold", str(config.score_threshold),
-        "--xdist-threshold", str(config.xdist_threshold),
-        "--bands-from", str(paths.filtered_candidates_root),
+        "--scorer",
+        config.scorer,
+        "--candidates-dir",
+        str(paths.probe_rescue_candidates_root),
+        "--image-root",
+        str(config.image_root),
+        "--gt-root",
+        str(config.gt_root),
+        "--model-path",
+        str(config.model_path),
+        "--scoring-output-dir",
+        str(paths.scoring_output_dir),
+        "--eval-output-dir",
+        str(paths.eval_output_dir),
+        "--score-threshold",
+        str(config.score_threshold),
+        "--xdist-threshold",
+        str(config.xdist_threshold),
+        "--bands-from",
+        str(paths.filtered_candidates_root),
     ]
     if not config.no_clean_output:
         cmd.append("--clean-output")
@@ -365,10 +461,26 @@ def build_score_eval_command(config: DenseProbeCandidateConfig, paths: DenseProb
 
 
 def build_attach_provenance_command(paths: DenseProbeCandidatePaths) -> list[str]:
-    return [sys.executable, "tools/issue120/attach_eval_provenance.py", "--output-dir", str(paths.eval_output_dir), "--results-dir", str(paths.scoring_output_dir), "--provenance-json", str(paths.route_provenance)]
+    return [
+        sys.executable,
+        "tools/issue120/attach_eval_provenance.py",
+        "--output-dir",
+        str(paths.eval_output_dir),
+        "--results-dir",
+        str(paths.scoring_output_dir),
+        "--provenance-json",
+        str(paths.route_provenance),
+    ]
 
 
-def run_candidate_comparison(*, left: Path, right: Path, output_dir: Path, label: str, command_runner: CommandRunner = run_command) -> dict[str, Any] | None:
+def run_candidate_comparison(
+    *,
+    left: Path,
+    right: Path,
+    output_dir: Path,
+    label: str,
+    command_runner: CommandRunner = run_command,
+) -> dict[str, Any] | None:
     if not left.exists():
         print(f"Skipping {label} comparison: historical root not found: {left}", flush=True)
         return None
@@ -376,18 +488,43 @@ def run_candidate_comparison(*, left: Path, right: Path, output_dir: Path, label
     return comparison_summary(output_dir / "filter_candidate_delta_summary.json")
 
 
-def run_issue36_generation_filter_compare(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths, *, command_runner: CommandRunner = run_command) -> dict[str, Any]:
+def run_issue36_generation_filter_compare(
+    config: DenseProbeCandidateConfig,
+    paths: DenseProbeCandidatePaths,
+    *,
+    command_runner: CommandRunner = run_command,
+) -> dict[str, Any]:
     command_runner(build_generation_command(config, paths))
     command_runner(build_filter_command(config, paths))
     comparisons = {
-        "raw": run_candidate_comparison(left=config.historical_raw_candidates_root, right=paths.raw_candidates_root, output_dir=paths.raw_compare_output_dir, label="raw", command_runner=command_runner),
-        "filtered": run_candidate_comparison(left=config.historical_filtered_candidates_root, right=paths.filtered_candidates_root, output_dir=paths.filtered_compare_output_dir, label="filtered", command_runner=command_runner),
-        "historical_scoring_input": run_candidate_comparison(left=config.historical_scoring_input_root, right=paths.filtered_candidates_root, output_dir=paths.scoring_input_compare_output_dir, label="historical scoring input", command_runner=command_runner),
+        "raw": run_candidate_comparison(
+            left=config.historical_raw_candidates_root,
+            right=paths.raw_candidates_root,
+            output_dir=paths.raw_compare_output_dir,
+            label="raw",
+            command_runner=command_runner,
+        ),
+        "filtered": run_candidate_comparison(
+            left=config.historical_filtered_candidates_root,
+            right=paths.filtered_candidates_root,
+            output_dir=paths.filtered_compare_output_dir,
+            label="filtered",
+            command_runner=command_runner,
+        ),
+        "historical_scoring_input": run_candidate_comparison(
+            left=config.historical_scoring_input_root,
+            right=paths.filtered_candidates_root,
+            output_dir=paths.scoring_input_compare_output_dir,
+            label="historical scoring input",
+            command_runner=command_runner,
+        ),
     }
     if config.require_candidate_match:
         assert_candidate_match(comparisons.get("raw"), label="raw")
         assert_candidate_match(comparisons.get("filtered"), label="filtered")
-        assert_candidate_match(comparisons.get("historical_scoring_input"), label="historical scoring input")
+        assert_candidate_match(
+            comparisons.get("historical_scoring_input"), label="historical scoring input"
+        )
     return comparisons
 
 
@@ -405,8 +542,19 @@ def canonical_images(image_root: Path) -> list[Path]:
     return images
 
 
-def run_probe_rescue_candidate_generation(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths) -> int:
-    detect_probe_kwargs = {"scan_gap_rescue": True, "scan_gap_threshold_ratio": 1.5, "scan_gap_rescue_min_ratio": 0.3, "scan_x_peak_rescue": True, "scan_rightmost_rescue": True, "divisi_rescue": True, "scan_center_on_peak": True, "max_per_band": 100}
+def run_probe_rescue_candidate_generation(
+    config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths
+) -> int:
+    detect_probe_kwargs = {
+        "scan_gap_rescue": True,
+        "scan_gap_threshold_ratio": 1.5,
+        "scan_gap_rescue_min_ratio": 0.3,
+        "scan_x_peak_rescue": True,
+        "scan_rightmost_rescue": True,
+        "divisi_rescue": True,
+        "scan_center_on_peak": True,
+        "max_per_band": 100,
+    }
     return run_probe_scan_batch(
         images=canonical_images(config.image_root),
         output_root=paths.probe_rescue_candidates_root,
@@ -424,15 +572,29 @@ def run_probe_rescue_candidate_generation(config: DenseProbeCandidateConfig, pat
     )
 
 
-def run_scoring_eval_and_coverage(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths, *, command_runner: CommandRunner = run_command) -> None:
+def run_scoring_eval_and_coverage(
+    config: DenseProbeCandidateConfig,
+    paths: DenseProbeCandidatePaths,
+    *,
+    command_runner: CommandRunner = run_command,
+) -> None:
     command_runner(build_score_eval_command(config, paths))
     command_runner(build_coverage_command(config, paths))
 
 
-def build_route_provenance(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths, *, comparisons: dict[str, Any] | None) -> dict[str, Any]:
+def build_route_provenance(
+    config: DenseProbeCandidateConfig,
+    paths: DenseProbeCandidatePaths,
+    *,
+    comparisons: dict[str, Any] | None,
+) -> dict[str, Any]:
     filter_summary = load_optional_json(paths.filter_summary)
-    clef_mask_resolution = filter_summary.get("clef_mask_resolution") if isinstance(filter_summary, dict) else None
-    reason_counts = filter_summary.get("reason_counts") if isinstance(filter_summary, dict) else None
+    clef_mask_resolution = (
+        filter_summary.get("clef_mask_resolution") if isinstance(filter_summary, dict) else None
+    )
+    reason_counts = (
+        filter_summary.get("reason_counts") if isinstance(filter_summary, dict) else None
+    )
     return {
         "schema_version": "pipeline.detector_routes.dense_probe_candidate.v1",
         "status": "detector_level_dense_probe_candidate_route",
@@ -443,44 +605,137 @@ def build_route_provenance(config: DenseProbeCandidateConfig, paths: DenseProbeC
         "evaluated_stage": "post_cnn_scoring_detector_intermediate",
         "pipeline_scope": {
             "level": "detector_level_partial_route",
-            "includes": ["dense candidate/bands generation", "clef-mask-aware filtering", "probe-rescue candidate generation", "CNN scoring", "canonical detector evaluation"],
-            "excludes": ["slow HOMR/SR/OMR upstream generation", "full end-to-end PDF pipeline execution", "downstream measure numbering and measure-count evaluation"],
+            "includes": [
+                "dense candidate/bands generation",
+                "clef-mask-aware filtering",
+                "probe-rescue candidate generation",
+                "CNN scoring",
+                "canonical detector evaluation",
+            ],
+            "excludes": [
+                "slow HOMR/SR/OMR upstream generation",
+                "full end-to-end PDF pipeline execution",
+                "downstream measure numbering and measure-count evaluation",
+            ],
         },
-        "route": ["Issue #36 v12 bench inventory", "generate dense raw candidates with band_cluster_max_dist=25.0", "apply clef-mask-aware filtering", "verify raw/filtered/scoring-input candidate roots when references are supplied", "use regenerated filtered root as probe-rescue bands_from", "score regenerated probe-rescue candidates with current CNN scoring", "#134 full-68 detector evaluator"],
-        "inputs": {"inventory": str(config.inventory), "exclude": str(config.exclude), "image_root": str(config.image_root), "gt_root": str(config.gt_root), "model_path": str(config.model_path), "baseline_dir": str(config.baseline_dir), "historical_raw_candidates_root": str(config.historical_raw_candidates_root), "historical_filtered_candidates_root": str(config.historical_filtered_candidates_root), "historical_scoring_input_root": str(config.historical_scoring_input_root)},
-        "outputs": {"output_root": str(config.output_root), "raw_candidates_root": str(paths.raw_candidates_root), "filtered_candidates_root": str(paths.filtered_candidates_root), "filter_suggestions_root": str(paths.suggestions_root), "probe_rescue_candidates_root": str(paths.probe_rescue_candidates_root), "scoring_output_dir": str(paths.scoring_output_dir), "eval_output_dir": str(paths.eval_output_dir), "route_provenance": str(paths.route_provenance)},
-        "candidate_root_summary": {"issue36_raw": candidate_root_summary(paths.raw_candidates_root), "issue36_filtered_bands_from": candidate_root_summary(paths.filtered_candidates_root), "probe_rescue_regenerated_candidates": candidate_root_summary(paths.probe_rescue_candidates_root), "scoring_input": candidate_root_summary(paths.scoring_output_dir)},
+        "route": [
+            "Issue #36 v12 bench inventory",
+            "generate dense raw candidates with band_cluster_max_dist=25.0",
+            "apply clef-mask-aware filtering",
+            "verify raw/filtered/scoring-input candidate roots when references are supplied",
+            "use regenerated filtered root as probe-rescue bands_from",
+            "score regenerated probe-rescue candidates with current CNN scoring",
+            "#134 full-68 detector evaluator",
+        ],
+        "inputs": {
+            "inventory": str(config.inventory),
+            "exclude": str(config.exclude),
+            "image_root": str(config.image_root),
+            "gt_root": str(config.gt_root),
+            "model_path": str(config.model_path),
+            "baseline_dir": str(config.baseline_dir),
+            "historical_raw_candidates_root": str(config.historical_raw_candidates_root),
+            "historical_filtered_candidates_root": str(config.historical_filtered_candidates_root),
+            "historical_scoring_input_root": str(config.historical_scoring_input_root),
+        },
+        "outputs": {
+            "output_root": str(config.output_root),
+            "raw_candidates_root": str(paths.raw_candidates_root),
+            "filtered_candidates_root": str(paths.filtered_candidates_root),
+            "filter_suggestions_root": str(paths.suggestions_root),
+            "probe_rescue_candidates_root": str(paths.probe_rescue_candidates_root),
+            "scoring_output_dir": str(paths.scoring_output_dir),
+            "eval_output_dir": str(paths.eval_output_dir),
+            "route_provenance": str(paths.route_provenance),
+        },
+        "candidate_root_summary": {
+            "issue36_raw": candidate_root_summary(paths.raw_candidates_root),
+            "issue36_filtered_bands_from": candidate_root_summary(paths.filtered_candidates_root),
+            "probe_rescue_regenerated_candidates": candidate_root_summary(
+                paths.probe_rescue_candidates_root
+            ),
+            "scoring_input": candidate_root_summary(paths.scoring_output_dir),
+        },
         "candidate_root_comparisons": comparisons or {},
         "issue36_provenance": load_optional_json(paths.issue36_route_provenance),
         "generation_params": GENERATION_PARAMS,
         "filter_params": FILTER_PARAMS,
-        "clef_mask_filtering": {"enabled": True, "resolution": clef_mask_resolution, "reason_counts": reason_counts, "summary_path": str(paths.filter_summary)},
-        "probe_rescue": {"bands_from": str(paths.filtered_candidates_root), "candidate_coverage_summary": load_optional_json(paths.eval_output_dir / "candidate_coverage_summary.json")},
-        "cnn_scoring": {"scorer": config.scorer, "cnn_apply_nms": config.cnn_apply_nms, "model_path": str(config.model_path), "score_threshold": config.score_threshold, "xdist_threshold": config.xdist_threshold, "stage_b_provenance": load_optional_json(paths.eval_output_dir / "stage_b_provenance.json")},
+        "clef_mask_filtering": {
+            "enabled": True,
+            "resolution": clef_mask_resolution,
+            "reason_counts": reason_counts,
+            "summary_path": str(paths.filter_summary),
+        },
+        "probe_rescue": {
+            "bands_from": str(paths.filtered_candidates_root),
+            "candidate_coverage_summary": load_optional_json(
+                paths.eval_output_dir / "candidate_coverage_summary.json"
+            ),
+        },
+        "cnn_scoring": {
+            "scorer": config.scorer,
+            "cnn_apply_nms": config.cnn_apply_nms,
+            "model_path": str(config.model_path),
+            "score_threshold": config.score_threshold,
+            "xdist_threshold": config.xdist_threshold,
+            "stage_b_provenance": load_optional_json(
+                paths.eval_output_dir / "stage_b_provenance.json"
+            ),
+        },
         "detector_target": TARGET_DETECTOR,
         "detector_summary": detector_summary(paths.eval_output_dir),
-        "measure_count_summary": {"status": "not_run_in_dense_probe_candidate_route", "note": "Detector metrics are evaluated here. Downstream measure-count validation remains a separate artifact/provenance stream."},
-        "scope_guards": {"general_pipeline_defaults_changed": False, "nms_policy_owner": "#142", "full_slow_pipeline_owner": "#141", "generated_outputs_under_ignored_logs": True, "direct_scoring_of_issue36_filtered_root_is_acceptance_route": False},
-        "incremental_debug": {"no_clean_output": config.no_clean_output, "skip_issue36_regeneration": config.skip_issue36_regeneration, "skip_probe_rescue_regeneration": config.skip_probe_rescue_regeneration, "skip_existing_probe_rescue": config.skip_existing_probe_rescue},
+        "measure_count_summary": {
+            "status": "not_run_in_dense_probe_candidate_route",
+            "note": "Detector metrics are evaluated here. Downstream measure-count validation remains a separate artifact/provenance stream.",
+        },
+        "scope_guards": {
+            "general_pipeline_defaults_changed": False,
+            "nms_policy_owner": "#142",
+            "full_slow_pipeline_owner": "#141",
+            "generated_outputs_under_ignored_logs": True,
+            "direct_scoring_of_issue36_filtered_root_is_acceptance_route": False,
+        },
+        "incremental_debug": {
+            "no_clean_output": config.no_clean_output,
+            "skip_issue36_regeneration": config.skip_issue36_regeneration,
+            "skip_probe_rescue_regeneration": config.skip_probe_rescue_regeneration,
+            "skip_existing_probe_rescue": config.skip_existing_probe_rescue,
+        },
         "generation_summary": load_optional_json(paths.generation_summary),
         "filter_summary": filter_summary,
     }
 
 
-def attach_route_provenance(config: DenseProbeCandidateConfig, paths: DenseProbeCandidatePaths, *, comparisons: dict[str, Any] | None, command_runner: CommandRunner = run_command) -> None:
-    write_json(paths.route_provenance, build_route_provenance(config, paths, comparisons=comparisons))
+def attach_route_provenance(
+    config: DenseProbeCandidateConfig,
+    paths: DenseProbeCandidatePaths,
+    *,
+    comparisons: dict[str, Any] | None,
+    command_runner: CommandRunner = run_command,
+) -> None:
+    write_json(
+        paths.route_provenance, build_route_provenance(config, paths, comparisons=comparisons)
+    )
     command_runner(build_attach_provenance_command(paths))
 
 
-def run_dense_probe_candidate_route(config: DenseProbeCandidateConfig, *, command_runner: CommandRunner = run_command) -> dict[str, Any] | None:
+def run_dense_probe_candidate_route(
+    config: DenseProbeCandidateConfig, *, command_runner: CommandRunner = run_command
+) -> dict[str, Any] | None:
     paths = resolve_paths(config)
     validate_inputs(config, paths)
     clean_outputs(config, paths)
     config.output_root.mkdir(parents=True, exist_ok=True)
-    effective_runner = make_logged_command_runner(config.output_root / "command_logs") if command_runner is run_command else command_runner
+    effective_runner = (
+        make_logged_command_runner(config.output_root / "command_logs")
+        if command_runner is run_command
+        else command_runner
+    )
     comparisons = None
     if not config.skip_issue36_regeneration:
-        comparisons = run_issue36_generation_filter_compare(config, paths, command_runner=effective_runner)
+        comparisons = run_issue36_generation_filter_compare(
+            config, paths, command_runner=effective_runner
+        )
     if not config.skip_probe_rescue_regeneration:
         processed = run_probe_rescue_candidate_generation(config, paths)
         print(f"Probe-rescue regeneration processed pages: {processed}")
@@ -513,43 +768,134 @@ def config_from_yaml(path: Path) -> DenseProbeCandidateConfig:
     workflow = route.get("workflow", {}) or {}
     if not isinstance(workflow, dict):
         raise ValueError("dense_probe_candidate_route.workflow must be a mapping.")
-    _reject_removed_keys(workflow, REMOVED_WORKFLOW_KEYS, section="dense_probe_candidate_route.workflow")
+    _reject_removed_keys(
+        workflow, REMOVED_WORKFLOW_KEYS, section="dense_probe_candidate_route.workflow"
+    )
     return DenseProbeCandidateConfig(
-        inventory=_path_from_config(route, "inventory", default=DenseProbeCandidateConfig.inventory),
+        inventory=_path_from_config(
+            route, "inventory", default=DenseProbeCandidateConfig.inventory
+        ),
         exclude=_path_from_config(route, "exclude", default=DenseProbeCandidateConfig.exclude),
-        image_root=_path_from_config(route, "image_root", default=DenseProbeCandidateConfig.image_root),
+        image_root=_path_from_config(
+            route, "image_root", default=DenseProbeCandidateConfig.image_root
+        ),
         gt_root=_path_from_config(route, "gt_root", default=DenseProbeCandidateConfig.gt_root),
-        model_path=_path_from_config(route, "model_path", default=DenseProbeCandidateConfig.model_path),
-        baseline_dir=_path_from_config(route, "baseline_dir", default=DenseProbeCandidateConfig.baseline_dir),
-        output_root=_path_from_config(route, "output_root", default=DenseProbeCandidateConfig.output_root),
-        historical_raw_candidates_root=_path_from_config(route, "historical_raw_candidates_root", default=DenseProbeCandidateConfig.historical_raw_candidates_root),
-        historical_filtered_candidates_root=_path_from_config(route, "historical_filtered_candidates_root", default=DenseProbeCandidateConfig.historical_filtered_candidates_root),
-        historical_scoring_input_root=_path_from_config(route, "historical_scoring_input_root", default=DenseProbeCandidateConfig.historical_scoring_input_root),
-        probe_rescue_candidates_root=_path_from_config(route, "probe_rescue_candidates_root", default=DenseProbeCandidateConfig.probe_rescue_candidates_root),
+        model_path=_path_from_config(
+            route, "model_path", default=DenseProbeCandidateConfig.model_path
+        ),
+        baseline_dir=_path_from_config(
+            route, "baseline_dir", default=DenseProbeCandidateConfig.baseline_dir
+        ),
+        output_root=_path_from_config(
+            route, "output_root", default=DenseProbeCandidateConfig.output_root
+        ),
+        historical_raw_candidates_root=_path_from_config(
+            route,
+            "historical_raw_candidates_root",
+            default=DenseProbeCandidateConfig.historical_raw_candidates_root,
+        ),
+        historical_filtered_candidates_root=_path_from_config(
+            route,
+            "historical_filtered_candidates_root",
+            default=DenseProbeCandidateConfig.historical_filtered_candidates_root,
+        ),
+        historical_scoring_input_root=_path_from_config(
+            route,
+            "historical_scoring_input_root",
+            default=DenseProbeCandidateConfig.historical_scoring_input_root,
+        ),
+        probe_rescue_candidates_root=_path_from_config(
+            route,
+            "probe_rescue_candidates_root",
+            default=DenseProbeCandidateConfig.probe_rescue_candidates_root,
+        ),
         scorer=str(scoring.get("scorer", DenseProbeCandidateConfig.scorer)),
         cnn_apply_nms=bool(scoring.get("cnn_apply_nms", DenseProbeCandidateConfig.cnn_apply_nms)),
-        score_threshold=float(scoring.get("score_threshold", DenseProbeCandidateConfig.score_threshold)),
-        xdist_threshold=float(scoring.get("xdist_threshold", DenseProbeCandidateConfig.xdist_threshold)),
-        no_clean_output=bool(workflow.get("no_clean_output", DenseProbeCandidateConfig.no_clean_output)),
-        skip_issue36_regeneration=bool(workflow.get("skip_issue36_regeneration", DenseProbeCandidateConfig.skip_issue36_regeneration)),
-        skip_probe_rescue_regeneration=bool(workflow.get("skip_probe_rescue_regeneration", DenseProbeCandidateConfig.skip_probe_rescue_regeneration)),
-        skip_existing_probe_rescue=bool(workflow.get("skip_existing_probe_rescue", DenseProbeCandidateConfig.skip_existing_probe_rescue)),
-        require_candidate_match=bool(workflow.get("require_candidate_match", DenseProbeCandidateConfig.require_candidate_match)),
-        require_detector_target=bool(workflow.get("require_detector_target", DenseProbeCandidateConfig.require_detector_target)),
-        disable_seed_splitting=bool(workflow.get("disable_seed_splitting", DenseProbeCandidateConfig.disable_seed_splitting)),
+        score_threshold=float(
+            scoring.get("score_threshold", DenseProbeCandidateConfig.score_threshold)
+        ),
+        xdist_threshold=float(
+            scoring.get("xdist_threshold", DenseProbeCandidateConfig.xdist_threshold)
+        ),
+        no_clean_output=bool(
+            workflow.get("no_clean_output", DenseProbeCandidateConfig.no_clean_output)
+        ),
+        skip_issue36_regeneration=bool(
+            workflow.get(
+                "skip_issue36_regeneration", DenseProbeCandidateConfig.skip_issue36_regeneration
+            )
+        ),
+        skip_probe_rescue_regeneration=bool(
+            workflow.get(
+                "skip_probe_rescue_regeneration",
+                DenseProbeCandidateConfig.skip_probe_rescue_regeneration,
+            )
+        ),
+        skip_existing_probe_rescue=bool(
+            workflow.get(
+                "skip_existing_probe_rescue", DenseProbeCandidateConfig.skip_existing_probe_rescue
+            )
+        ),
+        require_candidate_match=bool(
+            workflow.get(
+                "require_candidate_match", DenseProbeCandidateConfig.require_candidate_match
+            )
+        ),
+        require_detector_target=bool(
+            workflow.get(
+                "require_detector_target", DenseProbeCandidateConfig.require_detector_target
+            )
+        ),
+        disable_seed_splitting=bool(
+            workflow.get("disable_seed_splitting", DenseProbeCandidateConfig.disable_seed_splitting)
+        ),
     )
 
 
 def config_from_args(args: argparse.Namespace) -> DenseProbeCandidateConfig:
     config = config_from_yaml(args.config) if args.config else DenseProbeCandidateConfig()
     values = config.__dict__.copy()
-    overrides = {"inventory": args.inventory, "exclude": args.exclude, "image_root": args.image_root, "gt_root": args.gt_root, "model_path": args.model_path, "baseline_dir": args.baseline_dir, "output_root": args.output_root, "historical_raw_candidates_root": args.historical_raw_candidates_root, "historical_filtered_candidates_root": args.historical_filtered_candidates_root, "historical_scoring_input_root": args.historical_scoring_input_root, "raw_candidates_root": args.raw_candidates_root, "filtered_candidates_root": args.filtered_candidates_root, "suggestions_root": args.suggestions_root, "generation_summary": args.generation_summary, "filter_summary": args.filter_summary, "raw_compare_output_dir": args.raw_compare_output_dir, "filtered_compare_output_dir": args.filtered_compare_output_dir, "scoring_input_compare_output_dir": args.scoring_input_compare_output_dir, "probe_rescue_candidates_root": args.probe_rescue_candidates_root, "scoring_output_dir": args.scoring_output_dir, "eval_output_dir": args.eval_output_dir, "route_provenance": args.route_provenance, "scorer": args.scorer, "score_threshold": args.score_threshold, "xdist_threshold": args.xdist_threshold}
+    overrides = {
+        "inventory": args.inventory,
+        "exclude": args.exclude,
+        "image_root": args.image_root,
+        "gt_root": args.gt_root,
+        "model_path": args.model_path,
+        "baseline_dir": args.baseline_dir,
+        "output_root": args.output_root,
+        "historical_raw_candidates_root": args.historical_raw_candidates_root,
+        "historical_filtered_candidates_root": args.historical_filtered_candidates_root,
+        "historical_scoring_input_root": args.historical_scoring_input_root,
+        "raw_candidates_root": args.raw_candidates_root,
+        "filtered_candidates_root": args.filtered_candidates_root,
+        "suggestions_root": args.suggestions_root,
+        "generation_summary": args.generation_summary,
+        "filter_summary": args.filter_summary,
+        "raw_compare_output_dir": args.raw_compare_output_dir,
+        "filtered_compare_output_dir": args.filtered_compare_output_dir,
+        "scoring_input_compare_output_dir": args.scoring_input_compare_output_dir,
+        "probe_rescue_candidates_root": args.probe_rescue_candidates_root,
+        "scoring_output_dir": args.scoring_output_dir,
+        "eval_output_dir": args.eval_output_dir,
+        "route_provenance": args.route_provenance,
+        "scorer": args.scorer,
+        "score_threshold": args.score_threshold,
+        "xdist_threshold": args.xdist_threshold,
+    }
     for key, value in overrides.items():
         if value is not None:
             values[key] = value
     if args.pipeline_nms is not None:
         values["cnn_apply_nms"] = args.pipeline_nms
-    for flag in ["no_clean_output", "skip_issue36_regeneration", "skip_probe_rescue_regeneration", "skip_existing_probe_rescue", "require_candidate_match", "require_detector_target", "disable_seed_splitting"]:
+    for flag in [
+        "no_clean_output",
+        "skip_issue36_regeneration",
+        "skip_probe_rescue_regeneration",
+        "skip_existing_probe_rescue",
+        "require_candidate_match",
+        "require_detector_target",
+        "disable_seed_splitting",
+    ]:
         if getattr(args, flag):
             values[flag] = True
     if args.no_require_candidate_match:
@@ -583,7 +929,12 @@ def build_arg_parser(description: str | None = None) -> argparse.ArgumentParser:
     parser.add_argument("--eval-output-dir", type=Path, default=None)
     parser.add_argument("--route-provenance", type=Path, default=None)
     parser.add_argument("--scorer", choices=["pipeline", "legacy"], default=None)
-    parser.add_argument("--pipeline-nms", action=argparse.BooleanOptionalAction, default=None, help="Explicit CNN NMS setting. Issue #120 dense route uses --no-pipeline-nms.")
+    parser.add_argument(
+        "--pipeline-nms",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Explicit CNN NMS setting. Issue #120 dense route uses --no-pipeline-nms.",
+    )
     parser.add_argument("--score-threshold", type=float, default=None)
     parser.add_argument("--xdist-threshold", type=float, default=None)
     parser.add_argument("--no-clean-output", action="store_true")
@@ -604,7 +955,9 @@ def main(argv: list[str] | None = None) -> None:
     paths = resolve_paths(config)
     print(f"Dense probe-candidate route complete: {paths.eval_output_dir}")
     if summary:
-        print(f"Detector: TP={summary.get('tp')} FP={summary.get('fp')} FN={summary.get('fn')} Pred={summary.get('pred')} GT={summary.get('gt')}")
+        print(
+            f"Detector: TP={summary.get('tp')} FP={summary.get('fp')} FN={summary.get('fn')} Pred={summary.get('pred')} GT={summary.get('gt')}"
+        )
 
 
 if __name__ == "__main__":

--- a/src/pipeline/detector_routes/stage_e_dense_full_pipeline.py
+++ b/src/pipeline/detector_routes/stage_e_dense_full_pipeline.py
@@ -14,8 +14,10 @@ from src.pipeline.detector_routes.dense_full_pipeline import (  # noqa: F401
     DenseRouteArtifacts,
     load_route_image_paths,
     reconstruct_dense_full_pipeline_route,
-    regenerate_dense_candidates as _regenerate_dense_candidates,
     regenerate_probe_rescue_candidates,
+)
+from src.pipeline.detector_routes.dense_full_pipeline import (
+    regenerate_dense_candidates as _regenerate_dense_candidates,
 )
 
 STAGE_E_EXPECTED_PAGES = DENSE_ROUTE_EXPECTED_PAGES
@@ -53,7 +55,9 @@ def regenerate_dense_candidates(*, inventory: Path, exclude: Path, stage_e_root:
     )
 
 
-def regenerate_issue53_candidates(*, image_paths: list[Path], filtered_root: Path, stage_e_root: Path) -> Path:
+def regenerate_issue53_candidates(
+    *, image_paths: list[Path], filtered_root: Path, stage_e_root: Path
+) -> Path:
     """Compatibility wrapper for the historical Issue53-style rescue name."""
     return regenerate_probe_rescue_candidates(
         image_paths=image_paths,

--- a/src/pipeline/main.py
+++ b/src/pipeline/main.py
@@ -31,6 +31,7 @@ def run_pipeline(
     skip_existing: bool = False,
     page_limit: Optional[int] = None,
     debug: bool = False,
+    console_log_level: int = logging.INFO,
 ) -> Path:
     """Entry point for running the full pipeline."""
     from src.pipeline.utils.images import clear_image_cache
@@ -64,7 +65,8 @@ def run_pipeline(
     root_logger.setLevel(logging.DEBUG)
     root_logger.addHandler(file_handler)
 
-    # Ensure the existing console handler (from basicConfig) stays at INFO
+    # Keep the file log diagnostic, while allowing callers such as Stage E to
+    # make non-interactive captured stdout/stderr quieter by default.
     old_handler_levels = []
     for handler in root_logger.handlers:
         if handler == file_handler:
@@ -73,7 +75,7 @@ def run_pipeline(
         if isinstance(handler, logging.StreamHandler) and not isinstance(
             handler, logging.FileHandler
         ):
-            handler.setLevel(logging.INFO)
+            handler.setLevel(console_log_level)
 
     try:
         logger.info(f"Starting pipeline run: {run_id_value}")

--- a/tests/test_dense_probe_candidate_route.py
+++ b/tests/test_dense_probe_candidate_route.py
@@ -86,9 +86,7 @@ def test_dense_probe_candidate_yaml_config_round_trip():
 def test_dense_probe_candidate_yaml_rejects_legacy_issue53_keys(tmp_path):
     config_path = tmp_path / "route.yaml"
     config_path.write_text(
-        "dense_probe_candidate_route:\n"
-        "  workflow:\n"
-        "    skip_issue53_regeneration: true\n",
+        "dense_probe_candidate_route:\n  workflow:\n    skip_issue53_regeneration: true\n",
         encoding="utf-8",
     )
 

--- a/tests/test_pipeline_detection.py
+++ b/tests/test_pipeline_detection.py
@@ -205,7 +205,13 @@ class TestPipelineDetection(unittest.TestCase):
                     dry_run=False,
                 )
 
-            copied = tmp / "intermediate" / "probe_scan" / "eval2_images_Score_page_001" / "pipeline2_no_peak_candidates.json"
+            copied = (
+                tmp
+                / "intermediate"
+                / "probe_scan"
+                / "eval2_images_Score_page_001"
+                / "pipeline2_no_peak_candidates.json"
+            )
             self.assertTrue(copied.exists())
             mock_probe.assert_not_called()
             mock_cnn.assert_called_once()

--- a/tools/issue120/Makefile.stage_e.mk
+++ b/tools/issue120/Makefile.stage_e.mk
@@ -6,7 +6,12 @@ ISSUE120_STAGE_E_EXTRA_ARGS ?=
 
 run-issue120-stage-e-full: ## Run the full 68-page pipeline inside sr_eval_gpu container
 	@echo "Running Full Stage E Pipeline inside sr_eval_gpu..."
-	@docker run --rm --gpus all -v $(PWD):/workspace -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_gpu \
+	@docker run --rm --gpus all -v $(PWD):/workspace -w /workspace \
+		-e PYTHONPATH=/workspace \
+		-e PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS \
+		-e PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS \
+		-e PDFSCORE_SR_TILE_LOGS \
+		pdfscore_pipeline_gpu \
 		/bin/sh -lc '/opt/venv_pipeline/bin/python tools/issue120/run_stage_e_full_pipeline.py --config $(ISSUE120_STAGE_E_CONFIG) --output-root $(ISSUE120_STAGE_E_OUTPUT) $(ISSUE120_STAGE_E_EXTRA_ARGS); status=$$?; chmod -R a+rwX $(ISSUE120_STAGE_E_OUTPUT)/stage_e_full_pipeline 2>/dev/null || true; exit $$status'
 
 eval-issue120-stage-e-full: ## Evaluate Stage E detector metrics from manifest

--- a/tools/issue120/diagnose_stage_e_fns.py
+++ b/tools/issue120/diagnose_stage_e_fns.py
@@ -123,12 +123,26 @@ def first_existing(*paths: Path) -> Path:
 def stage_paths(args: argparse.Namespace, score: str, page: str) -> dict[str, Path]:
     recon = args.reconstruction_root
     probe_rescue = first_existing(
-        recon / "probe_rescue_candidates" / f"eval2_{score}_{page}" / "pipeline2_no_peak_candidates.json",
-        recon / "issue53_probe_rescue_candidates" / f"eval2_{score}_{page}" / "pipeline2_no_peak_candidates.json",
+        recon
+        / "probe_rescue_candidates"
+        / f"eval2_{score}_{page}"
+        / "pipeline2_no_peak_candidates.json",
+        recon
+        / "issue53_probe_rescue_candidates"
+        / f"eval2_{score}_{page}"
+        / "pipeline2_no_peak_candidates.json",
     )
     return {
-        "dense_raw": recon / "probe_candidates_from_inventory" / score / page / "pipeline2_no_peak_candidates.json",
-        "dense_filtered": recon / "probe_candidates_filtered" / score / page / "pipeline2_no_peak_candidates.json",
+        "dense_raw": recon
+        / "probe_candidates_from_inventory"
+        / score
+        / page
+        / "pipeline2_no_peak_candidates.json",
+        "dense_filtered": recon
+        / "probe_candidates_filtered"
+        / score
+        / page
+        / "pipeline2_no_peak_candidates.json",
         "probe_rescue": probe_rescue,
     }
 
@@ -163,7 +177,9 @@ def diagnose(args: argparse.Namespace) -> dict[str, Any]:
             dense_filtered = safe_boxes(
                 extra_paths["dense_filtered"], "candidate", args.score_threshold
             )
-            probe_rescue = safe_boxes(extra_paths["probe_rescue"], "candidate", args.score_threshold)
+            probe_rescue = safe_boxes(
+                extra_paths["probe_rescue"], "candidate", args.score_threshold
+            )
 
             result = greedy_barline_match(
                 preds,

--- a/tools/issue120/eval_stage_e_from_manifest.py
+++ b/tools/issue120/eval_stage_e_from_manifest.py
@@ -19,20 +19,16 @@ from src.common.barline_evaluation import greedy_barline_match, is_barline_match
 
 # Canonical Issue #120 evaluation2 page set: 68 pages.
 SCORES: dict[str, list[str]] = {
-    "Shostakovich-Festival_Overture_Va": [
-        f"page_{i:03d}" for i in range(1, 10)
-    ],
+    "Shostakovich-Festival_Overture_Va": [f"page_{i:03d}" for i in range(1, 10)],
     "Shostakovich-Sym5-Va": [
-        f"page_{i:03d}" for i in [2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,18,19,20,21,22,24,25]
+        f"page_{i:03d}"
+        for i in [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 22, 24, 25]
     ],
-    "Sibelius-Violin_Concerto-Viola": [
-        f"page_{i:03d}" for i in range(1, 11)
-    ],
-    "Va_Prokofiev_Symphony1": [
-        f"page_{i:03d}" for i in range(1, 7)
-    ],
+    "Sibelius-Violin_Concerto-Viola": [f"page_{i:03d}" for i in range(1, 11)],
+    "Va_Prokofiev_Symphony1": [f"page_{i:03d}" for i in range(1, 7)],
     "Va__Prokofiev_Symphony5": [
-        f"page_{i:03d}" for i in [1,2,3,4,5,7,8,9,10,11,13,14,15,16,17,18,19,20,21,22,23]
+        f"page_{i:03d}"
+        for i in [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
     ],
 }
 
@@ -77,12 +73,15 @@ def boxes_from_candidates(payload):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--manifest", type=Path, required=True,
-                        help="Path to the pipeline manifest.json")
-    parser.add_argument("--gt-root", type=Path,
-                        default="data/evaluation2/annotations")
-    parser.add_argument("--output-dir", type=Path,
-                        default="logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector")
+    parser.add_argument(
+        "--manifest", type=Path, required=True, help="Path to the pipeline manifest.json"
+    )
+    parser.add_argument("--gt-root", type=Path, default="data/evaluation2/annotations")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default="logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector",
+    )
     parser.add_argument("--score-threshold", type=float, default=0.1)
     parser.add_argument("--rule-name", default="center_anchor")
     parser.add_argument("--vov-threshold", type=float, default=0.5)
@@ -94,7 +93,7 @@ def main():
 
     # Build mapping: image_stem -> pipeline page data
     # Image stems are like "Shostakovich-Festival_Overture_Va_page_001"
-    page_map: dict[tuple[str,str], dict] = {}
+    page_map: dict[tuple[str, str], dict] = {}
     for p in pages:
         img_path = p.get("image_path", "")
         stem = Path(img_path).stem  # e.g. "Shostakovich-Festival_Overture_Va_page_001"
@@ -103,7 +102,7 @@ def main():
         if idx < 0:
             continue
         score = stem[:idx]
-        page = f"page_{stem[idx+6:]}"
+        page = f"page_{stem[idx + 6 :]}"
         page_map[(score, page)] = p
 
     total_tp = total_fp = total_fn = 0
@@ -138,17 +137,19 @@ def main():
             candidates_path = barlines_path.parent / "pipeline2_no_peak_candidates.json"
 
             if not scored_path.exists():
-                missing.append({"score": score, "page": page, "reason": f"missing_scored:{scored_path}"})
+                missing.append(
+                    {"score": score, "page": page, "reason": f"missing_scored:{scored_path}"}
+                )
                 continue
 
             gts = boxes_from_gt(json.loads(gt_path.read_text()))
             scored_data = json.loads(scored_path.read_text())
             # filtered_cnn is a list of plain bbox arrays (already filtered), not scored dicts
-            preds = boxes_from_scored(scored_data,
-                                      score_threshold=args.score_threshold)
+            preds = boxes_from_scored(scored_data, score_threshold=args.score_threshold)
 
             match_result = greedy_barline_match(
-                preds, gts,
+                preds,
+                gts,
                 rule_name=args.rule_name,
                 vov_threshold=args.vov_threshold,
                 xdist_threshold=args.xdist_threshold,
@@ -163,11 +164,16 @@ def main():
                 cand_boxes = boxes_from_candidates(json.loads(candidates_path.read_text()))
                 for gt_idx in match_result.false_negative_indices:
                     gt = gts[gt_idx]
-                    if any(is_barline_match(c, gt,
-                                           rule_name=args.rule_name,
-                                           vov_threshold=args.vov_threshold,
-                                           xdist_threshold=args.xdist_threshold)
-                           for c in cand_boxes):
+                    if any(
+                        is_barline_match(
+                            c,
+                            gt,
+                            rule_name=args.rule_name,
+                            vov_threshold=args.vov_threshold,
+                            xdist_threshold=args.xdist_threshold,
+                        )
+                        for c in cand_boxes
+                    ):
                         fn_cnn += 1
                     else:
                         fn_det += 1
@@ -182,17 +188,19 @@ def main():
             total_gt += len(gts)
             total_pred += len(preds)
 
-            page_results.append({
-                "score": score,
-                "page": page,
-                "gt": len(gts),
-                "pred": len(preds),
-                "tp": tp,
-                "fp": fp,
-                "fn": fn,
-                "fn_det": fn_det,
-                "fn_cnn": fn_cnn,
-            })
+            page_results.append(
+                {
+                    "score": score,
+                    "page": page,
+                    "gt": len(gts),
+                    "pred": len(preds),
+                    "tp": tp,
+                    "fp": fp,
+                    "fn": fn,
+                    "fn_det": fn_det,
+                    "fn_cnn": fn_cnn,
+                }
+            )
 
     # Output
     precision = total_tp / (total_tp + total_fp) if (total_tp + total_fp) > 0 else None
@@ -241,18 +249,20 @@ def main():
     print("=" * 60)
 
     if missing:
-        print(f"\nWARNING: {len(missing)} missing pages. See {args.output_dir / 'missing_pages.json'}")
+        print(
+            f"\nWARNING: {len(missing)} missing pages. See {args.output_dir / 'missing_pages.json'}"
+        )
         sys.exit(1)
 
     # Canonical target check
     CANONICAL = {"tp": 3580, "fp": 0, "fn": 1}
-    match = (total_tp == CANONICAL["tp"] and
-             total_fp == CANONICAL["fp"] and
-             total_fn == CANONICAL["fn"])
+    match = (
+        total_tp == CANONICAL["tp"] and total_fp == CANONICAL["fp"] and total_fn == CANONICAL["fn"]
+    )
     if match:
         print("\n✅ CANONICAL TARGET MET: TP=3580, FP=0, FN=1")
     else:
-        print(f"\n❌ CANONICAL TARGET NOT MET.")
+        print("\n❌ CANONICAL TARGET NOT MET.")
         print(f"   Expected: TP={CANONICAL['tp']} FP={CANONICAL['fp']} FN={CANONICAL['fn']}")
         print(f"   Got:      TP={total_tp} FP={total_fp} FN={total_fn}")
 

--- a/tools/issue120/run_issue36_dense_candidates_then_eval.py
+++ b/tools/issue120/run_issue36_dense_candidates_then_eval.py
@@ -92,9 +92,7 @@ def require_under_logs(path: Path, *, label: str) -> None:
     try:
         path.resolve().relative_to(logs_root)
     except ValueError as exc:
-        raise ValueError(
-            f"{label} must be under logs/ before cleanup. Got: {path}"
-        ) from exc
+        raise ValueError(f"{label} must be under logs/ before cleanup. Got: {path}") from exc
 
 
 def candidate_root_summary(root: Path) -> dict[str, int | str | bool]:
@@ -261,20 +259,32 @@ def validate_detector_target(eval_dir: Path) -> None:
         raise FileNotFoundError(f"Detector metrics not found under {eval_dir}")
     observed = {"tp": summary.get("tp"), "fp": summary.get("fp"), "fn": summary.get("fn")}
     if observed != TARGET_DETECTOR:
-        raise RuntimeError(f"Detector target mismatch: observed={observed} target={TARGET_DETECTOR}")
+        raise RuntimeError(
+            f"Detector target mismatch: observed={observed} target={TARGET_DETECTOR}"
+        )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--inventory", type=Path, default=Path("logs/issue36_prep/20260208_bench_inventory.json"))
-    parser.add_argument("--exclude", type=Path, default=Path("logs/issue36_prep/excluded_pages_for_gt_prep.json"))
+    parser.add_argument(
+        "--inventory", type=Path, default=Path("logs/issue36_prep/20260208_bench_inventory.json")
+    )
+    parser.add_argument(
+        "--exclude", type=Path, default=Path("logs/issue36_prep/excluded_pages_for_gt_prep.json")
+    )
     parser.add_argument("--image-root", type=Path, default=Path("data/evaluation2/images"))
     parser.add_argument("--gt-root", type=Path, default=Path("data/evaluation2/annotations"))
     parser.add_argument("--model-path", type=Path, default=DEFAULT_MODEL)
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
-    parser.add_argument("--historical-raw-candidates-root", type=Path, default=DEFAULT_HISTORICAL_RAW)
-    parser.add_argument("--historical-filtered-candidates-root", type=Path, default=DEFAULT_HISTORICAL_FILTERED)
-    parser.add_argument("--historical-scoring-input-root", type=Path, default=DEFAULT_HISTORICAL_SCORING_INPUT)
+    parser.add_argument(
+        "--historical-raw-candidates-root", type=Path, default=DEFAULT_HISTORICAL_RAW
+    )
+    parser.add_argument(
+        "--historical-filtered-candidates-root", type=Path, default=DEFAULT_HISTORICAL_FILTERED
+    )
+    parser.add_argument(
+        "--historical-scoring-input-root", type=Path, default=DEFAULT_HISTORICAL_SCORING_INPUT
+    )
     parser.add_argument("--score-threshold", type=float, default=0.1)
     parser.add_argument("--xdist-threshold", type=float, default=12.0)
     parser.add_argument("--scorer", choices=["pipeline", "legacy"], default="pipeline")
@@ -286,7 +296,9 @@ def main() -> None:
     )
     parser.add_argument("--require-candidate-match", action="store_true")
     parser.add_argument("--require-detector-target", action="store_true")
-    parser.add_argument("--no-clean-output", dest="clean_output", action="store_false", default=True)
+    parser.add_argument(
+        "--no-clean-output", dest="clean_output", action="store_false", default=True
+    )
     args = parser.parse_args()
 
     root = args.output_root
@@ -312,7 +324,12 @@ def main() -> None:
 
     comparisons = {}
     compare_specs = [
-        ("raw", args.historical_raw_candidates_root, args.raw_candidates_root, args.raw_compare_output_dir),
+        (
+            "raw",
+            args.historical_raw_candidates_root,
+            args.raw_candidates_root,
+            args.raw_compare_output_dir,
+        ),
         (
             "filtered",
             args.historical_filtered_candidates_root,

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -113,12 +113,70 @@ def _summarize_console_log(path: Path) -> dict[str, Any]:
                 logger_name = parts[3].rstrip(":")
                 logger_counts[logger_name] = logger_counts.get(logger_name, 0) + 1
 
-    summary["logger_counts"] = dict(sorted(logger_counts.items(), key=lambda item: item[1], reverse=True)[:20])
+    summary["logger_counts"] = dict(
+        sorted(logger_counts.items(), key=lambda item: item[1], reverse=True)[:20]
+    )
     summary["marker_counts"] = marker_counts
     summary_path = path.with_suffix(".summary.json")
     summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
     summary["summary_path"] = str(summary_path)
     return summary
+
+
+def _is_warning_or_error_line(line: str) -> bool:
+    lower = line.lower()
+    return any(
+        marker in lower
+        for marker in (
+            "warning",
+            "error",
+            "traceback",
+            "exception",
+            "failed",
+            "failure",
+        )
+    )
+
+
+def _is_progress_line(line: str) -> bool:
+    lower = line.lower()
+    stripped = line.strip()
+    if "|" in line and "%" in line:
+        return True
+    if stripped.startswith("Downloaded ") and "%" in stripped:
+        return True
+    if "downloaded" in lower and " of " in lower and "%" in lower:
+        return True
+    return False
+
+
+def _filter_default_console_log(*, raw_path: Path, filtered_path: Path) -> dict[str, Any]:
+    """Write a bounded default console log while preserving raw stdout/stderr separately."""
+    stats = {
+        "schema_version": "tools.issue120.stage_e_console_filter.v1",
+        "raw_path": str(raw_path),
+        "filtered_path": str(filtered_path),
+        "raw_line_count": 0,
+        "kept_line_count": 0,
+        "dropped_line_count": 0,
+        "dropped_progress_line_count": 0,
+        "dropped_external_raw_line_count": 0,
+    }
+    filtered_path.parent.mkdir(parents=True, exist_ok=True)
+    with raw_path.open("r", encoding="utf-8", errors="replace") as src:
+        with filtered_path.open("w", encoding="utf-8") as dst:
+            for line in src:
+                stats["raw_line_count"] += 1
+                if _is_warning_or_error_line(line):
+                    dst.write(line)
+                    stats["kept_line_count"] += 1
+                    continue
+                stats["dropped_line_count"] += 1
+                if _is_progress_line(line):
+                    stats["dropped_progress_line_count"] += 1
+                else:
+                    stats["dropped_external_raw_line_count"] += 1
+    return stats
 
 
 class ResourceSampler:
@@ -152,7 +210,9 @@ class ResourceSampler:
     def start(self) -> None:
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
         self._started_at = time.perf_counter()
-        self._thread = threading.Thread(target=self._run, name="stage-e-resource-sampler", daemon=True)
+        self._thread = threading.Thread(
+            target=self._run, name="stage-e-resource-sampler", daemon=True
+        )
         self._thread.start()
 
     def stop(self) -> dict[str, Any]:
@@ -172,7 +232,9 @@ class ResourceSampler:
         self_maxrss_bytes = _linux_maxrss_bytes(self_rusage.ru_maxrss)
         children_maxrss_bytes = _linux_maxrss_bytes(children_rusage.ru_maxrss)
         self._peak_self_maxrss_bytes = max(self._peak_self_maxrss_bytes, self_maxrss_bytes)
-        self._peak_children_maxrss_bytes = max(self._peak_children_maxrss_bytes, children_maxrss_bytes)
+        self._peak_children_maxrss_bytes = max(
+            self._peak_children_maxrss_bytes, children_maxrss_bytes
+        )
 
         total_cpu_sec = _cpu_seconds(self_rusage) + _cpu_seconds(children_rusage)
         rusage_cpu_percent = None
@@ -241,7 +303,9 @@ class ResourceSampler:
         self._previous_process_tree_cpu_sec = process_tree_cpu_times_sec
 
         self._peak_psutil_rss_bytes = max(self._peak_psutil_rss_bytes, rss_bytes)
-        self._peak_psutil_children_rss_bytes = max(self._peak_psutil_children_rss_bytes, children_rss_bytes)
+        self._peak_psutil_children_rss_bytes = max(
+            self._peak_psutil_children_rss_bytes, children_rss_bytes
+        )
         sample.update(
             {
                 "psutil_available": True,
@@ -329,11 +393,37 @@ def _redirect_stdout_stderr_to_file(path: Path):
             os.close(original_stderr_fd)
 
 
+@contextlib.contextmanager
+def _temporary_env(overrides: dict[str, str]):
+    """Temporarily set environment variables and restore their previous values."""
+    previous = {key: os.environ.get(key) for key in overrides}
+    try:
+        for key, value in overrides.items():
+            os.environ[key] = value
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def main():
     parser = argparse.ArgumentParser(description="Run Stage E full 68-page pipeline.")
-    parser.add_argument("--config", type=Path, default="configs/issue120_stage_e_full_pipeline.yaml")
-    parser.add_argument("--inventory", type=Path, default="logs/issue36_prep/20260208_bench_inventory.json")
-    parser.add_argument("--exclude", type=Path, default="logs/issue36_prep/excluded_pages_for_gt_prep.json")
+    parser.add_argument(
+        "--config", type=Path, default="configs/issue120_stage_e_full_pipeline.yaml"
+    )
+    parser.add_argument(
+        "--inventory", type=Path, default="logs/issue36_prep/20260208_bench_inventory.json"
+    )
+    parser.add_argument(
+        "--exclude", type=Path, default="logs/issue36_prep/excluded_pages_for_gt_prep.json"
+    )
     parser.add_argument("--output-root", type=Path, default="logs/issue120_e2e_recovery")
     parser.add_argument(
         "--dense-route-verbose-logs",
@@ -357,6 +447,14 @@ def main():
         default=None,
         help="File for stdout/stderr emitted by full pipeline execution. Defaults under the Stage E run directory.",
     )
+    parser.add_argument(
+        "--pipeline-diagnostic-logs",
+        action="store_true",
+        help=(
+            "Keep verbose pipeline INFO/progress output in the captured stdout/stderr log. "
+            "By default Stage E captures warning/error output and leaves detailed logs in pipeline.log."
+        ),
+    )
     args = parser.parse_args()
 
     if not args.inventory.exists():
@@ -366,7 +464,9 @@ def main():
         logger.error(f"Exclude file not found: {args.exclude}")
         sys.exit(1)
     if not args.no_resource_sampling and args.resource_sample_interval_sec <= 0:
-        parser.error("--resource-sample-interval-sec must be positive when resource sampling is enabled.")
+        parser.error(
+            "--resource-sample-interval-sec must be positive when resource sampling is enabled."
+        )
 
     route_root = args.output_root / "stage_e_full_pipeline"
     if route_root.exists():
@@ -403,7 +503,9 @@ def main():
     config["inputs"]["pdf_to_images"]["output_dir"] = str(route_images_dir)
     config["inputs"]["pdf_to_images"]["image_glob"] = "*.png"
     config["run"]["run_id"] = "stage_e_full_pipeline"
-    config["detection"]["precomputed_probe_candidates_root"] = str(route_artifacts.probe_rescue_root)
+    config["detection"]["precomputed_probe_candidates_root"] = str(
+        route_artifacts.probe_rescue_root
+    )
     config["detection"]["cnn_bands_from"] = str(route_artifacts.filtered_root)
     config["detection"]["probe_use_original_images"] = True
 
@@ -414,6 +516,18 @@ def main():
         yaml.dump(config, f, sort_keys=False)
 
     pipeline_console_log = args.pipeline_console_log or route_root / "pipeline_stdout_stderr.log"
+    pipeline_diagnostic_logs = args.pipeline_diagnostic_logs or _env_flag_enabled(
+        "PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS"
+    )
+    pipeline_capture_log = (
+        pipeline_console_log
+        if pipeline_diagnostic_logs
+        else pipeline_console_log.with_name(
+            f"{pipeline_console_log.stem}.raw{pipeline_console_log.suffix}"
+        )
+    )
+    pipeline_console_level = logging.INFO if pipeline_diagnostic_logs else logging.WARNING
+    progress_env_overrides = {} if pipeline_diagnostic_logs else {"TQDM_DISABLE": "1"}
     resource_sampler = None
     resource_summary: dict[str, Any] | None = None
     if not args.no_resource_sampling:
@@ -423,18 +537,26 @@ def main():
         )
 
     logger.info(f"Starting pipeline using config: {temp_config_path}")
-    logger.info("Pipeline stdout/stderr will be captured to %s", pipeline_console_log)
+    logger.info("Pipeline stdout/stderr will be captured to %s", pipeline_capture_log)
+    logger.info(
+        "Pipeline logging mode: %s (console_level=%s, progress_bars=%s)",
+        "diagnostic" if pipeline_diagnostic_logs else "default_quiet",
+        logging.getLevelName(pipeline_console_level),
+        "enabled" if pipeline_diagnostic_logs else "disabled",
+    )
 
     pipeline_started_at = time.perf_counter()
     try:
         if resource_sampler is not None:
             resource_sampler.start()
-        with _redirect_stdout_stderr_to_file(pipeline_console_log):
-            run_pipeline(
-                config_path=temp_config_path,
-                run_id="stage_e_full_pipeline",
-                output_root=args.output_root,
-            )
+        with _redirect_stdout_stderr_to_file(pipeline_capture_log):
+            with _temporary_env(progress_env_overrides):
+                run_pipeline(
+                    config_path=temp_config_path,
+                    run_id="stage_e_full_pipeline",
+                    output_root=args.output_root,
+                    console_log_level=pipeline_console_level,
+                )
     finally:
         if resource_sampler is not None:
             resource_summary = resource_sampler.stop()
@@ -442,6 +564,12 @@ def main():
 
     pipeline_phase_summary_path = route_root / "pipeline_phase_summary.json"
     pipeline_phase_summary = _load_optional_json(pipeline_phase_summary_path)
+    console_filter_summary = None
+    if not pipeline_diagnostic_logs:
+        console_filter_summary = _filter_default_console_log(
+            raw_path=pipeline_capture_log,
+            filtered_path=pipeline_console_log,
+        )
     pipeline_console_log_summary = _summarize_console_log(pipeline_console_log)
     run_summary_path = route_root / "stage_e_runtime_summary.json"
     run_summary = {
@@ -461,12 +589,40 @@ def main():
             "phase_summary_path": str(pipeline_phase_summary_path),
             "phase_summary": pipeline_phase_summary,
             "stdout_stderr_log": str(pipeline_console_log),
+            "stdout_stderr_raw_log": str(pipeline_capture_log)
+            if pipeline_capture_log != pipeline_console_log
+            else None,
+            "stdout_stderr_raw_log_size_bytes": pipeline_capture_log.stat().st_size
+            if pipeline_capture_log.exists()
+            else 0,
             "stdout_stderr_log_size_bytes": pipeline_console_log_summary["size_bytes"],
             "stdout_stderr_log_summary": pipeline_console_log_summary,
+            "stdout_stderr_filter_summary": console_filter_summary,
+            "logging_policy": {
+                "schema_version": "tools.issue120.stage_e_pipeline_logging_policy.v1",
+                "mode": "diagnostic" if pipeline_diagnostic_logs else "default_quiet",
+                "console_log_level": logging.getLevelName(pipeline_console_level),
+                "progress_bars_disabled": not pipeline_diagnostic_logs,
+                "detail_artifact": str(route_root / "pipeline.log"),
+                "raw_stdout_stderr_artifact": str(pipeline_capture_log)
+                if pipeline_capture_log != pipeline_console_log
+                else None,
+                "diagnostic_enable": (
+                    "--pipeline-diagnostic-logs or PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1"
+                ),
+            },
         },
         "resource_monitor": resource_summary,
     }
-    run_summary_path.write_text(json.dumps(run_summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    run_summary_path.write_text(
+        json.dumps(run_summary, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    logger.info(
+        "Captured pipeline stdout/stderr summary: lines=%s size_bytes=%s markers=%s",
+        pipeline_console_log_summary["line_count"],
+        pipeline_console_log_summary["size_bytes"],
+        pipeline_console_log_summary["marker_counts"],
+    )
     logger.info("Stage E runtime summary written to %s", run_summary_path)
     logger.info("Stage E full pipeline run completed.")
 

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -351,6 +351,7 @@ class CapturedProgressMirror:
         self._position = 0
         self._mirrored_progress_line_count = 0
         self._mirrored_warning_or_error_line_count = 0
+        self._lock = threading.Lock()
 
     def start(self) -> None:
         self._console_stderr_fd = os.dup(2)
@@ -386,16 +387,17 @@ class CapturedProgressMirror:
             self._drain_once()
 
     def _drain_once(self) -> None:
-        if self._console_stderr_fd is None or not self.capture_path.exists():
-            return
-        with self.capture_path.open("r", encoding="utf-8", errors="replace") as f:
-            f.seek(self._position)
-            while True:
-                line = f.readline()
-                if not line:
-                    break
-                self._position = f.tell()
-                self._mirror_line(line)
+        with self._lock:
+            if self._console_stderr_fd is None or not self.capture_path.exists():
+                return
+            with self.capture_path.open("r", encoding="utf-8", errors="replace") as f:
+                f.seek(self._position)
+                while True:
+                    line = f.readline()
+                    if not line:
+                        break
+                    self._position = f.tell()
+                    self._mirror_line(line)
 
     def _mirror_line(self, line: str) -> None:
         if self._console_stderr_fd is None:

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -187,6 +187,8 @@ def _is_low_value_external_line(
     preserve_homr_internal: bool = False,
     preserve_sr_tile_logs: bool = False,
 ) -> bool:
+    if _is_warning_or_error_line(line):
+        return False
     stripped = line.strip()
     lower = stripped.lower()
     if not stripped:

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -74,18 +74,6 @@ def _read_gpu_sample() -> list[dict[str, Any]]:
 
 def _summarize_console_log(path: Path) -> dict[str, Any]:
     """Summarize captured stdout/stderr without loading the whole file into memory."""
-    summary: dict[str, Any] = {
-        "path": str(path),
-        "exists": path.exists(),
-        "size_bytes": path.stat().st_size if path.exists() else 0,
-        "line_count": 0,
-        "logger_counts": {},
-        "marker_counts": {},
-    }
-    if not path.exists():
-        return summary
-
-    logger_counts: dict[str, int] = {}
     marker_counts = {
         "homr": 0,
         "real_esrgan": 0,
@@ -93,6 +81,21 @@ def _summarize_console_log(path: Path) -> dict[str, Any]:
         "progress_bar": 0,
         "warning_or_error": 0,
     }
+    summary: dict[str, Any] = {
+        "path": str(path),
+        "exists": path.exists(),
+        "size_bytes": path.stat().st_size if path.exists() else 0,
+        "line_count": 0,
+        "logger_counts": {},
+        "marker_counts": marker_counts.copy(),
+    }
+    summary_path = path.with_suffix(".summary.json")
+    if not path.exists():
+        summary["summary_path"] = str(summary_path)
+        summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+        return summary
+
+    logger_counts: dict[str, int] = {}
     with path.open("r", encoding="utf-8", errors="replace") as f:
         for line in f:
             summary["line_count"] += 1
@@ -117,7 +120,6 @@ def _summarize_console_log(path: Path) -> dict[str, Any]:
         sorted(logger_counts.items(), key=lambda item: item[1], reverse=True)[:20]
     )
     summary["marker_counts"] = marker_counts
-    summary_path = path.with_suffix(".summary.json")
     summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
     summary["summary_path"] = str(summary_path)
     return summary
@@ -139,15 +141,111 @@ def _is_warning_or_error_line(line: str) -> bool:
 
 
 def _is_progress_line(line: str) -> bool:
-    lower = line.lower()
-    stripped = line.strip()
     if "|" in line and "%" in line:
         return True
-    if stripped.startswith("Downloaded ") and "%" in stripped:
-        return True
-    if "downloaded" in lower and " of " in lower and "%" in lower:
-        return True
     return False
+
+
+def _is_real_esrgan_tile_line(stripped: str) -> bool:
+    return stripped.startswith("Tile ") and "/" in stripped
+
+
+def _is_low_value_external_line(
+    line: str,
+    *,
+    preserve_homr_internal: bool = False,
+    preserve_sr_tile_logs: bool = False,
+) -> bool:
+    stripped = line.strip()
+    lower = stripped.lower()
+    if not stripped:
+        return False
+    if _is_real_esrgan_tile_line(stripped):
+        return not preserve_sr_tile_logs
+    if preserve_homr_internal:
+        return False
+    low_value_prefixes = (
+        "Downloaded ",
+        "Dewarping staff",
+        "Running TrOmr inference on staff image",
+        "Creating bounds for",
+        "Found a cache",
+        "Loading from cache",
+        "Saving cache",
+        "Removing tuplets from measure",
+        "_check_choices_intelligently:",
+    )
+    low_value_markers = (
+        "[RapidOCR]",
+        "[W:onnxruntime",
+        "Fallback mode. May be extremely slow.",
+        " staff line fragments",
+        " noteheads",
+        " notes during segmentation",
+        "Average note head height:",
+        "Inference Time Tromr:",
+        "Segnet Inference time:",
+    )
+    return stripped.startswith(low_value_prefixes) or any(
+        marker.lower() in lower for marker in low_value_markers
+    )
+
+
+def _strip_low_value_suffix_from_progress_line(line: str) -> str:
+    if not _is_progress_line(line):
+        return line
+    for marker in (
+        "\x1b[",
+        "Found ",
+        "Inference Time Tromr:",
+        "Removing tuplets from measure",
+        "_check_choices_intelligently:",
+    ):
+        if marker in line:
+            prefix = line.split(marker, 1)[0].rstrip()
+            if prefix:
+                return prefix + "\n"
+    return line
+
+
+def _suppress_low_value_external_raw_log(
+    path: Path,
+    *,
+    preserve_homr_internal: bool = False,
+    preserve_sr_tile_logs: bool = False,
+) -> dict[str, Any]:
+    """Rewrite raw stdout/stderr with known low-value external chatter removed."""
+    stats = {
+        "schema_version": "tools.issue120.stage_e_low_value_raw_suppression.v1",
+        "path": str(path),
+        "preserve_homr_internal": preserve_homr_internal,
+        "preserve_sr_tile_logs": preserve_sr_tile_logs,
+        "input_line_count": 0,
+        "output_line_count": 0,
+        "suppressed_line_count": 0,
+        "sanitized_progress_line_count": 0,
+    }
+    if not path.exists():
+        return stats
+    temp_path = path.with_name(f"{path.stem}.filtered{path.suffix}")
+    with path.open("r", encoding="utf-8", errors="replace") as src:
+        with temp_path.open("w", encoding="utf-8") as dst:
+            for line in src:
+                stats["input_line_count"] += 1
+                sanitized = _strip_low_value_suffix_from_progress_line(line)
+                if sanitized != line:
+                    stats["sanitized_progress_line_count"] += 1
+                if _is_low_value_external_line(
+                    sanitized,
+                    preserve_homr_internal=preserve_homr_internal,
+                    preserve_sr_tile_logs=preserve_sr_tile_logs,
+                ):
+                    stats["suppressed_line_count"] += 1
+                    continue
+                dst.write(sanitized)
+                stats["output_line_count"] += 1
+    temp_path.replace(path)
+    return stats
 
 
 def _filter_default_console_log(*, raw_path: Path, filtered_path: Path) -> dict[str, Any]:
@@ -161,10 +259,12 @@ def _filter_default_console_log(*, raw_path: Path, filtered_path: Path) -> dict[
         "dropped_line_count": 0,
         "dropped_progress_line_count": 0,
         "dropped_external_raw_line_count": 0,
+        "filtered_log_written": False,
     }
     filtered_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = filtered_path.with_name(f"{filtered_path.stem}.tmp{filtered_path.suffix}")
     with raw_path.open("r", encoding="utf-8", errors="replace") as src:
-        with filtered_path.open("w", encoding="utf-8") as dst:
+        with temp_path.open("w", encoding="utf-8") as dst:
             for line in src:
                 stats["raw_line_count"] += 1
                 if _is_warning_or_error_line(line):
@@ -176,6 +276,12 @@ def _filter_default_console_log(*, raw_path: Path, filtered_path: Path) -> dict[
                     stats["dropped_progress_line_count"] += 1
                 else:
                     stats["dropped_external_raw_line_count"] += 1
+    if stats["kept_line_count"] > 0:
+        temp_path.replace(filtered_path)
+        stats["filtered_log_written"] = True
+    else:
+        temp_path.unlink(missing_ok=True)
+        filtered_path.unlink(missing_ok=True)
     return stats
 
 
@@ -504,6 +610,12 @@ def main():
         help="Write full subprocess logs for dense-route reconstruction. Defaults to compact bounded logs.",
     )
     parser.add_argument(
+        "--expected-pages",
+        type=int,
+        default=68,
+        help="Expected dense-route page count. Keep 68 for canonical Stage E; use a smaller value only for smoke checks.",
+    )
+    parser.add_argument(
         "--resource-sample-interval-sec",
         type=float,
         default=5.0,
@@ -552,6 +664,7 @@ def main():
         inventory=args.inventory,
         exclude=args.exclude,
         route_root=route_root,
+        expected_pages=args.expected_pages,
         verbose_logs=args.dense_route_verbose_logs,
     )
 
@@ -644,8 +757,14 @@ def main():
 
     pipeline_phase_summary_path = route_root / "pipeline_phase_summary.json"
     pipeline_phase_summary = _load_optional_json(pipeline_phase_summary_path)
+    low_value_raw_suppression_summary = None
     console_filter_summary = None
     if not pipeline_diagnostic_logs:
+        low_value_raw_suppression_summary = _suppress_low_value_external_raw_log(
+            pipeline_capture_log,
+            preserve_homr_internal=_env_flag_enabled("PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS"),
+            preserve_sr_tile_logs=_env_flag_enabled("PDFSCORE_SR_TILE_LOGS"),
+        )
         console_filter_summary = _filter_default_console_log(
             raw_path=pipeline_capture_log,
             filtered_path=pipeline_console_log,
@@ -677,6 +796,7 @@ def main():
             else 0,
             "stdout_stderr_log_size_bytes": pipeline_console_log_summary["size_bytes"],
             "stdout_stderr_log_summary": pipeline_console_log_summary,
+            "stdout_stderr_low_value_raw_suppression_summary": (low_value_raw_suppression_summary),
             "stdout_stderr_filter_summary": console_filter_summary,
             "stdout_stderr_progress_mirror_summary": progress_mirror_summary,
             "logging_policy": {

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -150,6 +150,37 @@ def _is_real_esrgan_tile_line(stripped: str) -> bool:
     return stripped.startswith("Tile ") and "/" in stripped
 
 
+def _low_value_marker_keys(line: str) -> list[str]:
+    stripped = line.strip()
+    markers: list[str] = []
+    marker_checks = (
+        ("realesrgan_tile", _is_real_esrgan_tile_line(stripped)),
+        ("homr_download_progress", stripped.startswith("Downloaded ")),
+        ("homr_dewarping_staff", stripped.startswith("Dewarping staff")),
+        (
+            "homr_tromr_inference",
+            stripped.startswith("Running TrOmr inference on staff image"),
+        ),
+        ("homr_creating_bounds", stripped.startswith("Creating bounds for")),
+        ("homr_cache_notice", stripped.startswith(("Found a cache", "Loading from cache"))),
+        ("homr_tuple_cleanup", stripped.startswith("Removing tuplets from measure")),
+        ("homr_choice_check", stripped.startswith("_check_choices_intelligently:")),
+        ("rapidocr_info", "[RapidOCR]" in stripped),
+        ("onnxruntime_warning", "[W:onnxruntime" in stripped),
+        ("onnxruntime_fallback", "Fallback mode. May be extremely slow." in stripped),
+        ("homr_staff_fragment_count", " staff line fragments" in stripped),
+        ("homr_notehead_count", " noteheads" in stripped),
+        ("homr_note_segmentation_count", " notes during segmentation" in stripped),
+        ("homr_notehead_height", "Average note head height:" in stripped),
+        ("homr_tromr_timing", "Inference Time Tromr:" in stripped),
+        ("homr_segnet_timing", "Segnet Inference time:" in stripped),
+    )
+    for key, matched in marker_checks:
+        if matched:
+            markers.append(key)
+    return markers
+
+
 def _is_low_value_external_line(
     line: str,
     *,
@@ -224,26 +255,47 @@ def _suppress_low_value_external_raw_log(
         "output_line_count": 0,
         "suppressed_line_count": 0,
         "sanitized_progress_line_count": 0,
+        "low_value_marker_counts": {},
+        "suppressed_marker_counts": {},
     }
     if not path.exists():
         return stats
+    low_value_marker_counts: dict[str, int] = {}
+    suppressed_marker_counts: dict[str, int] = {}
     temp_path = path.with_name(f"{path.stem}.filtered{path.suffix}")
     with path.open("r", encoding="utf-8", errors="replace") as src:
         with temp_path.open("w", encoding="utf-8") as dst:
             for line in src:
                 stats["input_line_count"] += 1
+                marker_keys = _low_value_marker_keys(line)
+                for marker_key in marker_keys:
+                    low_value_marker_counts[marker_key] = (
+                        low_value_marker_counts.get(marker_key, 0) + 1
+                    )
                 sanitized = _strip_low_value_suffix_from_progress_line(line)
+                marker_removed_by_sanitization = sanitized != line and bool(marker_keys)
                 if sanitized != line:
                     stats["sanitized_progress_line_count"] += 1
+                    for marker_key in marker_keys:
+                        suppressed_marker_counts[marker_key] = (
+                            suppressed_marker_counts.get(marker_key, 0) + 1
+                        )
                 if _is_low_value_external_line(
                     sanitized,
                     preserve_homr_internal=preserve_homr_internal,
                     preserve_sr_tile_logs=preserve_sr_tile_logs,
                 ):
                     stats["suppressed_line_count"] += 1
+                    if not marker_removed_by_sanitization:
+                        for marker_key in marker_keys:
+                            suppressed_marker_counts[marker_key] = (
+                                suppressed_marker_counts.get(marker_key, 0) + 1
+                            )
                     continue
                 dst.write(sanitized)
                 stats["output_line_count"] += 1
+    stats["low_value_marker_counts"] = dict(sorted(low_value_marker_counts.items()))
+    stats["suppressed_marker_counts"] = dict(sorted(suppressed_marker_counts.items()))
     temp_path.replace(path)
     return stats
 

--- a/tools/issue120/run_stage_e_full_pipeline.py
+++ b/tools/issue120/run_stage_e_full_pipeline.py
@@ -179,6 +179,79 @@ def _filter_default_console_log(*, raw_path: Path, filtered_path: Path) -> dict[
     return stats
 
 
+class CapturedProgressMirror:
+    """Mirror selected captured fd-level lines to the original console while retaining raw logs."""
+
+    def __init__(self, *, capture_path: Path, mirror_progress: bool = True) -> None:
+        self.capture_path = capture_path
+        self.mirror_progress = mirror_progress
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._console_stderr_fd: int | None = None
+        self._position = 0
+        self._mirrored_progress_line_count = 0
+        self._mirrored_warning_or_error_line_count = 0
+
+    def start(self) -> None:
+        self._console_stderr_fd = os.dup(2)
+        self._thread = threading.Thread(
+            target=self._run,
+            name="stage-e-captured-progress-mirror",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> dict[str, Any]:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        self._drain_once()
+        if self._console_stderr_fd is not None:
+            os.write(self._console_stderr_fd, b"\n")
+            os.close(self._console_stderr_fd)
+            self._console_stderr_fd = None
+        return self.summary()
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "schema_version": "tools.issue120.stage_e_console_progress_mirror.v1",
+            "capture_path": str(self.capture_path),
+            "mirror_progress": self.mirror_progress,
+            "mirrored_progress_line_count": self._mirrored_progress_line_count,
+            "mirrored_warning_or_error_line_count": self._mirrored_warning_or_error_line_count,
+        }
+
+    def _run(self) -> None:
+        while not self._stop.wait(0.5):
+            self._drain_once()
+
+    def _drain_once(self) -> None:
+        if self._console_stderr_fd is None or not self.capture_path.exists():
+            return
+        with self.capture_path.open("r", encoding="utf-8", errors="replace") as f:
+            f.seek(self._position)
+            while True:
+                line = f.readline()
+                if not line:
+                    break
+                self._position = f.tell()
+                self._mirror_line(line)
+
+    def _mirror_line(self, line: str) -> None:
+        if self._console_stderr_fd is None:
+            return
+        if _is_warning_or_error_line(line):
+            os.write(self._console_stderr_fd, ("\n" + line).encode("utf-8", errors="replace"))
+            self._mirrored_warning_or_error_line_count += 1
+            return
+        if self.mirror_progress and _is_progress_line(line):
+            os.write(
+                self._console_stderr_fd,
+                ("\r" + line.rstrip()).encode("utf-8", errors="replace"),
+            )
+            self._mirrored_progress_line_count += 1
+
+
 class ResourceSampler:
     """Best-effort process/GPU resource sampler for long Stage E runs."""
 
@@ -527,9 +600,11 @@ def main():
         )
     )
     pipeline_console_level = logging.INFO if pipeline_diagnostic_logs else logging.WARNING
-    progress_env_overrides = {} if pipeline_diagnostic_logs else {"TQDM_DISABLE": "1"}
+    progress_env_overrides: dict[str, str] = {}
     resource_sampler = None
     resource_summary: dict[str, Any] | None = None
+    progress_mirror = None
+    progress_mirror_summary = None
     if not args.no_resource_sampling:
         resource_sampler = ResourceSampler(
             output_path=route_root / "stage_e_resource_samples.jsonl",
@@ -542,13 +617,16 @@ def main():
         "Pipeline logging mode: %s (console_level=%s, progress_bars=%s)",
         "diagnostic" if pipeline_diagnostic_logs else "default_quiet",
         logging.getLevelName(pipeline_console_level),
-        "enabled" if pipeline_diagnostic_logs else "disabled",
+        "captured" if pipeline_diagnostic_logs else "mirrored_to_console_and_filtered_from_log",
     )
 
     pipeline_started_at = time.perf_counter()
     try:
         if resource_sampler is not None:
             resource_sampler.start()
+        if not pipeline_diagnostic_logs:
+            progress_mirror = CapturedProgressMirror(capture_path=pipeline_capture_log)
+            progress_mirror.start()
         with _redirect_stdout_stderr_to_file(pipeline_capture_log):
             with _temporary_env(progress_env_overrides):
                 run_pipeline(
@@ -558,6 +636,8 @@ def main():
                     console_log_level=pipeline_console_level,
                 )
     finally:
+        if progress_mirror is not None:
+            progress_mirror_summary = progress_mirror.stop()
         if resource_sampler is not None:
             resource_summary = resource_sampler.stop()
     pipeline_duration_sec = time.perf_counter() - pipeline_started_at
@@ -598,11 +678,12 @@ def main():
             "stdout_stderr_log_size_bytes": pipeline_console_log_summary["size_bytes"],
             "stdout_stderr_log_summary": pipeline_console_log_summary,
             "stdout_stderr_filter_summary": console_filter_summary,
+            "stdout_stderr_progress_mirror_summary": progress_mirror_summary,
             "logging_policy": {
                 "schema_version": "tools.issue120.stage_e_pipeline_logging_policy.v1",
                 "mode": "diagnostic" if pipeline_diagnostic_logs else "default_quiet",
                 "console_log_level": logging.getLevelName(pipeline_console_level),
-                "progress_bars_disabled": not pipeline_diagnostic_logs,
+                "progress_bars_console_mirrored": not pipeline_diagnostic_logs,
                 "detail_artifact": str(route_root / "pipeline.log"),
                 "raw_stdout_stderr_artifact": str(pipeline_capture_log)
                 if pipeline_capture_log != pipeline_console_log


### PR DESCRIPTION
## Related Issue
- Closes #162

## What (What was implemented)
- Stage E/full-pipeline 向けに、ログを以下の 5 種類へ分類する設計ドキュメントを追加しました。
  - acceptance-critical summary
  - operational progress
  - diagnostic per-item detail
  - external-tool raw output
  - warning/error
- default console は実行開始/終了、評価に必要な summary、各段階の tqdm 進捗、warning/error を中心に残し、per-item/detail や外部ツールの低価値ログは artifact 側へ分離・抑制するようにしました。
- `pipeline_stdout_stderr.log` は warning/error 等の default retained line がある場合だけ生成し、空ファイルを残さないようにしました。
- 抑制対象ログの marker count を runtime summary に記録し、診断時に「何がどれだけ抑制されたか」を確認できるようにしました。
- 診断用途として `PDFSCORE_STAGE_E_DIAGNOSTIC_LOGS=1`、`PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS=1`、`PDFSCORE_SR_TILE_LOGS=1` の opt-in 経路を追加しました。

## Why (Why this change is needed)
- #159 で Stage E の stdout/stderr capture と runtime/resource measurement が追加され、full-pipeline 実行時に HOMR/SR/ONNX/RapidOCR 由来の低価値ログが大量に混ざる状態になっていました。
- #163 で HOMR/SR overlap scheduling は採用しない結論になったため、今後の実験では runtime semantics ではなく observability を改善し、default log を bounded かつ読みやすく保つ必要があります。

## Scope (In / Out)
**In:**
- Stage E runner と関連 pipeline logging の default verbosity 調整
- tqdm による段階別進捗の console 表示維持
- HOMR/SR/RapidOCR/ONNXRuntime 由来の低価値 raw log 抑制と marker summary 記録
- logging taxonomy と最終 artifact 形式のドキュメント化
- warning/error 行の保持

**Out:**
- detector threshold の変更
- CNN scoring semantics の変更
- candidate generation semantics の変更
- NMS policy の変更
- detector metrics と downstream measure-count metrics の混在
- ONNX/RapidOCR provider fallback 自体の修正（follow-up: #172）

## How to test

### AI-side checks (performed by author / AI)
- `python3 -m py_compile tools/issue120/run_stage_e_full_pipeline.py`
- warning/error retention の局所サンプル検証
  - RapidOCR warning は default retained log に残る
  - RapidOCR info / ONNX fallback warning などの低価値 marker は抑制される
- `make lint`
- `env PYTHONPYCACHEPREFIX=/tmp/pdfscorebar_compileall_issue162 python3 -m compileall tools src`
- `git diff --check`
- 1-page subset smoke
  - default では `Tile ...` / `Dewarping staff ...` / RapidOCR info / ONNX fallback noise が raw/default から抑制されることを確認
  - default retained line がない場合、`pipeline_stdout_stderr.log` が生成されないことを確認
- 1-page diagnostic smoke
  - `PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS=1` が Docker 実行へ伝播し、HOMR internal detail を保持できることを確認
- full Stage E validation
  - `make run-issue120-stage-e-full ISSUE120_STAGE_E_EXTRA_ARGS="--resource-sample-interval-sec 1.0"`
  - `make eval-issue120-stage-e-full`
  - `PYTHONPATH=. python3 tools/issue120/attach_stage_e_eval_contract.py --manifest logs/issue120_e2e_recovery/stage_e_full_pipeline/manifest.json --eval-dir logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector --score-threshold 0.1 --xdist-threshold 12.0`
  - contract result:
    - `expected_pages=68`
    - `evaluated_pages=68`
    - `TP=3580 / FP=0 / FN=1`
    - `FN_det=0 / FN_cnn=1`
    - `cnn_apply_nms=false`
    - `target_met.detector=true`

### Human-side checks (to be performed locally)
- 必要に応じて Stage E full run の default console と `stage_e_runtime_summary.json` を確認してください。

## Notes / Implementation details
- default console と artifact log は同じ分類ルールで扱いますが、acceptance-critical summary と warning/error は外部ツール raw output と混在させない方針です。
- `pipeline_stdout_stderr.summary.json` には retained log の有無、行数、サイズ、marker count、抑制 marker count を記録します。
- `pipeline_stdout_stderr.log` は retained line がある場合のみ生成されます。
- full validation の detector contract は変更前と同じ canonical target を満たしており、検出器・CNN・候補生成・NMS の意味論は変更していません。

## Screenshots / Logs (optional)
- 生成ログや large artifact はコミットしていません。
- ONNX/RapidOCR provider fallback の根本対応は #172 に分離しています。

## Checklist
- [x] 対象 Issue の Goal / Acceptance Criteria をすべて満たしている
- [x] Issue に書かれていない機能を先取りしていない
- [x] 入出力仕様（パス・ファイル名）が Issue と一致している
- [x] エラー時のログが分かりやすい
- [x] 依存追加が最小限である
- [x] README / ドキュメント更新の要否を確認した
