### PR TITLE
Fix HOMR ONNX CUDA Conv fallback warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN /opt/venv_pipeline/bin/python docker/patch_homr_onnx_provider.py
 # Install project dependencies
 RUN uv pip install -e .
 
-# Apply basicsr patch for torchvision compatibility dynamically to avoid hardcoded python version paths
-RUN /opt/venv_pipeline/bin/python -c "import basicsr; from pathlib import Path; p = Path(basicsr.__file__).parent / 'data' / 'degradations.py'; s = p.read_text(); p.write_text(s.replace('from torchvision.transforms.functional_tensor import rgb_to_grayscale', 'from torchvision.transforms.functional import rgb_to_grayscale'))"
+# Apply basicsr patch for torchvision compatibility without importing basicsr/cv2 in the builder stage.
+RUN /opt/venv_pipeline/bin/python -c "from pathlib import Path; import sysconfig; p = Path(sysconfig.get_paths()['purelib']) / 'basicsr' / 'data' / 'degradations.py'; s = p.read_text(); p.write_text(s.replace('from torchvision.transforms.functional_tensor import rgb_to_grayscale', 'from torchvision.transforms.functional import rgb_to_grayscale'))"
 
 # Download model weights during build to a safe location (not masked by volume mount)
 # We place them in /opt/weights so they are always available. We will symlink them later if needed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /workspace
 
 # Copy only dependency-defining files first for better caching
 COPY pyproject.toml ./
+COPY docker/patch_homr_onnx_provider.py ./docker/patch_homr_onnx_provider.py
 
 # Create unified virtual environment and install dependencies
 RUN uv venv --python 3.11 /opt/venv_pipeline
@@ -34,6 +35,7 @@ RUN uv pip install --no-cache-dir --upgrade pip setuptools wheel
 # Pinned to specific commits for reproducible builds
 RUN uv pip install git+https://github.com/xinntao/Real-ESRGAN.git@a4abfb2979a7bbff3f69f58f58ae324608821e27
 RUN uv pip install git+https://github.com/liebharc/homr.git@b377620a3a55bd7ff657481cec5b688dfbc9cee9
+RUN /opt/venv_pipeline/bin/python docker/patch_homr_onnx_provider.py
 
 # Install project dependencies
 RUN uv pip install -e .

