### PR TITLE
Make Stage E contract evaluation one-command

### DIFF
--- a/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
+++ b/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
@@ -44,13 +44,26 @@ Pipeline logging taxonomy and default noisy-log policy are deferred to follow-up
 
 ## One-command Stage E Contract Evaluation
 
-After the full Stage E run completes, run contract evaluation with:
+After the full Stage E run completes, first run the small smoke check:
+
+```bash
+make eval-issue120-stage-e-smoke
+```
+
+This smoke target evaluates only the first `ISSUE120_STAGE_E_SMOKE_PAGES` canonical pages, defaulting to `2`. It is intended to verify Stage E artifact discovery, `eval_inputs` materialization, and contract output writing before spending time on the full 68-page contract evaluation. Because it is partial by design, the target passes `--allow-partial --allow-target-mismatch` and writes to smoke-specific directories:
+
+```text
+logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_inputs_smoke/
+logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector_smoke/
+```
+
+When the smoke check succeeds, run full contract evaluation with:
 
 ```bash
 make eval-issue120-stage-e-full
 ```
 
-The make target calls `tools/issue120/eval_stage_e_contract.py`, using `ISSUE120_STAGE_E_OUTPUT` as the input `--output-root`. By default this is:
+The full make target calls `tools/issue120/eval_stage_e_contract.py`, using `ISSUE120_STAGE_E_OUTPUT` as the input `--output-root`. By default this is:
 
 ```text
 logs/issue120_e2e_recovery
@@ -68,7 +81,7 @@ It then writes detector contract outputs to:
 logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector/
 ```
 
