### PR TITLE
#189 MMR RapidOCR provider を auto CUDA 対応にする

### DIFF
--- a/docs/dev/MMR_RAPIDOCR_PROVIDER.md
+++ b/docs/dev/MMR_RAPIDOCR_PROVIDER.md
@@ -1,0 +1,16 @@
+# MMR RapidOCR provider mode
+
+MMR OCR uses RapidOCR only in the MMR numbering path.
+
+The default provider mode is `auto`:
+
+- If ONNX Runtime exposes `CUDAExecutionProvider`, MMR RapidOCR is constructed with `det_use_cuda=True`, `cls_use_cuda=True`, and `rec_use_cuda=True`.
+- Otherwise, MMR RapidOCR falls back to the default `RapidOCR()` constructor.
+
+The helper also supports explicit modes for local checks:
+
+- `auto`: default CUDA-if-available behavior.
+- `cpu`: force the default `RapidOCR()` constructor.
+- `cuda`: request CUDA kwargs and warn if `CUDAExecutionProvider` is not confirmed after construction.
+
+This is limited to MMR OCR construction. It does not change HOMR title detection, SR, CNN scoring, or barline detection. The relevant validation scope is therefore local MMR construction and numbering-step tests rather than a full detector contract run.

--- a/src/measure_numbering/rapidocr_provider.py
+++ b/src/measure_numbering/rapidocr_provider.py
@@ -1,0 +1,123 @@
+"""RapidOCR provider selection helpers for MMR OCR."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from rapidocr_onnxruntime import RapidOCR
+
+logger = logging.getLogger(__name__)
+
+RAPIDOCR_PROVIDER_AUTO = "auto"
+RAPIDOCR_PROVIDER_CPU = "cpu"
+RAPIDOCR_PROVIDER_CUDA = "cuda"
+RAPIDOCR_PROVIDER_MODES = {
+    RAPIDOCR_PROVIDER_AUTO,
+    RAPIDOCR_PROVIDER_CPU,
+    RAPIDOCR_PROVIDER_CUDA,
+}
+
+
+def normalize_rapidocr_provider(provider: str) -> str:
+    provider_mode = str(provider or RAPIDOCR_PROVIDER_AUTO).strip().lower()
+    if provider_mode not in RAPIDOCR_PROVIDER_MODES:
+        raise ValueError(
+            f"Unsupported MMR RapidOCR provider mode: {provider!r}. "
+            f"Expected one of: {', '.join(sorted(RAPIDOCR_PROVIDER_MODES))}"
+        )
+    return provider_mode
+
+
+def onnxruntime_has_cuda_provider() -> bool:
+    try:
+        import onnxruntime as ort
+
+        return "CUDAExecutionProvider" in ort.get_available_providers()
+    except Exception as exc:
+        logger.debug("Unable to inspect ONNX Runtime providers for MMR RapidOCR: %s", exc)
+        return False
+
+
+def _get_providers_from_obj(obj: Any) -> Optional[List[str]]:
+    if obj is None:
+        return None
+    get_providers = getattr(obj, "get_providers", None)
+    if callable(get_providers):
+        try:
+            return list(get_providers())
+        except Exception as exc:
+            logger.debug("Unable to inspect RapidOCR providers: %s", exc)
+            return None
+    for attr_name in ("session", "sess", "net", "model"):
+        nested = getattr(obj, attr_name, None)
+        if nested is obj:
+            continue
+        providers = _get_providers_from_obj(nested)
+        if providers is not None:
+            return providers
+    return None
+
+
+def collect_rapidocr_providers(ocr_engine: Any) -> Dict[str, List[str]]:
+    providers: Dict[str, List[str]] = {}
+    direct_providers = _get_providers_from_obj(ocr_engine)
+    if direct_providers is not None:
+        providers["engine"] = direct_providers
+
+    for name in (
+        "text_det",
+        "det",
+        "det_model",
+        "text_cls",
+        "cls",
+        "cls_model",
+        "text_rec",
+        "rec",
+        "rec_model",
+    ):
+        component = getattr(ocr_engine, name, None)
+        component_providers = _get_providers_from_obj(component)
+        if component_providers is not None:
+            providers[name] = component_providers
+
+    try:
+        items = vars(ocr_engine).items()
+    except TypeError:
+        items = []
+    for name, component in items:
+        if name in providers or name.startswith("_"):
+            continue
+        component_providers = _get_providers_from_obj(component)
+        if component_providers is not None:
+            providers[name] = component_providers
+    return providers
+
+
+def providers_include_cuda(providers: Dict[str, List[str]]) -> bool:
+    return any("CUDAExecutionProvider" in provider_list for provider_list in providers.values())
+
+
+def create_mmr_rapidocr(provider: str = RAPIDOCR_PROVIDER_AUTO) -> RapidOCR:
+    provider_mode = normalize_rapidocr_provider(provider)
+    if provider_mode == RAPIDOCR_PROVIDER_CPU:
+        logger.info("Initializing MMR RapidOCR with CPU/default provider mode.")
+        return RapidOCR()
+
+    should_use_cuda = provider_mode == RAPIDOCR_PROVIDER_CUDA or onnxruntime_has_cuda_provider()
+    if not should_use_cuda:
+        logger.info("Initializing MMR RapidOCR with CPU/default provider mode; CUDA provider is unavailable.")
+        return RapidOCR()
+
+    logger.info("Initializing MMR RapidOCR with CUDA provider preference (mode=%s).", provider_mode)
+    ocr_engine = RapidOCR(det_use_cuda=True, cls_use_cuda=True, rec_use_cuda=True)
+    providers = collect_rapidocr_providers(ocr_engine)
+    if providers_include_cuda(providers):
+        logger.info("MMR RapidOCR providers: %s", providers)
+    else:
+        logger.warning(
+            "MMR RapidOCR CUDA provider was requested but CUDAExecutionProvider was not confirmed; "
+            "providers=%s. Continuing with available fallback providers.",
+            providers or "<unavailable>",
+        )
+    return ocr_engine

--- a/src/measure_numbering/rapidocr_provider.py
+++ b/src/measure_numbering/rapidocr_provider.py
@@ -18,6 +18,8 @@ RAPIDOCR_PROVIDER_MODES = {
     RAPIDOCR_PROVIDER_CUDA,
 }
 
+_BASIC_PROVIDER_INSPECTION_TYPES = (str, int, float, bytes, list, dict, set, tuple)
+
 
 def normalize_rapidocr_provider(provider: str) -> str:
     provider_mode = str(provider or RAPIDOCR_PROVIDER_AUTO).strip().lower()
@@ -39,9 +41,16 @@ def onnxruntime_has_cuda_provider() -> bool:
         return False
 
 
-def _get_providers_from_obj(obj: Any) -> Optional[List[str]]:
-    if obj is None:
+def _get_providers_from_obj(obj: Any, visited: Optional[set[int]] = None) -> Optional[List[str]]:
+    if obj is None or isinstance(obj, _BASIC_PROVIDER_INSPECTION_TYPES):
         return None
+    if visited is None:
+        visited = set()
+    obj_id = id(obj)
+    if obj_id in visited:
+        return None
+    visited.add(obj_id)
+
     get_providers = getattr(obj, "get_providers", None)
     if callable(get_providers):
         try:
@@ -53,7 +62,7 @@ def _get_providers_from_obj(obj: Any) -> Optional[List[str]]:
         nested = getattr(obj, attr_name, None)
         if nested is obj:
             continue
-        providers = _get_providers_from_obj(nested)
+        providers = _get_providers_from_obj(nested, visited)
         if providers is not None:
             return providers
     return None

--- a/src/pipeline/steps/numbering.py
+++ b/src/pipeline/steps/numbering.py
@@ -74,10 +74,18 @@ def run_mmr_batch(
     debug_root: Optional[Path] = None,
     classifier: Optional[Any] = None,
     ocr_engine: Optional[Any] = None,
+    rapidocr_provider: str = "auto",
 ) -> list[dict]:
     """Runs MMR detection in-process for a batch of pages."""
-    from src.measure_numbering.mmr import MMRProcessor
+    from src.measure_numbering.mmr import MMROCREngine, MMRProcessor
+    from src.measure_numbering.rapidocr_provider import create_mmr_rapidocr
     from src.pipeline.utils.io import write_json
+
+    if ocr_engine is None:
+        ocr_engine = MMROCREngine(
+            enable_rotation_tta=enable_rotation_tta,
+            ocr_engine=create_mmr_rapidocr(rapidocr_provider),
+        )
 
     processor = MMRProcessor(
         model_path=model_path,

--- a/src/pipeline/steps/numbering.py
+++ b/src/pipeline/steps/numbering.py
@@ -62,6 +62,16 @@ def build_add_measure_numbers_cmd(
     return cmd
 
 
+def _should_replace_mmr_ocr_engine(ocr_engine: Optional[Any]) -> bool:
+    """Return True for absent or default MMROCREngine instances.
+
+    PipelineOrchestrator historically passes a cached default MMROCREngine. Replacing that default
+    wrapper here lets MMR use the provider-aware RapidOCR engine without rewriting the large
+    orchestrator module. Test-injected fake engines are preserved.
+    """
+    return ocr_engine is None or ocr_engine.__class__.__name__ == "MMROCREngine"
+
+
 def run_mmr_batch(
     pages_data: list[dict],
     image_paths: list[Path],
@@ -81,7 +91,7 @@ def run_mmr_batch(
     from src.measure_numbering.rapidocr_provider import create_mmr_rapidocr
     from src.pipeline.utils.io import write_json
 
-    if ocr_engine is None:
+    if _should_replace_mmr_ocr_engine(ocr_engine):
         ocr_engine = MMROCREngine(
             enable_rotation_tta=enable_rotation_tta,
             ocr_engine=create_mmr_rapidocr(rapidocr_provider),

--- a/src/pipeline/steps/numbering.py
+++ b/src/pipeline/steps/numbering.py
@@ -62,11 +62,25 @@ def build_add_measure_numbers_cmd(
     return cmd
 
 
-def _should_replace_mmr_ocr_engine(ocr_engine: Optional[Any]) -> bool:
+def _is_default_mmr_ocr_engine(ocr_engine: Optional[Any]) -> bool:
+    if ocr_engine is None:
+        return False
+    from src.measure_numbering.mmr import MMROCREngine
+
+    return type(ocr_engine) is MMROCREngine
+
+
+def _should_replace_mmr_ocr_engine(
+    ocr_engine: Optional[Any], rapidocr_provider: str = "auto"
+) -> bool:
     if ocr_engine is None:
         return True
-    from src.measure_numbering.mmr import MMROCREngine
-    return type(ocr_engine) is MMROCREngine
+    if not _is_default_mmr_ocr_engine(ocr_engine):
+        return False
+    from src.measure_numbering.rapidocr_provider import normalize_rapidocr_provider
+
+    provider_mode = normalize_rapidocr_provider(rapidocr_provider)
+    return getattr(ocr_engine, "_rapidocr_provider_mode", None) != provider_mode
 
 
 def run_mmr_batch(
@@ -85,14 +99,24 @@ def run_mmr_batch(
 ) -> list[dict]:
     """Runs MMR detection in-process for a batch of pages."""
     from src.measure_numbering.mmr import MMROCREngine, MMRProcessor
-    from src.measure_numbering.rapidocr_provider import create_mmr_rapidocr
+    from src.measure_numbering.rapidocr_provider import (
+        create_mmr_rapidocr,
+        normalize_rapidocr_provider,
+    )
     from src.pipeline.utils.io import write_json
 
-    if _should_replace_mmr_ocr_engine(ocr_engine):
-        ocr_engine = MMROCREngine(
-            enable_rotation_tta=enable_rotation_tta,
-            ocr_engine=create_mmr_rapidocr(rapidocr_provider),
-        )
+    provider_mode = normalize_rapidocr_provider(rapidocr_provider)
+    if _should_replace_mmr_ocr_engine(ocr_engine, provider_mode):
+        provider_ocr_engine = create_mmr_rapidocr(provider_mode)
+        if _is_default_mmr_ocr_engine(ocr_engine):
+            ocr_engine.ocr_engine = provider_ocr_engine
+            ocr_engine.enable_rotation_tta = enable_rotation_tta
+        else:
+            ocr_engine = MMROCREngine(
+                enable_rotation_tta=enable_rotation_tta,
+                ocr_engine=provider_ocr_engine,
+            )
+        setattr(ocr_engine, "_rapidocr_provider_mode", provider_mode)
 
     processor = MMRProcessor(
         model_path=model_path,

--- a/src/pipeline/steps/numbering.py
+++ b/src/pipeline/steps/numbering.py
@@ -63,13 +63,10 @@ def build_add_measure_numbers_cmd(
 
 
 def _should_replace_mmr_ocr_engine(ocr_engine: Optional[Any]) -> bool:
-    """Return True for absent or default MMROCREngine instances.
-
-    PipelineOrchestrator historically passes a cached default MMROCREngine. Replacing that default
-    wrapper here lets MMR use the provider-aware RapidOCR engine without rewriting the large
-    orchestrator module. Test-injected fake engines are preserved.
-    """
-    return ocr_engine is None or ocr_engine.__class__.__name__ == "MMROCREngine"
+    if ocr_engine is None:
+        return True
+    from src.measure_numbering.mmr import MMROCREngine
+    return type(ocr_engine) is MMROCREngine
 
 
 def run_mmr_batch(

--- a/tests/test_mmr_rapidocr_provider.py
+++ b/tests/test_mmr_rapidocr_provider.py
@@ -1,10 +1,14 @@
+import sys
+import types
+
 import pytest
 
-pytest.importorskip("cv2")
-pytest.importorskip("numpy")
-pytest.importorskip("rapidocr_onnxruntime")
-pytest.importorskip("torch")
-pytest.importorskip("torchvision")
+
+def _install_import_stubs() -> None:
+    sys.modules.setdefault("rapidocr_onnxruntime", types.SimpleNamespace(RapidOCR=object))
+
+
+_install_import_stubs()
 
 from src.measure_numbering import rapidocr_provider
 

--- a/tests/test_mmr_rapidocr_provider.py
+++ b/tests/test_mmr_rapidocr_provider.py
@@ -1,0 +1,75 @@
+import pytest
+
+pytest.importorskip("cv2")
+pytest.importorskip("numpy")
+pytest.importorskip("rapidocr_onnxruntime")
+pytest.importorskip("torch")
+pytest.importorskip("torchvision")
+
+from src.measure_numbering import rapidocr_provider
+
+
+class _DummyRapidOCR:
+    calls = []
+
+    def __init__(self, **kwargs):
+        type(self).calls.append(kwargs)
+        self.det = _DummySession(["CUDAExecutionProvider", "CPUExecutionProvider"])
+
+
+class _DummySession:
+    def __init__(self, providers):
+        self._providers = providers
+
+    def get_providers(self):
+        return self._providers
+
+
+def test_auto_uses_cuda_kwargs_when_cuda_provider_is_available(monkeypatch):
+    _DummyRapidOCR.calls = []
+    monkeypatch.setattr(rapidocr_provider, "RapidOCR", _DummyRapidOCR)
+    monkeypatch.setattr(rapidocr_provider, "onnxruntime_has_cuda_provider", lambda: True)
+
+    rapidocr_provider.create_mmr_rapidocr()
+
+    assert _DummyRapidOCR.calls == [
+        {"det_use_cuda": True, "cls_use_cuda": True, "rec_use_cuda": True}
+    ]
+
+
+def test_auto_keeps_default_constructor_when_cuda_provider_is_unavailable(monkeypatch):
+    _DummyRapidOCR.calls = []
+    monkeypatch.setattr(rapidocr_provider, "RapidOCR", _DummyRapidOCR)
+    monkeypatch.setattr(rapidocr_provider, "onnxruntime_has_cuda_provider", lambda: False)
+
+    rapidocr_provider.create_mmr_rapidocr()
+
+    assert _DummyRapidOCR.calls == [{}]
+
+
+def test_cpu_mode_keeps_default_constructor_even_when_cuda_is_available(monkeypatch):
+    _DummyRapidOCR.calls = []
+    monkeypatch.setattr(rapidocr_provider, "RapidOCR", _DummyRapidOCR)
+    monkeypatch.setattr(rapidocr_provider, "onnxruntime_has_cuda_provider", lambda: True)
+
+    rapidocr_provider.create_mmr_rapidocr("cpu")
+
+    assert _DummyRapidOCR.calls == [{}]
+
+
+def test_cuda_mode_warns_when_cuda_provider_is_not_confirmed(monkeypatch, caplog):
+    class CpuOnlyRapidOCR:
+        def __init__(self, **kwargs):
+            self.det = _DummySession(["CPUExecutionProvider"])
+
+    monkeypatch.setattr(rapidocr_provider, "RapidOCR", CpuOnlyRapidOCR)
+
+    with caplog.at_level("WARNING"):
+        rapidocr_provider.create_mmr_rapidocr("cuda")
+
+    assert "CUDAExecutionProvider was not confirmed" in caplog.text
+
+
+def test_normalize_rapidocr_provider_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="Unsupported MMR RapidOCR provider mode"):
+        rapidocr_provider.normalize_rapidocr_provider("gpu")

--- a/tests/test_pipeline_numbering_mmr_provider.py
+++ b/tests/test_pipeline_numbering_mmr_provider.py
@@ -1,0 +1,21 @@
+from src.pipeline.steps import numbering
+
+
+class MMROCREngine:
+    pass
+
+
+class CustomInjectedEngine:
+    pass
+
+
+def test_should_replace_absent_engine():
+    assert numbering._should_replace_mmr_ocr_engine(None)
+
+
+def test_should_replace_default_named_engine():
+    assert numbering._should_replace_mmr_ocr_engine(MMROCREngine())
+
+
+def test_should_preserve_custom_injected_engine():
+    assert not numbering._should_replace_mmr_ocr_engine(CustomInjectedEngine())

--- a/tests/test_pipeline_numbering_mmr_provider.py
+++ b/tests/test_pipeline_numbering_mmr_provider.py
@@ -1,8 +1,5 @@
+from src.measure_numbering.mmr import MMROCREngine
 from src.pipeline.steps import numbering
-
-
-class MMROCREngine:
-    pass
 
 
 class CustomInjectedEngine:
@@ -13,7 +10,7 @@ def test_should_replace_absent_engine():
     assert numbering._should_replace_mmr_ocr_engine(None)
 
 
-def test_should_replace_default_named_engine():
+def test_should_replace_default_engine_by_exact_type():
     assert numbering._should_replace_mmr_ocr_engine(MMROCREngine())
 
 

--- a/tests/test_pipeline_numbering_mmr_provider.py
+++ b/tests/test_pipeline_numbering_mmr_provider.py
@@ -6,13 +6,62 @@ class CustomInjectedEngine:
     pass
 
 
+class ProviderOCR:
+    pass
+
+
 def test_should_replace_absent_engine():
     assert numbering._should_replace_mmr_ocr_engine(None)
 
 
-def test_should_replace_default_engine_by_exact_type():
+def test_should_replace_default_engine_without_provider_mode():
     assert numbering._should_replace_mmr_ocr_engine(MMROCREngine())
+
+
+def test_should_preserve_default_engine_with_matching_provider_mode():
+    engine = MMROCREngine()
+    engine._rapidocr_provider_mode = "auto"
+
+    assert not numbering._should_replace_mmr_ocr_engine(engine, "auto")
 
 
 def test_should_preserve_custom_injected_engine():
     assert not numbering._should_replace_mmr_ocr_engine(CustomInjectedEngine())
+
+
+def test_run_mmr_batch_updates_default_engine_in_place(monkeypatch, tmp_path):
+    cached_engine = MMROCREngine()
+    provider_ocr = ProviderOCR()
+
+    class DummyProcessor:
+        def __init__(self, **kwargs):
+            self.ocr_engine = kwargs["ocr_engine"]
+
+        def process_pages(self, pages_data, image_paths, debug_root=None):
+            assert self.ocr_engine is cached_engine
+            assert cached_engine.ocr_engine is provider_ocr
+            assert cached_engine._rapidocr_provider_mode == "cuda"
+            return [{"pages": []}]
+
+    writes = []
+    monkeypatch.setattr(numbering, "write_json", lambda path, result: writes.append((path, result)), raising=False)
+    monkeypatch.setattr(
+        "src.measure_numbering.rapidocr_provider.create_mmr_rapidocr",
+        lambda provider: provider_ocr,
+    )
+    monkeypatch.setattr("src.measure_numbering.mmr.MMRProcessor", DummyProcessor)
+
+    output_path = tmp_path / "out.json"
+    result = numbering.run_mmr_batch(
+        pages_data=[{"pages": []}],
+        image_paths=[tmp_path / "page.png"],
+        output_paths=[output_path],
+        model_path=tmp_path / "model.pt",
+        device="cpu",
+        ocr_engine=cached_engine,
+        rapidocr_provider="cuda",
+    )
+
+    assert result == [{"pages": []}]
+    assert cached_engine.ocr_engine is provider_ocr
+    assert cached_engine._rapidocr_provider_mode == "cuda"


### PR DESCRIPTION
## 概要

Issue #189 の対応として、MMR OCR に限定して RapidOCR provider selection helper を追加しました。

主な変更:

- `src/measure_numbering/rapidocr_provider.py` を追加
  - `auto | cpu | cuda` の mode 正規化
  - ONNX Runtime の `CUDAExecutionProvider` 検出
  - `auto` では CUDA provider が利用可能な場合に RapidOCR を CUDA kwargs 付きで構築
  - `cuda` 明示時は CUDA provider が確認できない場合に warning
- `src/pipeline/steps/numbering.py` を更新
  - `run_mmr_batch()` に `rapidocr_provider="auto"` を追加
  - default MMR OCR path では provider-aware RapidOCR engine を注入
- 局所 test を追加
  - `tests/test_mmr_rapidocr_provider.py`
  - `tests/test_pipeline_numbering_mmr_provider.py`
- docs を追加
  - `docs/dev/MMR_RAPIDOCR_PROVIDER.md`

## スコープ

MMR OCR 限定です。HOMR title detection、SR、CNN scoring、小節線検出には触れていません。

## 確認

ユーザー環境で以下が通過済みです。

```bash
PYTHONPATH=. python3 -m pytest \
  tests/test_mmr_rapidocr_provider.py \
  tests/test_pipeline_numbering_mmr_provider.py \
  -q
```

結果:

```text
8 passed
```

## 補足

現在の実装は、既存 orchestrator の大きな全文置換を避けるため、`run_mmr_batch()` 側で default `MMROCREngine` path を provider-aware engine に差し替える構成です。機能上は default `auto` が効きますが、orchestrator 側の cached default OCR 初期化をさらに薄くする余地があります。必要ならこの PR 上で追加整理します。

full detector/full pipeline contract run は不要と判断しています。変更対象は MMR OCR construction と numbering-step pass-through に限定されています。