--- a/docker/patch_homr_onnx_provider.py
+++ b/docker/patch_homr_onnx_provider.py
@@ -1,0 +1,61 @@
+"""Patch the pinned HOMR ONNX provider options used in the Docker image.
+
+Issue #172 showed that the pinned HOMR transformer fp16 encoder emits
+ONNX Runtime CUDA Conv fallback warnings when `cudnn_conv_algo_search` is
+`DEFAULT`. The Stage E smoke comparison found that `HEURISTIC` removes the
+warning while keeping the change limited to HOMR ONNX provider options.
+"""
+
+from pathlib import Path
+
+import homr
+
+
+HOMR_ROOT = Path(homr.__file__).resolve().parent
+ENCODER_PATH = HOMR_ROOT / "transformer" / "encoder_inference.py"
+DECODER_PATH = HOMR_ROOT / "transformer" / "decoder_inference.py"
+
+
+ENCODER_OLD = '''providers=[
+                        (
+                            "CUDAExecutionProvider",
+                            {
+                                "cudnn_conv_algo_search": "DEFAULT",
+                            },
+                        )
+                    ],'''
+
+ENCODER_NEW = '''providers=[
+                        (
+                            "CUDAExecutionProvider",
+                            {
+                                "cudnn_conv_algo_search": "HEURISTIC",
+                            },
+                        ),
+                        "CPUExecutionProvider",
+                    ],'''
+
+DECODER_OLD = 'config.filepaths.decoder_path_fp16, providers=["CUDAExecutionProvider"]'
+
+DECODER_NEW = (
+    'config.filepaths.decoder_path_fp16, '
+    'providers=[("CUDAExecutionProvider", {"cudnn_conv_algo_search": "HEURISTIC"}), '
+    '"CPUExecutionProvider"]'
+)
+
+
+def replace_exact(path: Path, old: str, new: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if old not in text:
+        raise RuntimeError(f"Expected HOMR patch target not found in {path}")
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+def main() -> None:
+    replace_exact(ENCODER_PATH, ENCODER_OLD, ENCODER_NEW)
+    replace_exact(DECODER_PATH, DECODER_OLD, DECODER_NEW)
+    print("Patched HOMR transformer ONNX CUDA provider options to HEURISTIC")
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/patch_homr_onnx_provider.py
+++ b/docker/patch_homr_onnx_provider.py
@@ -7,11 +7,10 @@ warning while keeping the change limited to HOMR ONNX provider options.
 """
 
 from pathlib import Path
+import sysconfig
 
-import homr
 
-
-HOMR_ROOT = Path(homr.__file__).resolve().parent
+HOMR_ROOT = Path(sysconfig.get_paths()["purelib"]) / "homr"
 ENCODER_PATH = HOMR_ROOT / "transformer" / "encoder_inference.py"
 DECODER_PATH = HOMR_ROOT / "transformer" / "decoder_inference.py"
 
@@ -31,16 +30,14 @@ ENCODER_NEW = '''providers=[
                             {
                                 "cudnn_conv_algo_search": "HEURISTIC",
                             },
-                        ),
-                        "CPUExecutionProvider",
+                        )
                     ],'''
 
 DECODER_OLD = 'config.filepaths.decoder_path_fp16, providers=["CUDAExecutionProvider"]'
 
 DECODER_NEW = (
     'config.filepaths.decoder_path_fp16, '
-    'providers=[("CUDAExecutionProvider", {"cudnn_conv_algo_search": "HEURISTIC"}), '
-    '"CPUExecutionProvider"]'
+    'providers=[("CUDAExecutionProvider", {"cudnn_conv_algo_search": "HEURISTIC"})]'
 )
 
 


### PR DESCRIPTION
## Summary

Closes #172.

This PR changes the Docker build so that the pinned HOMR package is patched after installation to use `cudnn_conv_algo_search=HEURISTIC` for HOMR transformer ONNX CUDA sessions.

The change is intentionally scoped to ONNX Runtime provider configuration for HOMR. It does not change detector thresholds, scoring, candidate generation, NMS, or Stage E acceptance logic.

## Changes

- Add `docker/patch_homr_onnx_provider.py`.
- Run the HOMR provider patch during Docker build.
- Patch the existing `basicsr` import compatibility step without importing `basicsr`, avoiding a builder-time `libGL.so.1` failure.
- After review, avoid importing `homr` in the patch script and do not add `CPUExecutionProvider`, preserving HOMR's existing caught-exception CPU fallback behavior.

## Validation

Docker image used for local validation:

```text
pdfscore_pipeline_gpu_issue172_homr_heuristic
```

### 1-page smoke after review fixes

Command completed successfully:

```text
2026-06-04 10:20:00,110 [INFO] __main__: Stage E full pipeline run completed.
```

Warning check:

- Conv fallback warning: `0`
- node assignment warning: `1`
- remaining warning is the generic `VerifyEachNodeIsAssignedToAnEp` message; no `Fallback mode. May be extremely slow` warning appears.

### Full Stage E validation

- Conv fallback warning: `0`
- node assignment warning: `1`
- remaining warning is the generic `VerifyEachNodeIsAssignedToAnEp` message; no `Fallback mode. May be extremely slow` warning remains
- `total_duration_sec ~= 7574.43`
- `pipeline_duration_sec ~= 7513.16`

### Detector contract

Contract evaluation was run after normalizing current full-pipeline output paths into evaluator-compatible `eval_inputs`. Follow-up #180 tracks making this one-command and layout-compatible.

Result:

```text
Pages: 68/68
GT=3581
Pred=3600
TP=3580
FP=0
FN=1
FN_det=0
FN_cnn=1
Precision=1.000000
Recall=0.999721
```

`detector_metrics.json`:

```json
{
  "page_count": 68,
  "expected_page_count": 68,
  "gt": 3581,
  "pred": 3600,
  "candidate_count": 27758,
  "tp": 3580,
  "fp": 0,
  "fn": 1,
  "fn_det": 0,
  "fn_cnn": 1,
  "precision": 1.0,
  "recall": 0.9997207483943032
}
```

## Follow-up

- #180: Make Stage E contract evaluation one-command and layout-compatible.

## Local cleanup note

After reviewing or merging this PR, remove the temporary local validation image/container `pdfscore_pipeline_gpu_issue172_homr_heuristic` to avoid stale-image confusion with `pdfscore_pipeline_gpu:latest`. After merge, rebuild or retag the normal `pdfscore_pipeline_gpu:latest` image so regular runs use this fix.