### PR TITLE
Fix #200 MMR OCR heuristic guards

### DIFF
--- a/src/measure_numbering/mmr.py
+++ b/src/measure_numbering/mmr.py
@@ -238,8 +238,14 @@ class MMROCREngine:
     def _candidate_items(self, ocr_result: List) -> List[Tuple[List, str]]:
         """Return raw and merged OCR items so merges do not erase valid single digits."""
         raw_items = [(item, "raw") for item in ocr_result]
-        merged_items = [(item, "merged") for item in self.merge_ocr_results(list(ocr_result))]
+        merged_results = self.merge_ocr_results(list(ocr_result))
+        merged_items = [(item, "merged") for item in merged_results if item not in ocr_result]
         return raw_items + merged_items
+
+    def _extract_numeric_candidates(self, text: str, blacklisted: bool) -> List[str]:
+        if blacklisted:
+            return re.findall(r"(?<![A-Za-z])\d+(?![A-Za-z])", text)
+        return re.findall(r"\d+", text)
 
     def select_best_candidate(
         self, ocr_result: List, img_width: int, img_height: int
@@ -254,11 +260,8 @@ class MMROCREngine:
             box_points, text, _ = item
             clean_text = re.sub(r"^[EP](\d)", r"\1", text)
             clean_text = re.sub(r"[.,;]", "", clean_text)
-            nums_found = re.findall(r"\d+", clean_text)
-
             blacklisted = self._has_blacklisted_text(text)
-            if blacklisted and not nums_found:
-                continue
+            nums_found = self._extract_numeric_candidates(clean_text, blacklisted)
             if not nums_found:
                 continue
 
@@ -289,8 +292,6 @@ class MMROCREngine:
                         score -= 50
                     if val > 20 and img_width < 100:
                         score -= 200
-                    if source == "merged" and val > 20:
-                        score -= 40
 
                     debug_flags = [
                         f"dx={dist_x_norm:.2f}",
@@ -300,8 +301,6 @@ class MMROCREngine:
                     ]
                     if blacklisted:
                         debug_flags.append("blacklist_digit")
-                    if source == "merged" and val > 20:
-                        debug_flags.append("merged_high_count_penalty")
 
                     candidates.append(
                         {

--- a/src/measure_numbering/mmr.py
+++ b/src/measure_numbering/mmr.py
@@ -232,24 +232,33 @@ class MMROCREngine:
         merged.append(current_box)
         return merged
 
+    def _has_blacklisted_text(self, text: str) -> bool:
+        return any(b.lower() in text.lower() for b in self.blacklist)
+
+    def _candidate_items(self, ocr_result: List) -> List[Tuple[List, str]]:
+        """Return raw and merged OCR items so merges do not erase valid single digits."""
+        raw_items = [(item, "raw") for item in ocr_result]
+        merged_items = [(item, "merged") for item in self.merge_ocr_results(list(ocr_result))]
+        return raw_items + merged_items
+
     def select_best_candidate(
         self, ocr_result: List, img_width: int, img_height: int
     ) -> Tuple[Optional[int], float, str]:
         if not ocr_result:
             return None, 0, ""
 
-        ocr_result = self.merge_ocr_results(ocr_result)
         candidates = []
         center_x = img_width / 2.0
 
-        for item in ocr_result:
+        for item, source in self._candidate_items(ocr_result):
             box_points, text, _ = item
-            if any(b.lower() in text.lower() for b in self.blacklist):
-                continue
-
             clean_text = re.sub(r"^[EP](\d)", r"\1", text)
             clean_text = re.sub(r"[.,;]", "", clean_text)
             nums_found = re.findall(r"\d+", clean_text)
+
+            blacklisted = self._has_blacklisted_text(text)
+            if blacklisted and not nums_found:
+                continue
             if not nums_found:
                 continue
 
@@ -280,12 +289,25 @@ class MMROCREngine:
                         score -= 50
                     if val > 20 and img_width < 100:
                         score -= 200
+                    if source == "merged" and val > 20:
+                        score -= 40
+
+                    debug_flags = [
+                        f"dx={dist_x_norm:.2f}",
+                        f"dy={dist_y_norm:.2f}",
+                        f"h={h_ratio:.2f}",
+                        source,
+                    ]
+                    if blacklisted:
+                        debug_flags.append("blacklist_digit")
+                    if source == "merged" and val > 20:
+                        debug_flags.append("merged_high_count_penalty")
 
                     candidates.append(
                         {
                             "val": val,
                             "score": score,
-                            "debug": f"dx={dist_x_norm:.2f},dy={dist_y_norm:.2f},h={h_ratio:.2f}",
+                            "debug": ",".join(debug_flags),
                         }
                     )
                 except ValueError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_mmr_ocr_heuristics.py
+++ b/tests/test_mmr_ocr_heuristics.py
@@ -1,0 +1,83 @@
+import unittest
+
+try:
+    from src.measure_numbering.mmr import MMROCREngine
+except ModuleNotFoundError as exc:  # pragma: no cover - environment guard
+    MMROCREngine = None
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
+
+
+def _box(x1, y1, x2, y2):
+    return [[x1, y1], [x2, y1], [x2, y2], [x1, y2]]
+
+
+@unittest.skipIf(MMROCREngine is None, f"MMR OCR dependencies unavailable: {IMPORT_ERROR}")
+class TestMMROCRHeuristics(unittest.TestCase):
+    def setUp(self):
+        self.ocr = MMROCREngine(ocr_engine=object())
+
+    def test_blacklisted_text_without_digits_is_rejected(self):
+        num, score, debug = self.ocr.select_best_candidate(
+            [[_box(40, 25, 60, 75), "con sord.", 0.99]],
+            img_width=100,
+            img_height=100,
+        )
+
+        self.assertIsNone(num)
+        self.assertEqual(score, 0)
+        self.assertEqual(debug, "")
+
+    def test_digit_with_blacklisted_direction_remains_candidate(self):
+        num, _, debug = self.ocr.select_best_candidate(
+            [[_box(40, 25, 60, 75), "7 (con sord.)", 0.99]],
+            img_width=100,
+            img_height=100,
+        )
+
+        self.assertEqual(num, 7)
+        self.assertIn("blacklist_digit", debug)
+
+    def test_digit_with_blacklisted_instrument_remains_candidate(self):
+        num, _, debug = self.ocr.select_best_candidate(
+            [
+                [_box(40, 25, 55, 75), "(VC) 5", 0.99],
+                [_box(82, 25, 98, 75), "10]", 0.99],
+            ],
+            img_width=100,
+            img_height=100,
+        )
+
+        self.assertEqual(num, 5)
+        self.assertIn("blacklist_digit", debug)
+
+    def test_raw_single_digit_survives_high_count_merge_candidate(self):
+        num, _, debug = self.ocr.select_best_candidate(
+            [
+                [_box(45, 25, 50, 75), "3", 0.99],
+                [_box(52, 25, 57, 75), "9", 0.99],
+            ],
+            img_width=100,
+            img_height=100,
+        )
+
+        self.assertEqual(num, 3)
+        self.assertIn("raw", debug)
+
+    def test_legitimate_split_two_digit_candidate_still_wins(self):
+        num, _, debug = self.ocr.select_best_candidate(
+            [
+                [_box(43, 25, 48, 75), "1", 0.99],
+                [_box(50, 25, 55, 75), "5", 0.99],
+            ],
+            img_width=100,
+            img_height=100,
+        )
+
+        self.assertEqual(num, 15)
+        self.assertIn("merged", debug)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mmr_ocr_heuristics.py
+++ b/tests/test_mmr_ocr_heuristics.py
@@ -52,11 +52,24 @@ class TestMMROCRHeuristics(unittest.TestCase):
         self.assertEqual(num, 5)
         self.assertIn("blacklist_digit", debug)
 
-    def test_raw_single_digit_survives_high_count_merge_candidate(self):
+    def test_attached_digit_in_blacklisted_text_is_rejected(self):
+        for text in ["VC5", "Ob2"]:
+            with self.subTest(text=text):
+                num, score, debug = self.ocr.select_best_candidate(
+                    [[_box(40, 25, 60, 75), text, 0.99]],
+                    img_width=100,
+                    img_height=100,
+                )
+
+                self.assertIsNone(num)
+                self.assertEqual(score, 0)
+                self.assertEqual(debug, "")
+
+    def test_raw_single_digit_survives_ambiguous_high_count_merge_candidate(self):
         num, _, debug = self.ocr.select_best_candidate(
             [
-                [_box(45, 25, 50, 75), "3", 0.99],
-                [_box(52, 25, 57, 75), "9", 0.99],
+                [_box(48, 25, 53, 75), "3", 0.99],
+                [_box(76, 25, 81, 75), "9", 0.99],
             ],
             img_width=100,
             img_height=100,
@@ -76,6 +89,19 @@ class TestMMROCRHeuristics(unittest.TestCase):
         )
 
         self.assertEqual(num, 15)
+        self.assertIn("merged", debug)
+
+    def test_legitimate_split_high_count_candidate_still_wins(self):
+        num, _, debug = self.ocr.select_best_candidate(
+            [
+                [_box(43, 25, 48, 75), "3", 0.99],
+                [_box(50, 25, 55, 75), "9", 0.99],
+            ],
+            img_width=100,
+            img_height=100,
+        )
+
+        self.assertEqual(num, 39)
         self.assertIn("merged", debug)
 
 


### PR DESCRIPTION
## Summary

Fixes #200 scoped MMR OCR heuristic issues by narrowing the implementation to blacklist over-filtering and OCR merge candidate loss.

Changes:

- Allow OCR text containing blacklist words to still contribute numeric candidates when it contains an independent digit candidate.
  - Example: `7 (con sord.)`
  - Example: `(VC) 5`
- Preserve raw OCR candidates alongside merged OCR candidates so a merge such as `3` + `9` -> `39` does not erase the valid raw `3` candidate.
- Add unit-level regression tests for blacklist and merge behavior.
- Add `tests/conftest.py` so pytest can resolve repository-local `src.*` imports consistently.

Out of scope:

- #197 system/divisi grouping redesign
- #201 manual correction workflow
- CNN retraining or threshold tuning
- score-gate / page033 FP guard
- Stage E detector contract or full-pipeline detector work

## Validation

Host environment:

```text
pytest tests/test_mmr_ocr_heuristics.py tests/test_numbering_overrides.py
=> 2 passed, 5 skipped
```

The host CNN env skips MMR OCR tests because the runtime OCR dependencies are not available there.

Docker runtime (`pdfscore_pipeline_gpu`):

```text
pytest tests/test_mmr_ocr_heuristics.py tests/test_numbering_overrides.py
=> 6 passed, 1 skipped
```

MMR-only aggregate validation using Docker runtime:

```text
python tools/issue94/eval_all_mmr.py

Total Pages:         68
Total Base Measures: 3325
Total Expected:      182
Total Detected:      178
Matched (TP):        169
Missed (FN):         5
Skip Mismatch:       8
Unexpected (FP):     1
Precision:           0.9494
Recall:              0.9286
F1-Score:            0.9389
```

Relative to the pre-fix current residual framing (`TP=165 / FN=7 / mismatch=10 / FP=1`):

| metric | before | after | delta |
|---|---:|---:|---:|
| TP | 165 | 169 | +4 |
| FN | 7 | 5 | -2 |
| mismatch | 10 | 8 | -2 |
| FP | 1 | 1 | 0 |
| residual total | 18 | 14 | -4 |

Targeted trace confirmed intended fixes:

- `page_023 [22,4,4]`: `7 (con sord.)` -> selected `7`
- `page_049 [48,6,3]`: raw `3` selected instead of merged `39`
- `page_049 [48,6,6]`: `(VC) 5` -> selected `5`
- `page_025 [24,0,0]`: additional improvement, selected `5` instead of `97`

Known remaining residuals are intentionally not addressed by this PR, especially `page_033` current FP candidate and #197 grouping-related cases.