-Expected contract outputs:
+Expected full contract outputs:
 
 ```text
 logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector/evaluation_contract.json

--- a/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
+++ b/docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md
@@ -42,9 +42,59 @@ Issue #159 uses these artifacts to identify safe parallelization opportunities. 
 
 Pipeline logging taxonomy and default noisy-log policy are deferred to follow-up issue #162/#164. Issue #159 captures and summarizes stdout/stderr but does not redesign default logger semantics.
 
+## One-command Stage E Contract Evaluation
+
+After the full Stage E run completes, run contract evaluation with:
+
+```bash
+make eval-issue120-stage-e-full
+```
+
+The make target calls `tools/issue120/eval_stage_e_contract.py`, using `ISSUE120_STAGE_E_OUTPUT` as the input `--output-root`. By default this is:
+
+```text
+logs/issue120_e2e_recovery
+```
+
+The evaluator does not require manual path discovery or one-off copy scripts. It materializes an evaluator-compatible input tree from the current full-pipeline artifact layout:
+
+```text
+logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_inputs/
+```
+
+It then writes detector contract outputs to:
+
+```text
+logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector/
+```
+
+Expected contract outputs:
+
+```text
+logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector/evaluation_contract.json
+logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector/detector_metrics.json
+logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector/detector_page_metrics.csv
+logs/issue120_e2e_recovery/stage_e_full_pipeline/eval_detector/manifest.json
+```
+
+The wrapper checks the canonical Stage E detector target by default and exits non-zero if the target is not met. For diagnostic runs that intentionally inspect a mismatch, pass extra arguments through:
+
+```bash
+make eval-issue120-stage-e-full ISSUE120_STAGE_E_EVAL_EXTRA_ARGS=--allow-target-mismatch
+```
+
+The full run artifacts and resource summaries remain under:
+
+```text
+logs/issue120_e2e_recovery/stage_e_full_pipeline/
+logs/issue120_e2e_recovery/stage_e_full_pipeline/stage_e_runtime_summary.json
+logs/issue120_e2e_recovery/stage_e_full_pipeline/dense_route_execution_summary.json
+logs/issue120_e2e_recovery/stage_e_full_pipeline/stage_e_resource_samples.summary.json
+```
+
 ## Detector Metrics vs Target
 
-The detector metrics are produced from the full-pipeline `manifest.json` using `tools/issue120/eval_stage_e_from_manifest.py` and recorded in `evaluation_contract.json`.
+The detector metrics are produced from full-pipeline Stage E artifacts using `tools/issue120/eval_stage_e_contract.py` and recorded in `evaluation_contract.json`.
 
 - **Target**: `TP=3580 / FP=0 / FN=1`
 - **Observed Stage E run**: `TP=3580 / FP=0 / FN=1`
@@ -82,7 +132,7 @@ The repair connects Stage E to the recovered route without consuming historical 
 2. Apply clef/staff-aware candidate filtering inside the current Stage E run.
 3. Regenerate probe-rescue candidates from that filtered root inside the current Stage E run.
 4. Feed the freshly regenerated probe-rescue candidate root into the full pipeline detector/CNN scoring path.
-5. Evaluate detector metrics from the full-pipeline manifest.
+5. Evaluate detector metrics from the full-pipeline Stage E artifacts.
 
 This keeps #151 as detector-level evidence while making #141 validate a real full-pipeline Stage E run.
 

--- a/tools/issue120/Makefile.stage_e.mk
+++ b/tools/issue120/Makefile.stage_e.mk
@@ -1,8 +1,13 @@
 ISSUE120_STAGE_E_CONFIG ?= configs/issue120_stage_e_full_pipeline.yaml
 ISSUE120_STAGE_E_OUTPUT ?= logs/issue120_e2e_recovery
-ISSUE120_STAGE_E_MANIFEST ?= $(ISSUE120_STAGE_E_OUTPUT)/stage_e_full_pipeline/manifest.json
-ISSUE120_STAGE_E_EVAL_DIR ?= $(ISSUE120_STAGE_E_OUTPUT)/stage_e_full_pipeline/eval_detector
+ISSUE120_STAGE_E_RUN_ROOT ?= $(ISSUE120_STAGE_E_OUTPUT)/stage_e_full_pipeline
+ISSUE120_STAGE_E_EVAL_INPUTS_DIR ?= $(ISSUE120_STAGE_E_RUN_ROOT)/eval_inputs
+ISSUE120_STAGE_E_EVAL_DIR ?= $(ISSUE120_STAGE_E_RUN_ROOT)/eval_detector
+ISSUE120_STAGE_E_GT_ROOT ?= data/evaluation2/annotations
+ISSUE120_STAGE_E_SCORE_THRESHOLD ?= 0.1
+ISSUE120_STAGE_E_XDIST_THRESHOLD ?= 12.0
 ISSUE120_STAGE_E_EXTRA_ARGS ?=
+ISSUE120_STAGE_E_EVAL_EXTRA_ARGS ?=
 
 run-issue120-stage-e-full: ## Run the full 68-page pipeline inside sr_eval_gpu container
 	@echo "Running Full Stage E Pipeline inside sr_eval_gpu..."
@@ -12,13 +17,15 @@ run-issue120-stage-e-full: ## Run the full 68-page pipeline inside sr_eval_gpu c
 		-e PDFSCORE_HOMR_VERBOSE_INTERNAL_LOGS \
 		-e PDFSCORE_SR_TILE_LOGS \
 		pdfscore_pipeline_gpu \
-		/bin/sh -lc '/opt/venv_pipeline/bin/python tools/issue120/run_stage_e_full_pipeline.py --config $(ISSUE120_STAGE_E_CONFIG) --output-root $(ISSUE120_STAGE_E_OUTPUT) $(ISSUE120_STAGE_E_EXTRA_ARGS); status=$$?; chmod -R a+rwX $(ISSUE120_STAGE_E_OUTPUT)/stage_e_full_pipeline 2>/dev/null || true; exit $$status'
+		/bin/sh -lc '/opt/venv_pipeline/bin/python tools/issue120/run_stage_e_full_pipeline.py --config $(ISSUE120_STAGE_E_CONFIG) --output-root $(ISSUE120_STAGE_E_OUTPUT) $(ISSUE120_STAGE_E_EXTRA_ARGS); status=$$?; chmod -R a+rwX $(ISSUE120_STAGE_E_RUN_ROOT) 2>/dev/null || true; exit $$status'
 
-eval-issue120-stage-e-full: ## Evaluate Stage E detector metrics from manifest
-	@echo "Evaluating Stage E Detector Metrics from manifest..."
-	@PYTHONPATH=. python3 tools/issue120/eval_stage_e_from_manifest.py \
-		--manifest $(ISSUE120_STAGE_E_MANIFEST) \
-		--gt-root data/evaluation2/annotations \
-		--output-dir $(ISSUE120_STAGE_E_EVAL_DIR) \
-		--score-threshold 0.1 \
-		--xdist-threshold 12.0
+eval-issue120-stage-e-full: ## Build Stage E eval inputs and write detector contract outputs
+	@echo "Evaluating Stage E Detector Contract from full-pipeline artifacts..."
+	@PYTHONPATH=. python3 tools/issue120/eval_stage_e_contract.py \
+		--output-root $(ISSUE120_STAGE_E_OUTPUT) \
+		--eval-inputs-dir $(ISSUE120_STAGE_E_EVAL_INPUTS_DIR) \
+		--eval-output-dir $(ISSUE120_STAGE_E_EVAL_DIR) \
+		--gt-root $(ISSUE120_STAGE_E_GT_ROOT) \
+		--score-threshold $(ISSUE120_STAGE_E_SCORE_THRESHOLD) \
+		--xdist-threshold $(ISSUE120_STAGE_E_XDIST_THRESHOLD) \
+		$(ISSUE120_STAGE_E_EVAL_EXTRA_ARGS)

--- a/tools/issue120/Makefile.stage_e.mk
+++ b/tools/issue120/Makefile.stage_e.mk
@@ -6,6 +6,7 @@ ISSUE120_STAGE_E_EVAL_DIR ?= $(ISSUE120_STAGE_E_RUN_ROOT)/eval_detector
 ISSUE120_STAGE_E_GT_ROOT ?= data/evaluation2/annotations
 ISSUE120_STAGE_E_SCORE_THRESHOLD ?= 0.1
 ISSUE120_STAGE_E_XDIST_THRESHOLD ?= 12.0
+ISSUE120_STAGE_E_SMOKE_PAGES ?= 2
 ISSUE120_STAGE_E_EXTRA_ARGS ?=
 ISSUE120_STAGE_E_EVAL_EXTRA_ARGS ?=
 
@@ -29,3 +30,10 @@ eval-issue120-stage-e-full: ## Build Stage E eval inputs and write detector cont
 		--score-threshold $(ISSUE120_STAGE_E_SCORE_THRESHOLD) \
 		--xdist-threshold $(ISSUE120_STAGE_E_XDIST_THRESHOLD) \
 		$(ISSUE120_STAGE_E_EVAL_EXTRA_ARGS)
+
+eval-issue120-stage-e-smoke: ## Smoke-check Stage E contract wiring on the first N pages
+	@echo "Smoke-checking Stage E Detector Contract wiring from full-pipeline artifacts..."
+	@$(MAKE) eval-issue120-stage-e-full \
+		ISSUE120_STAGE_E_EVAL_INPUTS_DIR=$(ISSUE120_STAGE_E_RUN_ROOT)/eval_inputs_smoke \
+		ISSUE120_STAGE_E_EVAL_DIR=$(ISSUE120_STAGE_E_RUN_ROOT)/eval_detector_smoke \
+		ISSUE120_STAGE_E_EVAL_EXTRA_ARGS="--page-limit $(ISSUE120_STAGE_E_SMOKE_PAGES) --allow-partial --allow-target-mismatch $(ISSUE120_STAGE_E_EVAL_EXTRA_ARGS)"

--- a/tools/issue120/eval_stage_e_contract.py
+++ b/tools/issue120/eval_stage_e_contract.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
-"""Run Stage E detector contract evaluation from a full-pipeline output root.
-
-The Stage E runner writes full-pipeline scored files and reconstructed candidate
-files in separate production-oriented artifact trees. This wrapper materializes
-an evaluator-compatible ``eval_inputs`` tree from those artifacts, then delegates
-metric calculation and contract writing to ``eval_full68_from_intermediates.py``.
-"""
+"""Run Stage E detector contract evaluation from a full-pipeline output root."""
 
 from __future__ import annotations
 
@@ -45,9 +39,7 @@ class MissingStageEArtifactError(RuntimeError):
 
 
 def _stage_e_run_root(args: argparse.Namespace) -> Path:
-    if args.run_root is not None:
-        return args.run_root
-    return args.output_root / "stage_e_full_pipeline"
+    return args.run_root or args.output_root / "stage_e_full_pipeline"
 
 
 def _default_eval_inputs_dir(run_root: Path, args: argparse.Namespace) -> Path:
@@ -68,53 +60,27 @@ def _selected_records(args: argparse.Namespace) -> list[full68_eval.PageRecord]:
 
 
 def _candidate_paths(root: Path, record: full68_eval.PageRecord, filename: str) -> list[Path]:
+    score = record.score
+    page = record.page
     return [
-        root
-        / "intermediate"
-        / "probe_scan"
-        / f"eval2_images_{record.score}_{record.page}"
-        / filename,
-        root
-        / "dense_candidate_reconstruction"
-        / "probe_candidates_from_inventory"
-        / record.score
-        / record.page
-        / filename,
-        root
-        / "dense_candidate_reconstruction"
-        / "probe_candidates_filtered"
-        / record.score
-        / record.page
-        / filename,
-        root
-        / "dense_candidate_reconstruction"
-        / "probe_rescue_candidates"
-        / record.score
-        / record.page
-        / filename,
+        root / "intermediate" / "probe_scan" / f"eval2_images_{score}_{page}" / filename,
+        root / "dense_candidate_reconstruction" / "probe_candidates_from_inventory" / score / page / filename,
+        root / "dense_candidate_reconstruction" / "probe_candidates_filtered" / score / page / filename,
+        root / "dense_candidate_reconstruction" / "probe_rescue_candidates" / score / page / filename,
     ]
 
 
 def _scored_paths(root: Path, record: full68_eval.PageRecord, filename: str) -> list[Path]:
+    score = record.score
+    page = record.page
     return [
-        root
-        / "intermediate"
-        / "probe_scan"
-        / f"eval2_images_{record.score}_{record.page}"
-        / filename,
-        root
-        / "intermediate"
-        / "probe_scan"
-        / f"eval2_{record.score}_{record.page}"
-        / filename,
+        root / "intermediate" / "probe_scan" / f"eval2_images_{score}_{page}" / filename,
+        root / "intermediate" / "probe_scan" / f"eval2_{score}_{page}" / filename,
     ]
 
 
 def _first_existing(paths: list[Path]) -> Path | None:
-    for path in paths:
-        if path.exists():
-            return path
-    return None
+    return next((path for path in paths if path.exists()), None)
 
 
 def _materialize_file(src: Path, dst: Path, *, mode: str) -> None:
@@ -124,7 +90,7 @@ def _materialize_file(src: Path, dst: Path, *, mode: str) -> None:
     if mode == "copy":
         shutil.copy2(src, dst)
     elif mode == "symlink":
-        dst.symlink_to(src.resolve())
+        dst.symlink_to(os.path.relpath(src, dst.parent))
     elif mode == "hardlink":
         os.link(src, dst)
     else:
@@ -150,21 +116,11 @@ def _prepare_eval_inputs(args: argparse.Namespace) -> tuple[Path, list[dict[str,
         page_dir = eval_inputs_dir / f"eval2_{record.score}_{record.page}"
 
         if scored_src is None:
-            missing.append(
-                f"missing scored file for {record.score}/{record.page}: {args.scored_file}"
-            )
+            missing.append(f"missing scored file for {record.score}/{record.page}: {args.scored_file}")
         else:
-            _materialize_file(
-                scored_src,
-                page_dir / args.scored_file,
-                mode=args.link_mode,
-            )
+            _materialize_file(scored_src, page_dir / args.scored_file, mode=args.link_mode)
 
         if candidates_src is None:
-            message = (
-                f"missing candidates file for {record.score}/{record.page}: "
-                f"{args.candidates_file}"
-            )
             if args.allow_missing_candidates:
                 records.append(
                     {
@@ -177,13 +133,9 @@ def _prepare_eval_inputs(args: argparse.Namespace) -> tuple[Path, list[dict[str,
                     }
                 )
                 continue
-            missing.append(message)
+            missing.append(f"missing candidates file for {record.score}/{record.page}: {args.candidates_file}")
         else:
-            _materialize_file(
-                candidates_src,
-                page_dir / args.candidates_file,
-                mode=args.link_mode,
-            )
+            _materialize_file(candidates_src, page_dir / args.candidates_file, mode=args.link_mode)
 
         records.append(
             {
@@ -218,19 +170,12 @@ def _prepare_eval_inputs(args: argparse.Namespace) -> tuple[Path, list[dict[str,
 
     if missing:
         missing_path = eval_inputs_dir / "missing_stage_e_artifacts.json"
-        missing_path.write_text(
-            json.dumps(missing, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
-        raise MissingStageEArtifactError(
-            f"Missing {len(missing)} Stage E artifact(s). See {missing_path}"
-        )
-
+        missing_path.write_text(json.dumps(missing, indent=2, ensure_ascii=False), encoding="utf-8")
+        raise MissingStageEArtifactError(f"Missing {len(missing)} Stage E artifact(s). See {missing_path}")
     return eval_inputs_dir, records
 
 
-def _build_eval_args(
-    args: argparse.Namespace, eval_inputs_dir: Path, eval_output_dir: Path
-) -> argparse.Namespace:
+def _build_eval_args(args: argparse.Namespace, eval_inputs_dir: Path, eval_output_dir: Path) -> argparse.Namespace:
     return argparse.Namespace(
         results_dir=str(eval_inputs_dir),
         gt_root=str(args.gt_root),
@@ -249,14 +194,12 @@ def _build_eval_args(
 def _metric_matches(actual: int | float | None, expected: int | float) -> bool:
     if actual is None:
         return False
-    if isinstance(expected, float):
-        return abs(float(actual) - expected) <= 1e-12
-    return int(actual) == expected
+    if isinstance(expected, float) or isinstance(actual, float):
+        return abs(float(actual) - float(expected)) <= 1e-12
+    return actual == expected
 
 
-def _canonical_mismatches(
-    summary: full68_eval.DetectorSummary,
-) -> dict[str, dict[str, int | float | None]]:
+def _canonical_mismatches(summary: full68_eval.DetectorSummary) -> dict[str, dict[str, int | float | None]]:
     payload = asdict(summary)
     mismatches: dict[str, dict[str, int | float | None]] = {}
     for key, expected in EXPECTED_DETECTOR_METRICS.items():
@@ -297,72 +240,23 @@ def _print_summary(
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--output-root",
-        type=Path,
-        default=Path("logs/issue120_e2e_recovery"),
-        help="Output root passed to run_stage_e_full_pipeline.py.",
-    )
-    parser.add_argument(
-        "--run-root",
-        type=Path,
-        default=None,
-        help="Explicit Stage E run root. Defaults to <output-root>/stage_e_full_pipeline.",
-    )
-    parser.add_argument(
-        "--eval-inputs-dir",
-        type=Path,
-        default=None,
-        help="Evaluator-compatible input directory. Defaults under the Stage E run root.",
-    )
-    parser.add_argument(
-        "--eval-output-dir",
-        type=Path,
-        default=None,
-        help="Contract output directory. Defaults to <run-root>/eval_detector.",
-    )
-    parser.add_argument(
-        "--page-limit",
-        type=int,
-        default=None,
-        help="Evaluate only the first N canonical pages. Use with --allow-partial for smoke tests.",
-    )
+    parser.add_argument("--output-root", type=Path, default=Path("logs/issue120_e2e_recovery"))
+    parser.add_argument("--run-root", type=Path, default=None)
+    parser.add_argument("--eval-inputs-dir", type=Path, default=None)
+    parser.add_argument("--eval-output-dir", type=Path, default=None)
+    parser.add_argument("--page-limit", type=int, default=None)
     parser.add_argument("--gt-root", type=Path, default=Path("data/evaluation2/annotations"))
     parser.add_argument("--scored-file", default="pipeline2_no_peak_scored.json")
     parser.add_argument("--candidates-file", default="pipeline2_no_peak_candidates.json")
     parser.add_argument("--score-threshold", type=float, default=0.1)
-    parser.add_argument(
-        "--rule-name", default="center_anchor", choices=["center_anchor", "baseline_iou"]
-    )
+    parser.add_argument("--rule-name", default="center_anchor", choices=["center_anchor", "baseline_iou"])
     parser.add_argument("--vov-threshold", type=float, default=0.5)
     parser.add_argument("--xdist-threshold", type=float, default=12.0)
-    parser.add_argument(
-        "--link-mode",
-        choices=["copy", "symlink", "hardlink"],
-        default="copy",
-        help="How to materialize evaluator inputs. Copy is the portable default.",
-    )
-    parser.add_argument(
-        "--allow-partial",
-        action="store_true",
-        help="Pass through to eval_full68_from_intermediates.py for incomplete page sets.",
-    )
-    parser.add_argument(
-        "--allow-missing-candidates",
-        action="store_true",
-        help="Permit contract evaluation without candidate files; fn_det/fn_cnn may be null.",
-    )
-    parser.add_argument(
-        "--allow-target-mismatch",
-        action="store_true",
-        help="Write outputs and exit 0 even when canonical detector metrics differ.",
-    )
-    parser.add_argument(
-        "--measure-summary-json",
-        type=Path,
-        default=None,
-        help="Optional downstream measure-count summary JSON to attach to the contract.",
-    )
+    parser.add_argument("--link-mode", choices=["copy", "symlink", "hardlink"], default="copy")
+    parser.add_argument("--allow-partial", action="store_true")
+    parser.add_argument("--allow-missing-candidates", action="store_true")
+    parser.add_argument("--allow-target-mismatch", action="store_true")
+    parser.add_argument("--measure-summary-json", type=Path, default=None)
     return parser
 
 

--- a/tools/issue120/eval_stage_e_contract.py
+++ b/tools/issue120/eval_stage_e_contract.py
@@ -18,8 +18,10 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(SCRIPT_DIR))
 
 import eval_full68_from_intermediates as full68_eval  # noqa: E402
 
@@ -54,6 +56,15 @@ def _default_eval_inputs_dir(run_root: Path, args: argparse.Namespace) -> Path:
 
 def _default_eval_output_dir(run_root: Path, args: argparse.Namespace) -> Path:
     return args.eval_output_dir or run_root / "eval_detector"
+
+
+def _selected_records(args: argparse.Namespace) -> list[full68_eval.PageRecord]:
+    records = full68_eval.iter_manifest()
+    if args.page_limit is None:
+        return records
+    if args.page_limit <= 0:
+        raise ValueError("--page-limit must be positive when provided")
+    return records[: args.page_limit]
 
 
 def _candidate_paths(root: Path, record: full68_eval.PageRecord, filename: str) -> list[Path]:
@@ -130,9 +141,10 @@ def _prepare_eval_inputs(args: argparse.Namespace) -> tuple[Path, list[dict[str,
         shutil.rmtree(eval_inputs_dir)
     eval_inputs_dir.mkdir(parents=True, exist_ok=True)
 
+    selected_records = _selected_records(args)
     records: list[dict[str, Any]] = []
     missing: list[str] = []
-    for record in full68_eval.iter_manifest():
+    for record in selected_records:
         scored_src = _first_existing(_scored_paths(run_root, record, args.scored_file))
         candidates_src = _first_existing(_candidate_paths(run_root, record, args.candidates_file))
         page_dir = eval_inputs_dir / f"eval2_{record.score}_{record.page}"
@@ -193,6 +205,8 @@ def _prepare_eval_inputs(args: argparse.Namespace) -> tuple[Path, list[dict[str,
                 "link_mode": args.link_mode,
                 "scored_file": args.scored_file,
                 "candidates_file": args.candidates_file,
+                "selected_page_count": len(selected_records),
+                "canonical_page_count": len(full68_eval.iter_manifest()),
                 "page_count": len(records),
                 "records": records,
             },
@@ -307,6 +321,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Contract output directory. Defaults to <run-root>/eval_detector.",
     )
+    parser.add_argument(
+        "--page-limit",
+        type=int,
+        default=None,
+        help="Evaluate only the first N canonical pages. Use with --allow-partial for smoke tests.",
+    )
     parser.add_argument("--gt-root", type=Path, default=Path("data/evaluation2/annotations"))
     parser.add_argument("--scored-file", default="pipeline2_no_peak_scored.json")
     parser.add_argument("--candidates-file", default="pipeline2_no_peak_candidates.json")
@@ -348,6 +368,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = build_parser().parse_args()
+    if args.page_limit is not None and not args.allow_partial:
+        raise SystemExit("--page-limit is intended for smoke tests and requires --allow-partial")
     run_root = _stage_e_run_root(args)
     eval_inputs_dir, _records = _prepare_eval_inputs(args)
     eval_output_dir = _default_eval_output_dir(run_root, args)

--- a/tools/issue120/eval_stage_e_contract.py
+++ b/tools/issue120/eval_stage_e_contract.py
@@ -2,7 +2,7 @@
 """Run Stage E detector contract evaluation from a full-pipeline output root.
 
 The Stage E runner writes full-pipeline scored files and reconstructed candidate
-files in separate production-oriented artifact trees.  This wrapper materializes
+files in separate production-oriented artifact trees. This wrapper materializes
 an evaluator-compatible ``eval_inputs`` tree from those artifacts, then delegates
 metric calculation and contract writing to ``eval_full68_from_intermediates.py``.
 """
@@ -14,6 +14,7 @@ import json
 import os
 import shutil
 import sys
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
@@ -90,7 +91,11 @@ def _scored_paths(root: Path, record: full68_eval.PageRecord, filename: str) -> 
         / "probe_scan"
         / f"eval2_images_{record.score}_{record.page}"
         / filename,
-        root / "intermediate" / "probe_scan" / f"eval2_{record.score}_{record.page}" / filename,
+        root
+        / "intermediate"
+        / "probe_scan"
+        / f"eval2_{record.score}_{record.page}"
+        / filename,
     ]
 
 
@@ -145,7 +150,8 @@ def _prepare_eval_inputs(args: argparse.Namespace) -> tuple[Path, list[dict[str,
 
         if candidates_src is None:
             message = (
-                f"missing candidates file for {record.score}/{record.page}: {args.candidates_file}"
+                f"missing candidates file for {record.score}/{record.page}: "
+                f"{args.candidates_file}"
             )
             if args.allow_missing_candidates:
                 records.append(
@@ -198,7 +204,9 @@ def _prepare_eval_inputs(args: argparse.Namespace) -> tuple[Path, list[dict[str,
 
     if missing:
         missing_path = eval_inputs_dir / "missing_stage_e_artifacts.json"
-        missing_path.write_text(json.dumps(missing, indent=2, ensure_ascii=False), encoding="utf-8")
+        missing_path.write_text(
+            json.dumps(missing, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
         raise MissingStageEArtifactError(
             f"Missing {len(missing)} Stage E artifact(s). See {missing_path}"
         )
@@ -235,7 +243,7 @@ def _metric_matches(actual: int | float | None, expected: int | float) -> bool:
 def _canonical_mismatches(
     summary: full68_eval.DetectorSummary,
 ) -> dict[str, dict[str, int | float | None]]:
-    payload = full68_eval.asdict(summary)
+    payload = asdict(summary)
     mismatches: dict[str, dict[str, int | float | None]] = {}
     for key, expected in EXPECTED_DETECTOR_METRICS.items():
         actual = payload.get(key)
@@ -260,8 +268,8 @@ def _print_summary(
     print(f"Pages: {summary.page_count}/{summary.expected_page_count}")
     print(
         "Detector: "
-        f"GT={summary.gt} Pred={summary.pred} TP={summary.tp} FP={summary.fp} FN={summary.fn} "
-        f"FN_det={summary.fn_det} FN_cnn={summary.fn_cnn} "
+        f"GT={summary.gt} Pred={summary.pred} TP={summary.tp} FP={summary.fp} "
+        f"FN={summary.fn} FN_det={summary.fn_det} FN_cnn={summary.fn_cnn} "
         f"Precision={full68_eval.format_metric(summary.precision)} "
         f"Recall={full68_eval.format_metric(summary.recall)}"
     )

--- a/tools/issue120/eval_stage_e_contract.py
+++ b/tools/issue120/eval_stage_e_contract.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Run Stage E detector contract evaluation from a full-pipeline output root.
+
+The Stage E runner writes full-pipeline scored files and reconstructed candidate
+files in separate production-oriented artifact trees.  This wrapper materializes
+an evaluator-compatible ``eval_inputs`` tree from those artifacts, then delegates
+metric calculation and contract writing to ``eval_full68_from_intermediates.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import eval_full68_from_intermediates as full68_eval  # noqa: E402
+
+EXPECTED_DETECTOR_METRICS: dict[str, int | float] = {
+    "page_count": 68,
+    "expected_page_count": 68,
+    "gt": 3581,
+    "pred": 3600,
+    "tp": 3580,
+    "fp": 0,
+    "fn": 1,
+    "fn_det": 0,
+    "fn_cnn": 1,
+    "precision": 1.0,
+    "recall": 0.9997207483943032,
+}
+
+
+class MissingStageEArtifactError(RuntimeError):
+    """Raised when the Stage E run root does not contain required artifacts."""
+
+
+def _stage_e_run_root(args: argparse.Namespace) -> Path:
+    if args.run_root is not None:
+        return args.run_root
+    return args.output_root / "stage_e_full_pipeline"
+
+
+def _default_eval_inputs_dir(run_root: Path, args: argparse.Namespace) -> Path:
+    return args.eval_inputs_dir or run_root / "eval_inputs"
+
+
+def _default_eval_output_dir(run_root: Path, args: argparse.Namespace) -> Path:
+    return args.eval_output_dir or run_root / "eval_detector"
+
+
+def _candidate_paths(root: Path, record: full68_eval.PageRecord, filename: str) -> list[Path]:
+    return [
+        root
+        / "intermediate"
+        / "probe_scan"
+        / f"eval2_images_{record.score}_{record.page}"
+        / filename,
+        root
+        / "dense_candidate_reconstruction"
+        / "probe_candidates_from_inventory"
+        / record.score
+        / record.page
+        / filename,
+        root
+        / "dense_candidate_reconstruction"
+        / "probe_candidates_filtered"
+        / record.score
+        / record.page
+        / filename,
+        root
+        / "dense_candidate_reconstruction"
+        / "probe_rescue_candidates"
+        / record.score
+        / record.page
+        / filename,
+    ]
+
+
+def _scored_paths(root: Path, record: full68_eval.PageRecord, filename: str) -> list[Path]:
+    return [
+        root
+        / "intermediate"
+        / "probe_scan"
+        / f"eval2_images_{record.score}_{record.page}"
+        / filename,
+        root / "intermediate" / "probe_scan" / f"eval2_{record.score}_{record.page}" / filename,
+    ]
+
+
+def _first_existing(paths: list[Path]) -> Path | None:
+    for path in paths:
+        if path.exists():
+            return path
+    return None
+
+
+def _materialize_file(src: Path, dst: Path, *, mode: str) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists() or dst.is_symlink():
+        dst.unlink()
+    if mode == "copy":
+        shutil.copy2(src, dst)
+    elif mode == "symlink":
+        dst.symlink_to(src.resolve())
+    elif mode == "hardlink":
+        os.link(src, dst)
+    else:
+        raise ValueError(f"Unknown link mode: {mode}")
+
+
+def _prepare_eval_inputs(args: argparse.Namespace) -> tuple[Path, list[dict[str, Any]]]:
+    run_root = _stage_e_run_root(args)
+    if not run_root.exists():
+        raise MissingStageEArtifactError(f"Stage E run root not found: {run_root}")
+
+    eval_inputs_dir = _default_eval_inputs_dir(run_root, args)
+    if eval_inputs_dir.exists():
+        shutil.rmtree(eval_inputs_dir)
+    eval_inputs_dir.mkdir(parents=True, exist_ok=True)
+
+    records: list[dict[str, Any]] = []
+    missing: list[str] = []
+    for record in full68_eval.iter_manifest():
+        scored_src = _first_existing(_scored_paths(run_root, record, args.scored_file))
+        candidates_src = _first_existing(_candidate_paths(run_root, record, args.candidates_file))
+        page_dir = eval_inputs_dir / f"eval2_{record.score}_{record.page}"
+
+        if scored_src is None:
+            missing.append(
+                f"missing scored file for {record.score}/{record.page}: {args.scored_file}"
+            )
+        else:
+            _materialize_file(
+                scored_src,
+                page_dir / args.scored_file,
+                mode=args.link_mode,
+            )
+
+        if candidates_src is None:
+            message = (
+                f"missing candidates file for {record.score}/{record.page}: {args.candidates_file}"
+            )
+            if args.allow_missing_candidates:
+                records.append(
+                    {
+                        "score": record.score,
+                        "page": record.page,
+                        "scored_source": str(scored_src) if scored_src else None,
+                        "candidates_source": None,
+                        "candidates_status": "missing_allowed",
+                        "eval_input_dir": str(page_dir),
+                    }
+                )
+                continue
+            missing.append(message)
+        else:
+            _materialize_file(
+                candidates_src,
+                page_dir / args.candidates_file,
+                mode=args.link_mode,
+            )
+
+        records.append(
+            {
+                "score": record.score,
+                "page": record.page,
+                "scored_source": str(scored_src) if scored_src else None,
+                "candidates_source": str(candidates_src) if candidates_src else None,
+                "candidates_status": "present" if candidates_src else "missing",
+                "eval_input_dir": str(page_dir),
+            }
+        )
+
+    manifest_path = eval_inputs_dir / "input_manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "tools.issue120.stage_e_eval_inputs.v1",
+                "stage_e_run_root": str(run_root),
+                "link_mode": args.link_mode,
+                "scored_file": args.scored_file,
+                "candidates_file": args.candidates_file,
+                "page_count": len(records),
+                "records": records,
+            },
+            indent=2,
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    if missing:
+        missing_path = eval_inputs_dir / "missing_stage_e_artifacts.json"
+        missing_path.write_text(json.dumps(missing, indent=2, ensure_ascii=False), encoding="utf-8")
+        raise MissingStageEArtifactError(
+            f"Missing {len(missing)} Stage E artifact(s). See {missing_path}"
+        )
+
+    return eval_inputs_dir, records
+
+
+def _build_eval_args(
+    args: argparse.Namespace, eval_inputs_dir: Path, eval_output_dir: Path
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        results_dir=str(eval_inputs_dir),
+        gt_root=str(args.gt_root),
+        output_dir=str(eval_output_dir),
+        scored_file=args.scored_file,
+        candidates_file=args.candidates_file,
+        score_threshold=args.score_threshold,
+        rule_name=args.rule_name,
+        vov_threshold=args.vov_threshold,
+        xdist_threshold=args.xdist_threshold,
+        allow_partial=args.allow_partial,
+        measure_summary_json=args.measure_summary_json,
+    )
+
+
+def _metric_matches(actual: int | float | None, expected: int | float) -> bool:
+    if actual is None:
+        return False
+    if isinstance(expected, float):
+        return abs(float(actual) - expected) <= 1e-12
+    return int(actual) == expected
+
+
+def _canonical_mismatches(
+    summary: full68_eval.DetectorSummary,
+) -> dict[str, dict[str, int | float | None]]:
+    payload = full68_eval.asdict(summary)
+    mismatches: dict[str, dict[str, int | float | None]] = {}
+    for key, expected in EXPECTED_DETECTOR_METRICS.items():
+        actual = payload.get(key)
+        if not _metric_matches(actual, expected):
+            mismatches[key] = {"expected": expected, "actual": actual}
+    return mismatches
+
+
+def _print_summary(
+    *,
+    run_root: Path,
+    eval_inputs_dir: Path,
+    eval_output_dir: Path,
+    contract: full68_eval.EvaluationContract,
+    mismatches: dict[str, dict[str, int | float | None]],
+) -> None:
+    summary = contract.detector_summary
+    print("Stage E contract evaluation")
+    print(f"Stage E run root: {run_root}")
+    print(f"Eval inputs: {eval_inputs_dir}")
+    print(f"Contract outputs: {eval_output_dir}")
+    print(f"Pages: {summary.page_count}/{summary.expected_page_count}")
+    print(
+        "Detector: "
+        f"GT={summary.gt} Pred={summary.pred} TP={summary.tp} FP={summary.fp} FN={summary.fn} "
+        f"FN_det={summary.fn_det} FN_cnn={summary.fn_cnn} "
+        f"Precision={full68_eval.format_metric(summary.precision)} "
+        f"Recall={full68_eval.format_metric(summary.recall)}"
+    )
+    if mismatches:
+        print("Canonical detector target: NOT MET")
+        for key, values in mismatches.items():
+            print(f"  {key}: expected={values['expected']} actual={values['actual']}")
+    else:
+        print("Canonical detector target: MET")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path("logs/issue120_e2e_recovery"),
+        help="Output root passed to run_stage_e_full_pipeline.py.",
+    )
+    parser.add_argument(
+        "--run-root",
+        type=Path,
+        default=None,
+        help="Explicit Stage E run root. Defaults to <output-root>/stage_e_full_pipeline.",
+    )
+    parser.add_argument(
+        "--eval-inputs-dir",
+        type=Path,
+        default=None,
+        help="Evaluator-compatible input directory. Defaults under the Stage E run root.",
+    )
+    parser.add_argument(
+        "--eval-output-dir",
+        type=Path,
+        default=None,
+        help="Contract output directory. Defaults to <run-root>/eval_detector.",
+    )
+    parser.add_argument("--gt-root", type=Path, default=Path("data/evaluation2/annotations"))
+    parser.add_argument("--scored-file", default="pipeline2_no_peak_scored.json")
+    parser.add_argument("--candidates-file", default="pipeline2_no_peak_candidates.json")
+    parser.add_argument("--score-threshold", type=float, default=0.1)
+    parser.add_argument(
+        "--rule-name", default="center_anchor", choices=["center_anchor", "baseline_iou"]
+    )
+    parser.add_argument("--vov-threshold", type=float, default=0.5)
+    parser.add_argument("--xdist-threshold", type=float, default=12.0)
+    parser.add_argument(
+        "--link-mode",
+        choices=["copy", "symlink", "hardlink"],
+        default="copy",
+        help="How to materialize evaluator inputs. Copy is the portable default.",
+    )
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Pass through to eval_full68_from_intermediates.py for incomplete page sets.",
+    )
+    parser.add_argument(
+        "--allow-missing-candidates",
+        action="store_true",
+        help="Permit contract evaluation without candidate files; fn_det/fn_cnn may be null.",
+    )
+    parser.add_argument(
+        "--allow-target-mismatch",
+        action="store_true",
+        help="Write outputs and exit 0 even when canonical detector metrics differ.",
+    )
+    parser.add_argument(
+        "--measure-summary-json",
+        type=Path,
+        default=None,
+        help="Optional downstream measure-count summary JSON to attach to the contract.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    run_root = _stage_e_run_root(args)
+    eval_inputs_dir, _records = _prepare_eval_inputs(args)
+    eval_output_dir = _default_eval_output_dir(run_root, args)
+    contract = full68_eval.evaluate(_build_eval_args(args, eval_inputs_dir, eval_output_dir))
+    mismatches = _canonical_mismatches(contract.detector_summary)
+    _print_summary(
+        run_root=run_root,
+        eval_inputs_dir=eval_inputs_dir,
+        eval_output_dir=eval_output_dir,
+        contract=contract,
+        mismatches=mismatches,
+    )
+    if mismatches and not args.allow_target_mismatch:
+        raise SystemExit("Canonical Stage E detector target was not met.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `tools/issue120/eval_stage_e_contract.py` to materialize evaluator-compatible Stage E `eval_inputs` from the current full-pipeline output layout and then delegate metric/contract writing to `eval_full68_from_intermediates.py`.
- Add a small partial smoke path via `--page-limit` and `make eval-issue120-stage-e-smoke` so artifact discovery and contract-output writing can be checked before running the full 68-page evaluation.
- Update `make eval-issue120-stage-e-full` to run the new contract evaluator from `ISSUE120_STAGE_E_OUTPUT`.
- Document the smoke-first flow, full one-command flow, canonical detector target, and expected artifact locations in `docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md`.

## Scope notes

- Does not change detector thresholds, candidate generation, scoring, NMS, or acceptance logic.
- `logs/` artifacts remain ignored/local only.
- The evaluator takes `--output-root` / `ISSUE120_STAGE_E_OUTPUT` as the Stage E run input root and defaults outputs under that run root.
- The smoke target is partial by design and passes `--allow-partial --allow-target-mismatch`; it is intended to catch wiring/layout/output failures, not to assert the canonical 68-page metric target.

## Validation

- Syntax-checked the new wrapper locally as a standalone Python file before committing its contents.
- User confirmed compile check passed locally.
- Full canonical Stage E execution was not run here because it requires the local GPU/container/data environment.

Closes #180