### PR TITLE
Require explicit CNN model path for issue 185

### DIFF
--- a/src/pipeline/steps/cnn_scoring.py
+++ b/src/pipeline/steps/cnn_scoring.py
@@ -37,19 +37,25 @@ class GPUNormalize(torch.nn.Module):
         return (x - self.mean) / self.std
 
 
-def _resolve_model_path(model_path: Path) -> Path:
-    if model_path.is_file():
-        return model_path
-    if model_path.exists():
+def _resolve_model_path(model_path: Path | str | None) -> Path:
+    if model_path is None:
+        raise ValueError(
+            "CNN model path is not configured (None). "
+            "Configure detection.cnn_model_path to an existing model file."
+        )
+    resolved_path = Path(model_path)
+    if resolved_path.is_file():
+        return resolved_path
+    if resolved_path.exists():
         raise FileNotFoundError(
             "CNN model path is not a file. "
             "Configure detection.cnn_model_path to an existing model file. "
-            f"Configured path: {model_path}"
+            f"Configured path: {resolved_path}"
         )
     raise FileNotFoundError(
         "CNN model file not found. "
         "Configure detection.cnn_model_path to an existing model file. "
-        f"Configured path: {model_path}"
+        f"Configured path: {resolved_path}"
     )
 
 
@@ -376,7 +382,7 @@ def run_cnn_scoring_batch(
     *,
     probe_output_root: Path,
     images: Iterable[Path],
-    model_path: Path,
+    model_path: Path | str | None,
     threshold: float,
     score_name: Optional[str] = None,
     batch_size: int = 64,

--- a/src/pipeline/steps/cnn_scoring.py
+++ b/src/pipeline/steps/cnn_scoring.py
@@ -38,12 +38,19 @@ class GPUNormalize(torch.nn.Module):
 
 
 def _resolve_model_path(model_path: Path) -> Path:
-    if model_path.exists():
+    if model_path.is_file():
         return model_path
-    candidates = list(Path("experiments/cnn_classifier").rglob("best_model.pth"))
-    if candidates:
-        return candidates[0]
-    raise FileNotFoundError(f"Model not found: {model_path}")
+    if model_path.exists():
+        raise FileNotFoundError(
+            "CNN model path is not a file. "
+            "Configure detection.cnn_model_path to an existing model file. "
+            f"Configured path: {model_path}"
+        )
+    raise FileNotFoundError(
+        "CNN model file not found. "
+        "Configure detection.cnn_model_path to an existing model file. "
+        f"Configured path: {model_path}"
+    )
 
 
 def _load_model(model_path: Path, device: torch.device) -> torch.nn.Module:

--- a/tests/test_cnn_scoring_model_path.py
+++ b/tests/test_cnn_scoring_model_path.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("torchvision")
+
+from src.pipeline.steps.cnn_scoring import _resolve_model_path
+
+
+def test_resolve_model_path_requires_existing_file(tmp_path):
+    missing_model = tmp_path / "missing_model.pth"
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        _resolve_model_path(missing_model)
+
+    message = str(exc_info.value)
+    assert "CNN model file not found" in message
+    assert "detection.cnn_model_path" in message
+    assert str(missing_model) in message
+
+
+def test_resolve_model_path_rejects_directory(tmp_path):
+    model_dir = tmp_path / "model_dir"
+    model_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        _resolve_model_path(model_dir)
+
+    message = str(exc_info.value)
+    assert "CNN model path is not a file" in message
+    assert "detection.cnn_model_path" in message
+    assert str(model_dir) in message
+
+
+def test_resolve_model_path_accepts_existing_file(tmp_path):
+    model_path = tmp_path / "model.pth"
+    model_path.write_bytes(b"placeholder")
+
+    assert _resolve_model_path(model_path) == model_path

--- a/tests/test_cnn_scoring_model_path.py
+++ b/tests/test_cnn_scoring_model_path.py
@@ -38,3 +38,19 @@ def test_resolve_model_path_accepts_existing_file(tmp_path):
     model_path.write_bytes(b"placeholder")
 
     assert _resolve_model_path(model_path) == model_path
+
+
+def test_resolve_model_path_accepts_existing_file_string(tmp_path):
+    model_path = tmp_path / "model.pth"
+    model_path.write_bytes(b"placeholder")
+
+    assert _resolve_model_path(str(model_path)) == model_path
+
+
+def test_resolve_model_path_rejects_none():
+    with pytest.raises(ValueError) as exc_info:
+        _resolve_model_path(None)
+
+    message = str(exc_info.value)
+    assert "CNN model path is not configured" in message
+    assert "detection.cnn_model_path" in message


### PR DESCRIPTION
Summary:

- Remove the fallback search under `experiments/cnn_classifier/**/best_model.pth` from `src/pipeline/steps/cnn_scoring.py`.
- Require `detection.cnn_model_path` to point to an explicitly configured model file.
- Raise explicit errors for missing paths, directory paths, and missing `detection.cnn_model_path` configuration.
- Normalize string model paths through `Path(...)`.
- Add focused tests for model path resolution behavior, including `Path`, `str`, directory, missing-file, and `None` cases.

Validation:

Maintainer confirmed the following local checks passed after fast-forwarding to the latest PR head:

```bash
git diff --check
PYTHONPYCACHEPREFIX=/tmp/pycache-issue185 \
PYTHONPATH=. .venv_pdf/bin/python -m py_compile \
  src/pipeline/steps/cnn_scoring.py \
  tests/test_cnn_scoring_model_path.py
PYTHONPATH=. .venv_pdf/bin/python -m pytest \
  tests/test_cnn_scoring_model_path.py
```

Result:

```text
collected 5 items
tests/test_cnn_scoring_model_path.py ..... [100%]
5 passed
```

Closes #185.