### PR TITLE
Fix existing ruff lint issues

### DIFF
--- a/docker/patch_homr_onnx_provider.py
+++ b/docker/patch_homr_onnx_provider.py
@@ -6,37 +6,36 @@ ONNX Runtime CUDA Conv fallback warnings when `cudnn_conv_algo_search` is
 warning while keeping the change limited to HOMR ONNX provider options.
 """
 
-from pathlib import Path
 import sysconfig
-
+from pathlib import Path
 
 HOMR_ROOT = Path(sysconfig.get_paths()["purelib"]) / "homr"
 ENCODER_PATH = HOMR_ROOT / "transformer" / "encoder_inference.py"
 DECODER_PATH = HOMR_ROOT / "transformer" / "decoder_inference.py"
 
 
-ENCODER_OLD = '''providers=[
+ENCODER_OLD = """providers=[
                         (
                             "CUDAExecutionProvider",
                             {
                                 "cudnn_conv_algo_search": "DEFAULT",
                             },
                         )
-                    ],'''
+                    ],"""
 
-ENCODER_NEW = '''providers=[
+ENCODER_NEW = """providers=[
                         (
                             "CUDAExecutionProvider",
                             {
                                 "cudnn_conv_algo_search": "HEURISTIC",
                             },
                         )
-                    ],'''
+                    ],"""
 
 DECODER_OLD = 'config.filepaths.decoder_path_fp16, providers=["CUDAExecutionProvider"]'
 
 DECODER_NEW = (
-    'config.filepaths.decoder_path_fp16, '
+    "config.filepaths.decoder_path_fp16, "
     'providers=[("CUDAExecutionProvider", {"cudnn_conv_algo_search": "HEURISTIC"})]'
 )
 

--- a/src/measure_numbering/rapidocr_provider.py
+++ b/src/measure_numbering/rapidocr_provider.py
@@ -115,7 +115,9 @@ def create_mmr_rapidocr(provider: str = RAPIDOCR_PROVIDER_AUTO) -> RapidOCR:
 
     should_use_cuda = provider_mode == RAPIDOCR_PROVIDER_CUDA or onnxruntime_has_cuda_provider()
     if not should_use_cuda:
-        logger.info("Initializing MMR RapidOCR with CPU/default provider mode; CUDA provider is unavailable.")
+        logger.info(
+            "Initializing MMR RapidOCR with CPU/default provider mode; CUDA provider is unavailable."
+        )
         return RapidOCR()
 
     logger.info("Initializing MMR RapidOCR with CUDA provider preference (mode=%s).", provider_mode)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_cnn_scoring_model_path.py
+++ b/tests/test_cnn_scoring_model_path.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 pytest.importorskip("torch")

--- a/tests/test_pipeline_numbering_mmr_provider.py
+++ b/tests/test_pipeline_numbering_mmr_provider.py
@@ -44,7 +44,9 @@ def test_run_mmr_batch_updates_default_engine_in_place(monkeypatch, tmp_path):
             return [{"pages": []}]
 
     writes = []
-    monkeypatch.setattr(numbering, "write_json", lambda path, result: writes.append((path, result)), raising=False)
+    monkeypatch.setattr(
+        numbering, "write_json", lambda path, result: writes.append((path, result)), raising=False
+    )
     monkeypatch.setattr(
         "src.measure_numbering.rapidocr_provider.create_mmr_rapidocr",
         lambda provider: provider_ocr,

--- a/tools/gt_relabel_gui/build_rest_gt_config.py
+++ b/tools/gt_relabel_gui/build_rest_gt_config.py
@@ -63,19 +63,19 @@ def main() -> None:
         try:
             with open(args.manifest, "r") as f:
                 manifest_data = json.load(f)
-            
+
             # Map page_id to work and page_str
             for p in manifest_data.get("pages", []):
                 page_id = p.get("page_id")
                 img_path_str = p.get("image_path", "")
                 if not page_id or not img_path_str:
                     continue
-                
+
                 # Extract work name and page stem
                 # e.g., logs/issue120_e2e_recovery/stage_e_full_pipeline/images/Sibelius-Violin_Concerto-Viola_page_001.png
                 img_path = Path(img_path_str)
                 img_name = img_path.name
-                
+
                 # Split work and page from Sibelius-Violin_Concerto-Viola_page_001.png
                 # Or Va__Prokofiev_Symphony5_page_001.png
                 # Try to extract the page token (e.g. page_001)
@@ -83,26 +83,30 @@ def main() -> None:
                 if not match:
                     # Alternates
                     match = re.search(r"(page_\d+)", img_name)
-                
+
                 if match:
                     page_token = match.group(1).lstrip("_")
-                    work_name = img_name.replace(f"_{page_token}.png", "").replace(f"{page_token}.png", "").rstrip("_")
+                    work_name = (
+                        img_name.replace(f"_{page_token}.png", "")
+                        .replace(f"{page_token}.png", "")
+                        .rstrip("_")
+                    )
                 else:
                     page_token = page_id
                     work_name = "unknown"
-                
+
                 # Check for numbering in intermediate/page_xxx/numbering_base.json
                 numbering_path = args.numbering_root / page_id / "numbering_base.json"
                 if not numbering_path.exists():
                     # Fallback to direct search
                     numbering_path = find_numbering_file(args.numbering_root, work_name, page_token)
-                
+
                 # Try to resolve actual image source path from data/evaluation2/images
                 resolved_img_path = args.images_root / work_name / f"{page_token}.png"
                 if not resolved_img_path.exists():
                     # Try alternate path structures
                     resolved_img_path = Path(img_path_str)
-                
+
                 if numbering_path and numbering_path.exists():
                     output_path = args.rest_gt_root / work_name / page_token / "rest_gt.json"
                     pages.append(
@@ -146,7 +150,9 @@ def main() -> None:
                         Path("logs/experiments/mmr_dataset_test"), work, page_str
                     )
                 if not numbering_path:
-                    numbering_path = find_numbering_file(Path("logs/cache_dataset_gen"), work, page_str)
+                    numbering_path = find_numbering_file(
+                        Path("logs/cache_dataset_gen"), work, page_str
+                    )
 
                 if numbering_path is None:
                     skipped.append(f"{work}/{page_str}")
@@ -174,4 +180,5 @@ def main() -> None:
 
 if __name__ == "__main__":
     import re
+
     main()

--- a/tools/issue120/eval_stage_e_contract.py
+++ b/tools/issue120/eval_stage_e_contract.py
@@ -64,9 +64,24 @@ def _candidate_paths(root: Path, record: full68_eval.PageRecord, filename: str) 
     page = record.page
     return [
         root / "intermediate" / "probe_scan" / f"eval2_images_{score}_{page}" / filename,
-        root / "dense_candidate_reconstruction" / "probe_candidates_from_inventory" / score / page / filename,
-        root / "dense_candidate_reconstruction" / "probe_candidates_filtered" / score / page / filename,
-        root / "dense_candidate_reconstruction" / "probe_rescue_candidates" / score / page / filename,
+        root
+        / "dense_candidate_reconstruction"
+        / "probe_candidates_from_inventory"
+        / score
+        / page
+        / filename,
+        root
+        / "dense_candidate_reconstruction"
+        / "probe_candidates_filtered"
+        / score
+        / page
+        / filename,
+        root
+        / "dense_candidate_reconstruction"
+        / "probe_rescue_candidates"
+        / score
+        / page
+        / filename,
     ]
 
 
@@ -116,7 +131,9 @@ def _prepare_eval_inputs(args: argparse.Namespace) -> tuple[Path, list[dict[str,
         page_dir = eval_inputs_dir / f"eval2_{record.score}_{record.page}"
 
         if scored_src is None:
-            missing.append(f"missing scored file for {record.score}/{record.page}: {args.scored_file}")
+            missing.append(
+                f"missing scored file for {record.score}/{record.page}: {args.scored_file}"
+            )
         else:
             _materialize_file(scored_src, page_dir / args.scored_file, mode=args.link_mode)
 
@@ -133,7 +150,9 @@ def _prepare_eval_inputs(args: argparse.Namespace) -> tuple[Path, list[dict[str,
                     }
                 )
                 continue
-            missing.append(f"missing candidates file for {record.score}/{record.page}: {args.candidates_file}")
+            missing.append(
+                f"missing candidates file for {record.score}/{record.page}: {args.candidates_file}"
+            )
         else:
             _materialize_file(candidates_src, page_dir / args.candidates_file, mode=args.link_mode)
 
@@ -171,11 +190,15 @@ def _prepare_eval_inputs(args: argparse.Namespace) -> tuple[Path, list[dict[str,
     if missing:
         missing_path = eval_inputs_dir / "missing_stage_e_artifacts.json"
         missing_path.write_text(json.dumps(missing, indent=2, ensure_ascii=False), encoding="utf-8")
-        raise MissingStageEArtifactError(f"Missing {len(missing)} Stage E artifact(s). See {missing_path}")
+        raise MissingStageEArtifactError(
+            f"Missing {len(missing)} Stage E artifact(s). See {missing_path}"
+        )
     return eval_inputs_dir, records
 
 
-def _build_eval_args(args: argparse.Namespace, eval_inputs_dir: Path, eval_output_dir: Path) -> argparse.Namespace:
+def _build_eval_args(
+    args: argparse.Namespace, eval_inputs_dir: Path, eval_output_dir: Path
+) -> argparse.Namespace:
     return argparse.Namespace(
         results_dir=str(eval_inputs_dir),
         gt_root=str(args.gt_root),
@@ -199,7 +222,9 @@ def _metric_matches(actual: int | float | None, expected: int | float) -> bool:
     return actual == expected
 
 
-def _canonical_mismatches(summary: full68_eval.DetectorSummary) -> dict[str, dict[str, int | float | None]]:
+def _canonical_mismatches(
+    summary: full68_eval.DetectorSummary,
+) -> dict[str, dict[str, int | float | None]]:
     payload = asdict(summary)
     mismatches: dict[str, dict[str, int | float | None]] = {}
     for key, expected in EXPECTED_DETECTOR_METRICS.items():
@@ -249,7 +274,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--scored-file", default="pipeline2_no_peak_scored.json")
     parser.add_argument("--candidates-file", default="pipeline2_no_peak_candidates.json")
     parser.add_argument("--score-threshold", type=float, default=0.1)
-    parser.add_argument("--rule-name", default="center_anchor", choices=["center_anchor", "baseline_iou"])
+    parser.add_argument(
+        "--rule-name", default="center_anchor", choices=["center_anchor", "baseline_iou"]
+    )
     parser.add_argument("--vov-threshold", type=float, default=0.5)
     parser.add_argument("--xdist-threshold", type=float, default=12.0)
     parser.add_argument("--link-mode", choices=["copy", "symlink", "hardlink"], default="copy")

--- a/tools/issue194/experiment_a.py
+++ b/tools/issue194/experiment_a.py
@@ -47,7 +47,9 @@ def analyze_system_first_measure(page_id, data):
                 "avg_staff_height": avg_staff_height,
                 "staff_left": staff_left,
                 "ratio_to_median": first_width / median_width if median_width > 0 else 0,
-                "ratio_to_staff_height": first_width / avg_staff_height if avg_staff_height > 0 else 0,
+                "ratio_to_staff_height": first_width / avg_staff_height
+                if avg_staff_height > 0
+                else 0,
                 "dist_to_first_bar": dist_to_first_bar,
             }
         )

--- a/tools/issue194/experiment_b.py
+++ b/tools/issue194/experiment_b.py
@@ -1,8 +1,12 @@
 import json
 from pathlib import Path
 
-SCORED_PATH = Path("logs/issue120_e2e_recovery/stage_e_full_pipeline/intermediate/probe_scan/eval2_images_Va__Prokofiev_Symphony5_page_015/pipeline2_no_peak_scored.json")
-FILTERED_PATH = Path("logs/issue120_e2e_recovery/stage_e_full_pipeline/intermediate/probe_scan/eval2_images_Va__Prokofiev_Symphony5_page_015/pipeline2_no_peak_filtered_cnn.json")
+SCORED_PATH = Path(
+    "logs/issue120_e2e_recovery/stage_e_full_pipeline/intermediate/probe_scan/eval2_images_Va__Prokofiev_Symphony5_page_015/pipeline2_no_peak_scored.json"
+)
+FILTERED_PATH = Path(
+    "logs/issue120_e2e_recovery/stage_e_full_pipeline/intermediate/probe_scan/eval2_images_Va__Prokofiev_Symphony5_page_015/pipeline2_no_peak_filtered_cnn.json"
+)
 
 
 def analyze_scores():
@@ -16,24 +20,29 @@ def analyze_scores():
         scored_data = json.load(f)
     with open(FILTERED_PATH, "r") as f:
         json.load(f)
-        
+
     sys10_filtered = [
         [580, 4005, 584, 4115],
         [1028, 4002, 1037, 4112],
         [1705, 4004, 1714, 4114],
         [2326, 4007, 2335, 4116],
         [2948, 4005, 2952, 4115],
-        [3465, 4009, 3475, 4119]
+        [3465, 4009, 3475, 4119],
     ]
-    
+
     print("\n--- Search Sys 10 barlines in scored data ---")
     for target in sys10_filtered:
         found = False
         for item in scored_data:
-            if isinstance(item, dict) and 'bbox' in item:
-                bbox = item['bbox']
-                score = item['score']
-                if abs(bbox[0] - target[0]) <= 2 and abs(bbox[1] - target[1]) <= 2 and abs(bbox[2] - target[2]) <= 2 and abs(bbox[3] - target[3]) <= 2:
+            if isinstance(item, dict) and "bbox" in item:
+                bbox = item["bbox"]
+                score = item["score"]
+                if (
+                    abs(bbox[0] - target[0]) <= 2
+                    and abs(bbox[1] - target[1]) <= 2
+                    and abs(bbox[2] - target[2]) <= 2
+                    and abs(bbox[3] - target[3]) <= 2
+                ):
                     print(f"Target: {target} -> Found! BBox={bbox}, Score={score:.6f}")
                     found = True
                     break

--- a/tools/issue194/experiment_c.py
+++ b/tools/issue194/experiment_c.py
@@ -124,8 +124,12 @@ def analyze_page(page_id, info):
         print(f"  Staff 1 bbox: {s1_bbox}")
         print(f"  Staff 2 bbox: {s2_bbox}")
         print(f"  Vertical Gap: {gap} px (Ratio to Avg Staff Height: {ratio:.2f})")
-        print(f"  Aligned Barlines Count: {len(aligned_xs)} (positions: {[int(x) for x in aligned_xs]})")
-        print(f"  Ink Connection Check: {'CONNECTED' if connected else 'DISCONNECTED'} ({valid_conn_count} valid connections)")
+        print(
+            f"  Aligned Barlines Count: {len(aligned_xs)} (positions: {[int(x) for x in aligned_xs]})"
+        )
+        print(
+            f"  Ink Connection Check: {'CONNECTED' if connected else 'DISCONNECTED'} ({valid_conn_count} valid connections)"
+        )
         print(
             f"  Left Edge Diff: {abs(s1_bbox[0] - s2_bbox[0])} px, "
             f"Width Diff: {abs((s1_bbox[2] - s1_bbox[0]) - (s2_bbox[2] - s2_bbox[0]))} px"

--- a/tools/issue194/visualize_issue194.py
+++ b/tools/issue194/visualize_issue194.py
@@ -41,7 +41,9 @@ def draw_boxes(image, boxes, color, thickness=3, label_func=None):
         cv2.rectangle(img_copy, (x1, y1), (x2, y2), color, thickness)
         if label_func:
             label = label_func(i, box)
-            cv2.putText(img_copy, label, (x1, y1 - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.8, color, 2, cv2.LINE_AA)
+            cv2.putText(
+                img_copy, label, (x1, y1 - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.8, color, 2, cv2.LINE_AA
+            )
     return img_copy
 
 
@@ -100,7 +102,9 @@ def main():
             if x1_min != float("inf"):
                 system_boxes.append([int(x1_min), int(y1_min), int(x2_max), int(y2_max)])
 
-        img_system = draw_boxes(img, system_boxes, (0, 255, 255), thickness=4, label_func=lambda idx, box: f"Sys {idx}")
+        img_system = draw_boxes(
+            img, system_boxes, (0, 255, 255), thickness=4, label_func=lambda idx, box: f"Sys {idx}"
+        )
         cv2.imwrite(str(OUTPUT_DIR / f"system_bbox_{page_id}.png"), img_system)
 
         measure_boxes = []

--- a/tools/issue94/eval_all_mmr.py
+++ b/tools/issue94/eval_all_mmr.py
@@ -1,11 +1,12 @@
 import json
 import logging
 from pathlib import Path
-import torch
 
+import torch
 from src.measure_numbering.rapidocr_provider import normalize_rapidocr_provider
 from src.pipeline.steps.numbering import run_mmr_batch
-from tools.issue94.eval_mmr_overrides import _load_json, _write_json, _build_summary
+
+from tools.issue94.eval_mmr_overrides import _build_summary, _load_json, _write_json
 
 logging.basicConfig(
     level=logging.INFO,
@@ -64,7 +65,7 @@ def main():
         rapidocr_provider=normalize_rapidocr_provider(rapidocr_provider),
     )
     logger.info("run_mmr_batch completed. Generating summaries...")
-    
+
     total_base_measures = 0
     total_detected = 0
     total_expected = 0
@@ -72,18 +73,18 @@ def main():
     total_missed = 0
     total_skip_mismatch = 0
     total_unexpected = 0
-    
+
     page_summaries = []
-    
+
     # 各ページの要約を生成
     for p, nb_payload, out_path in zip(pages, pages_data, output_paths):
         page_id = p["page_id"]
         detected_payload = _load_json(out_path)
-        
+
         # Load expected overrides if exists
         expected_path = Path("tests/fixtures") / f"expected_overrides_{page_id}.json"
         expected_payload = _load_json(expected_path) if expected_path.exists() else None
-        
+
         summary = _build_summary(
             numbering_json=Path(p["numbering_base"]),
             image=Path(p["image"]),
@@ -96,7 +97,7 @@ def main():
             detected_payload=detected_payload,
             expected_payload=expected_payload,
         )
-        
+
         # Aggregate counts
         cnt = summary["counts"]
         total_base_measures += cnt["base_measures"]
@@ -106,25 +107,27 @@ def main():
         total_missed += cnt["missed"]
         total_skip_mismatch += cnt["skip_mismatch"]
         total_unexpected += cnt["unexpected"]
-        
-        page_summaries.append({
-            "page_id": page_id,
-            "image": Path(p["image"]).name,
-            "expected": cnt["expected_overrides"],
-            "detected": cnt["detected_overrides"],
-            "matched": cnt["matched"],
-            "missed": cnt["missed"],
-            "mismatch": cnt["skip_mismatch"],
-            "unexpected": cnt["unexpected"]
-        })
-        
+
+        page_summaries.append(
+            {
+                "page_id": page_id,
+                "image": Path(p["image"]).name,
+                "expected": cnt["expected_overrides"],
+                "detected": cnt["detected_overrides"],
+                "matched": cnt["matched"],
+                "missed": cnt["missed"],
+                "mismatch": cnt["skip_mismatch"],
+                "unexpected": cnt["unexpected"],
+            }
+        )
+
         summary_path = output_root / page_id / "mmr_eval_summary.json"
         _write_json(summary_path, summary)
-        
+
     # Print quantitative summary metrics
-    print("\n" + "="*50)
+    print("\n" + "=" * 50)
     print(" MMR EVALUATION METRICS SUMMARY (REST GT)")
-    print("="*50)
+    print("=" * 50)
     print(f"Total Pages:         {len(pages)}")
     print(f"Total Base Measures: {total_base_measures}")
     print(f"Total Expected:      {total_expected} (Positive MMRs in GT)")
@@ -133,20 +136,20 @@ def main():
     print(f"Missed (FN):         {total_missed}")
     print(f"Skip Mismatch:       {total_skip_mismatch}")
     print(f"Unexpected (FP):     {total_unexpected}")
-    
+
     # Calculate Precision / Recall
     # Precision = TP / (TP + FP) = Matched / Detected
     # Recall = TP / Expected = Matched / Expected
     precision = total_matched / total_detected if total_detected > 0 else 0
     recall = total_matched / total_expected if total_expected > 0 else 0
     f1 = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0
-    
-    print("-"*50)
+
+    print("-" * 50)
     print(f"Precision:           {precision:.4f}")
     print(f"Recall:              {recall:.4f}")
     print(f"F1-Score:            {f1:.4f}")
-    print("="*50)
-    
+    print("=" * 50)
+
     # Write aggregated summary to logs
     aggregated_report = {
         "summary": {
@@ -160,12 +163,13 @@ def main():
             "unexpected_fp": total_unexpected,
             "precision": precision,
             "recall": recall,
-            "f1_score": f1
+            "f1_score": f1,
         },
-        "pages": page_summaries
+        "pages": page_summaries,
     }
     _write_json(output_root / "aggregated_eval_summary.json", aggregated_report)
     logger.info("All evaluations completed. Aggregated summary saved.")
-    
+
+
 if __name__ == "__main__":
     main()

--- a/tools/issue94/eval_all_mmr.py
+++ b/tools/issue94/eval_all_mmr.py
@@ -1,11 +1,14 @@
+# ruff: noqa: I001
+
 import json
 import logging
 from pathlib import Path
-import torch
 
+import torch
 from src.measure_numbering.rapidocr_provider import normalize_rapidocr_provider
 from src.pipeline.steps.numbering import run_mmr_batch
-from tools.issue94.eval_mmr_overrides import _load_json, _write_json, _build_summary
+
+from tools.issue94.eval_mmr_overrides import _build_summary, _load_json, _write_json
 
 logging.basicConfig(
     level=logging.INFO,
@@ -64,7 +67,7 @@ def main():
         rapidocr_provider=normalize_rapidocr_provider(rapidocr_provider),
     )
     logger.info("run_mmr_batch completed. Generating summaries...")
-    
+
     total_base_measures = 0
     total_detected = 0
     total_expected = 0
@@ -72,18 +75,18 @@ def main():
     total_missed = 0
     total_skip_mismatch = 0
     total_unexpected = 0
-    
+
     page_summaries = []
-    
+
     # 各ページの要約を生成
     for p, nb_payload, out_path in zip(pages, pages_data, output_paths):
         page_id = p["page_id"]
         detected_payload = _load_json(out_path)
-        
+
         # Load expected overrides if exists
         expected_path = Path("tests/fixtures") / f"expected_overrides_{page_id}.json"
         expected_payload = _load_json(expected_path) if expected_path.exists() else None
-        
+
         summary = _build_summary(
             numbering_json=Path(p["numbering_base"]),
             image=Path(p["image"]),
@@ -96,7 +99,7 @@ def main():
             detected_payload=detected_payload,
             expected_payload=expected_payload,
         )
-        
+
         # Aggregate counts
         cnt = summary["counts"]
         total_base_measures += cnt["base_measures"]
@@ -106,25 +109,27 @@ def main():
         total_missed += cnt["missed"]
         total_skip_mismatch += cnt["skip_mismatch"]
         total_unexpected += cnt["unexpected"]
-        
-        page_summaries.append({
-            "page_id": page_id,
-            "image": Path(p["image"]).name,
-            "expected": cnt["expected_overrides"],
-            "detected": cnt["detected_overrides"],
-            "matched": cnt["matched"],
-            "missed": cnt["missed"],
-            "mismatch": cnt["skip_mismatch"],
-            "unexpected": cnt["unexpected"]
-        })
-        
+
+        page_summaries.append(
+            {
+                "page_id": page_id,
+                "image": Path(p["image"]).name,
+                "expected": cnt["expected_overrides"],
+                "detected": cnt["detected_overrides"],
+                "matched": cnt["matched"],
+                "missed": cnt["missed"],
+                "mismatch": cnt["skip_mismatch"],
+                "unexpected": cnt["unexpected"],
+            }
+        )
+
         summary_path = output_root / page_id / "mmr_eval_summary.json"
         _write_json(summary_path, summary)
-        
+
     # Print quantitative summary metrics
-    print("\n" + "="*50)
+    print("\n" + "=" * 50)
     print(" MMR EVALUATION METRICS SUMMARY (REST GT)")
-    print("="*50)
+    print("=" * 50)
     print(f"Total Pages:         {len(pages)}")
     print(f"Total Base Measures: {total_base_measures}")
     print(f"Total Expected:      {total_expected} (Positive MMRs in GT)")
@@ -133,20 +138,20 @@ def main():
     print(f"Missed (FN):         {total_missed}")
     print(f"Skip Mismatch:       {total_skip_mismatch}")
     print(f"Unexpected (FP):     {total_unexpected}")
-    
+
     # Calculate Precision / Recall
     # Precision = TP / (TP + FP) = Matched / Detected
     # Recall = TP / Expected = Matched / Expected
     precision = total_matched / total_detected if total_detected > 0 else 0
     recall = total_matched / total_expected if total_expected > 0 else 0
     f1 = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0
-    
-    print("-"*50)
+
+    print("-" * 50)
     print(f"Precision:           {precision:.4f}")
     print(f"Recall:              {recall:.4f}")
     print(f"F1-Score:            {f1:.4f}")
-    print("="*50)
-    
+    print("=" * 50)
+
     # Write aggregated summary to logs
     aggregated_report = {
         "summary": {
@@ -160,12 +165,13 @@ def main():
             "unexpected_fp": total_unexpected,
             "precision": precision,
             "recall": recall,
-            "f1_score": f1
+            "f1_score": f1,
         },
-        "pages": page_summaries
+        "pages": page_summaries,
     }
     _write_json(output_root / "aggregated_eval_summary.json", aggregated_report)
     logger.info("All evaluations completed. Aggregated summary saved.")
-    
+
+
 if __name__ == "__main__":
     main()

--- a/tools/issue94/normalize_mmr_expected_overrides.py
+++ b/tools/issue94/normalize_mmr_expected_overrides.py
@@ -79,7 +79,11 @@ def main() -> None:
 
         if match:
             page_token = match.group(1).lstrip("_")
-            work_name = img_name.replace(f"_{page_token}.png", "").replace(f"{page_token}.png", "").rstrip("_")
+            work_name = (
+                img_name.replace(f"_{page_token}.png", "")
+                .replace(f"{page_token}.png", "")
+                .rstrip("_")
+            )
         else:
             page_token = page_id
             work_name = "unknown"
@@ -146,7 +150,9 @@ def main() -> None:
                 best_shift = s
 
         if best_shift != 0:
-            print(f"  [INFO] Detected index shift of {best_shift:+} for {page_id} ({work_name}/{page_token})")
+            print(
+                f"  [INFO] Detected index shift of {best_shift:+} for {page_id} ({work_name}/{page_token})"
+            )
 
         # Map to expected overrides format
         expected_overrides = []
@@ -160,14 +166,18 @@ def main() -> None:
             target_idx = g_idx + best_shift
             if 0 <= target_idx < len(global_map):
                 s_idx, m_idx = global_map[target_idx]
-                expected_overrides.append({
-                    "page": page_num_idx,
-                    "system": s_idx,
-                    "measure": m_idx,
-                    "skip": rest_count - 1
-                })
+                expected_overrides.append(
+                    {
+                        "page": page_num_idx,
+                        "system": s_idx,
+                        "measure": m_idx,
+                        "skip": rest_count - 1,
+                    }
+                )
             else:
-                print(f"  [Warn] Out-of-bounds target index {target_idx} for GT index {g_idx} (shift {best_shift}) on {page_id}")
+                print(
+                    f"  [Warn] Out-of-bounds target index {target_idx} for GT index {g_idx} (shift {best_shift}) on {page_id}"
+                )
 
         if expected_overrides:
             out_path = args.output_dir / f"expected_overrides_{page_id}.json"
@@ -175,7 +185,9 @@ def main() -> None:
                 json.dump({"overrides": expected_overrides}, out_f, indent=2)
             processed_count += 1
 
-    print(f"\nSuccessfully generated {processed_count} expected override JSON files under {args.output_dir}")
+    print(
+        f"\nSuccessfully generated {processed_count} expected override JSON files under {args.output_dir}"
+    )
 
 
 if __name__ == "__main__":

--- a/tools/issue94/visualize_mmr_errors.py
+++ b/tools/issue94/visualize_mmr_errors.py
@@ -11,10 +11,12 @@ Note:
     if requested.
 """
 
-import os
 import glob
 import json
+import os
+
 from PIL import Image, ImageDraw, ImageFont
+
 
 def get_ttf_font(size=40):
     # Try to find a standard TTF font on Linux
@@ -29,7 +31,7 @@ def get_ttf_font(size=40):
         system_ttfs = glob.glob("/usr/share/fonts/**/*.ttf", recursive=True)
         if system_ttfs:
             font_paths.insert(0, system_ttfs[0])
-            
+
     for path in font_paths:
         try:
             return ImageFont.truetype(path, size)
@@ -37,15 +39,19 @@ def get_ttf_font(size=40):
             continue
     return ImageFont.load_default()
 
+
 def draw_thick_rectangle(draw, bbox, color, width=6):
     xmin, ymin, xmax, ymax = bbox
     for i in range(width):
         draw.rectangle([xmin - i, ymin - i, xmax + i, ymax + i], outline=color)
 
+
 def main():
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-    
-    eval_summary_path = os.path.join(repo_root, "logs/issue94_mmr_current_state/eval/aggregated_eval_summary.json")
+
+    eval_summary_path = os.path.join(
+        repo_root, "logs/issue94_mmr_current_state/eval/aggregated_eval_summary.json"
+    )
     if not os.path.exists(eval_summary_path):
         print(f"Error: Aggregated summary not found at {eval_summary_path}")
         return
@@ -65,16 +71,18 @@ def main():
     for page_entry in aggregated.get("pages", []):
         page_id = page_entry["page_id"]
         # Check if the page has any errors
-        has_error = (page_entry["missed"] > 0 or 
-                     page_entry["mismatch"] > 0 or 
-                     page_entry["unexpected"] > 0)
+        has_error = (
+            page_entry["missed"] > 0 or page_entry["mismatch"] > 0 or page_entry["unexpected"] > 0
+        )
         if not has_error:
             continue
 
         print(f"Processing error page: {page_id}")
-        
+
         # Load page-specific eval summary
-        page_summary_path = os.path.join(repo_root, f"logs/issue94_mmr_current_state/eval/{page_id}/mmr_eval_summary.json")
+        page_summary_path = os.path.join(
+            repo_root, f"logs/issue94_mmr_current_state/eval/{page_id}/mmr_eval_summary.json"
+        )
         if not os.path.exists(page_summary_path):
             print(f"  Warning: Summary not found for {page_id}")
             continue
@@ -97,15 +105,17 @@ def main():
         img_path = os.path.join(repo_root, img_rel)
         if not os.path.exists(img_path):
             # Fallback check under stage_e_full_pipeline/images
-            img_path = os.path.join(repo_root, "logs/issue120_e2e_recovery/stage_e_full_pipeline/images", os.path.basename(img_rel))
-        
+            img_path = os.path.join(
+                repo_root,
+                "logs/issue120_e2e_recovery/stage_e_full_pipeline/images",
+                os.path.basename(img_rel),
+            )
+
         image_loaded = False
         img = None
-        draw = None
         if os.path.exists(img_path):
             try:
                 img = Image.open(img_path).convert("RGB")
-                draw = ImageDraw.Draw(img)
                 image_loaded = True
             except Exception as e:
                 print(f"  Failed to load image {img_path}: {e}")
@@ -128,7 +138,7 @@ def main():
             key = entry["key"]
             expected_skip = entry["expected_skip"]
             classification_hint = entry.get("classification_hint")
-            
+
             case = {
                 "page_id": page_id,
                 "image": os.path.basename(img_rel),
@@ -141,7 +151,7 @@ def main():
                 "classification_hint": classification_hint,
                 "numbering_base_json": num_base_rel,
                 "expected_fixture": expected_fixture_rel,
-                "detected_overrides_json": detected_overrides_rel
+                "detected_overrides_json": detected_overrides_rel,
             }
             error_cases.append(case)
             page_errors.append(case)
@@ -152,7 +162,7 @@ def main():
             expected_skip = entry["expected_skip"]
             detected_skip = entry["detected_skip"]
             classification_hint = entry.get("classification_hint")
-            
+
             case = {
                 "page_id": page_id,
                 "image": os.path.basename(img_rel),
@@ -165,7 +175,7 @@ def main():
                 "classification_hint": classification_hint,
                 "numbering_base_json": num_base_rel,
                 "expected_fixture": expected_fixture_rel,
-                "detected_overrides_json": detected_overrides_rel
+                "detected_overrides_json": detected_overrides_rel,
             }
             error_cases.append(case)
             page_errors.append(case)
@@ -178,7 +188,7 @@ def main():
                 # In unexpected, it might be in "skip" attribute
                 detected_skip = entry.get("skip")
             classification_hint = entry.get("classification_hint")
-            
+
             case = {
                 "page_id": page_id,
                 "image": os.path.basename(img_rel),
@@ -191,7 +201,7 @@ def main():
                 "classification_hint": classification_hint,
                 "numbering_base_json": num_base_rel,
                 "expected_fixture": expected_fixture_rel,
-                "detected_overrides_json": detected_overrides_rel
+                "detected_overrides_json": detected_overrides_rel,
             }
             error_cases.append(case)
             page_errors.append(case)
@@ -199,35 +209,35 @@ def main():
         # Draw overlays if image and numbering base are loaded
         if image_loaded and numbering_base:
             categories_on_page = set(e["category"] for e in page_errors)
-            
+
             for cat in categories_on_page:
                 # Copy the original image
                 cat_img = img.copy()
                 cat_draw = ImageDraw.Draw(cat_img)
-                
+
                 cat_errors = [e for e in page_errors if e["category"] == cat]
                 for err in cat_errors:
                     key = err["key"]
                     cat_name = err["category"]
-                    
+
                     # Resolve color
                     if cat_name == "missed":
-                        color = (255, 0, 0) # Red
+                        color = (255, 0, 0)  # Red
                         label = f"[FN] Missed (Expected Rest: {err['expected_rest_count']})"
                     elif cat_name == "skip_mismatch":
-                        color = (255, 140, 0) # Dark Orange
+                        color = (255, 140, 0)  # Dark Orange
                         label = f"[Mismatch] ExpRest: {err['expected_rest_count']}, DetRest: {err['detected_rest_count']}"
                     else:
-                        color = (147, 112, 219) # Medium Purple
+                        color = (147, 112, 219)  # Medium Purple
                         label = f"[FP] Unexpected (Detected Rest: {err['detected_rest_count']})"
 
                     # Find bbox from numbering base
                     system_idx = key[1]
                     measure_idx = key[2]
-                    
+
                     bbox = None
                     bbox_type = "Measure"
-                    
+
                     try:
                         systems = numbering_base["pages"][0]["systems"]
                         if system_idx < len(systems):
@@ -249,18 +259,28 @@ def main():
                         draw_thick_rectangle(cat_draw, bbox, color, width=8)
                         # Draw label text above/below the rectangle
                         tx, ty = bbox[0], max(0, bbox[1] - 50)
-                        
+
                         # Draw background box for text legibility
                         if hasattr(cat_draw, "textbbox"):
-                            text_w, text_h = cat_draw.textsize(label, font=font) if hasattr(cat_draw, "textsize") else (400, 40)
+                            text_w, text_h = (
+                                cat_draw.textsize(label, font=font)
+                                if hasattr(cat_draw, "textsize")
+                                else (400, 40)
+                            )
                         else:
                             text_w, text_h = 600, 50
-                        
-                        cat_draw.rectangle([tx, ty, tx + text_w + 10, ty + text_h + 5], fill=(255, 255, 255))
+
+                        cat_draw.rectangle(
+                            [tx, ty, tx + text_w + 10, ty + text_h + 5], fill=(255, 255, 255)
+                        )
                         cat_draw.text((tx + 5, ty + 2), label, fill=color, font=font)
-                        print(f"  Drew {cat_name} overlay at system {system_idx}, measure {measure_idx} ({bbox_type} BBox)")
+                        print(
+                            f"  Drew {cat_name} overlay at system {system_idx}, measure {measure_idx} ({bbox_type} BBox)"
+                        )
                     else:
-                        print(f"  Could not find bbox for key {key} (System {system_idx}, Measure {measure_idx})")
+                        print(
+                            f"  Could not find bbox for key {key} (System {system_idx}, Measure {measure_idx})"
+                        )
 
                 # Save category image
                 out_img_name = f"{page_id}_{cat}.png"
@@ -274,6 +294,7 @@ def main():
         json.dump(error_cases, f, indent=2)
     print(f"\nSuccessfully wrote error summary to {summary_out_path}")
     print(f"Total error cases found: {len(error_cases)}")
+
 
 if __name__ == "__main__":
     main()

--- a/tools/issue94/visualize_mmr_errors.py
+++ b/tools/issue94/visualize_mmr_errors.py
@@ -262,11 +262,10 @@ def main():
 
                         # Draw background box for text legibility
                         if hasattr(cat_draw, "textbbox"):
-                            text_w, text_h = (
-                                cat_draw.textsize(label, font=font)
-                                if hasattr(cat_draw, "textsize")
-                                else (400, 40)
+                            left, top, right, bottom = cat_draw.textbbox(
+                                (0, 0), label, font=font
                             )
+                            text_w, text_h = right - left, bottom - top
                         else:
                             text_w, text_h = 600, 50
 

--- a/tools/issue94/visualize_mmr_errors.py
+++ b/tools/issue94/visualize_mmr_errors.py
@@ -262,9 +262,7 @@ def main():
 
                         # Draw background box for text legibility
                         if hasattr(cat_draw, "textbbox"):
-                            left, top, right, bottom = cat_draw.textbbox(
-                                (0, 0), label, font=font
-                            )
+                            left, top, right, bottom = cat_draw.textbbox((0, 0), label, font=font)
                             text_w, text_h = right - left, bottom - top
                         else:
                             text_w, text_h = 600, 50


### PR DESCRIPTION
## Summary

Fixes existing full-repository ruff lint failures that are unrelated to #201.

Changes:

- organize imports in existing files reported by ruff
- remove an unused import in the CNN model path test
- remove an unused assignment in the issue94 visualization helper
- apply ruff formatting to touched files

## Scope

This is separated from #209 / #201 so the manual-correction workflow PR does not mix schema/helper work with existing lint cleanup.

## Validation

I validated the reconstructed touched-file set with the repository ruff settings. Please validate in the actual repository worktree with `make lint`.

After this PR is merged into `develop`, update #209 and rerun its validation.