### PR TITLE
Improve #201 manual GUI base/effective MMR view

### DIFF
--- a/docs/refactors/issue201/MANUAL_CORRECTION_GUI.md
+++ b/docs/refactors/issue201/MANUAL_CORRECTION_GUI.md
@@ -1,6 +1,6 @@
 # Issue #201 manual correction GUI
 
-This document records the first GUI implementation for the #201 manual-correction workflow.
+This document records the manual-correction GUI implementation for the #201 workflow.
 
 ## Decision
 
@@ -11,7 +11,7 @@ The existing modes keep their current output contracts:
 - `gt`: edits barline GT boxes and writes raw/sorted GT payloads.
 - `rest`: edits the older page-local multi-rest GT payload.
 
-The new `manual` mode writes the durable #201 correction schema under `data/evaluation2/manual_corrections/`.
+The `manual` mode writes the durable #201 correction schema under `data/evaluation2/manual_corrections/`.
 
 ## Files
 
@@ -32,16 +32,26 @@ PYTHONPATH=. python3 tools/gt_relabel_gui/manual_config_builder.py \
   logs/.../numbering_base.json \
   <work>_page_015 \
   15 \
-  data/evaluation2/manual_correction_config.json
+  data/evaluation2/manual_correction_config.json \
+  logs/.../mmr_measure_overrides.json \
+  logs/.../pipeline2_no_peak_scored.json
 ```
 
 The positional arguments are:
 
 ```text
-IMAGE NUMBERING NAME PAGE OUTPUT
+IMAGE NUMBERING NAME PAGE OUTPUT [MMR] [BARLINES]
 ```
 
-For `remove_barline`, add a `barlines` field to the generated config page if a detected-barline artifact is available:
+`MMR` is optional but recommended. It should point to a JSON payload containing `measure_overrides` or `overrides`. When present, the GUI shows each measure as:
+
+```text
+base=<span from MMR artifact> effective=<span after manual correction>
+```
+
+`BARLINES` is optional. It is used only to display selectable base barlines for `remove_barline`.
+
+The generated config uses these page fields:
 
 ```json
 {
@@ -51,6 +61,7 @@ For `remove_barline`, add a `barlines` field to the generated config page if a d
       "page": 15,
       "image": "data/evaluation2/images/Va__Prokofiev_Symphony5/page_015.png",
       "numbering": "logs/.../numbering_base.json",
+      "mmr": "logs/.../mmr_measure_overrides.json",
       "barlines": "logs/.../pipeline2_no_peak_scored.json"
     }
   ]
@@ -83,11 +94,17 @@ Then open:
 http://localhost:8010
 ```
 
+## Save semantics
+
+Save writes only the relevant manual correction JSON file. It does not update the base MMR artifact, run evaluation, or rewrite pipeline outputs.
+
+The GUI updates its effective display immediately after staging a correction, but persisted effects are visible to the evaluator only after the relevant pipeline/evaluation command is re-run.
+
 ## Supported operations
 
 ### `mmr_measure_span`
 
-The reviewer selects an existing measure ROI from the numbering artifact.
+The reviewer selects an existing measure ROI from the numbering artifact. If an MMR artifact is configured, the list and overlay show both the base span and the effective span after manual corrections.
 
 Supported operations:
 
@@ -126,4 +143,4 @@ data/evaluation2/manual_corrections/measure_construction_overrides.json
 
 ## Future grouping
 
-`group_staves_as_system` remains a future #197/divisi grouping extension. The first GUI pass does not write that operation.
+`group_staves_as_system` remains a future #197/divisi grouping extension. This GUI pass does not write that operation.

--- a/src/pipeline/steps/manual_corrections.py
+++ b/src/pipeline/steps/manual_corrections.py
@@ -24,29 +24,41 @@ Payload = Dict[str, Any]
 OverrideKey = Tuple[Optional[int], Optional[int], Optional[int]]
 
 
+def _to_int_or_none(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _measure_key(item: Dict[str, Any]) -> OverrideKey:
-    return (item.get("page"), item.get("system"), item.get("measure"))
+    return (
+        _to_int_or_none(item.get("page")),
+        _to_int_or_none(item.get("system")),
+        _to_int_or_none(item.get("measure")),
+    )
 
 
 def _normalise_measure_override(item: Dict[str, Any]) -> MeasureOverride:
     override = deepcopy(item)
-    if "page" in override:
-        override["page"] = int(override["page"])
-    if "system" in override:
-        override["system"] = int(override["system"])
-    if "measure" in override:
-        override["measure"] = int(override["measure"])
-    if "skip" in override:
-        override["skip"] = int(override["skip"])
-    if "set_number" in override and override["set_number"] is not None:
-        override["set_number"] = int(override["set_number"])
+    for key in ("page", "system", "measure", "skip", "set_number"):
+        if key in override and override[key] is not None:
+            try:
+                override[key] = int(override[key])
+            except (TypeError, ValueError):
+                pass
     return override
 
 
 def _normalise_barline_override(item: Dict[str, Any]) -> BarlineOverride:
     override = deepcopy(item)
-    if "page" in override:
-        override["page"] = int(override["page"])
+    if "page" in override and override["page"] is not None:
+        try:
+            override["page"] = int(override["page"])
+        except (TypeError, ValueError):
+            pass
     if "bbox" in override and isinstance(override["bbox"], list):
         override["bbox"] = [int(value) for value in override["bbox"]]
     return override
@@ -133,7 +145,10 @@ def apply_mmr_measure_span_corrections(
         op = item.get("op")
         if op not in {"suppress", "set_measure_span"}:
             continue
-        key = (int(item["page"]), int(item["system"]), int(item["measure"]))
+        try:
+            key = (int(item["page"]), int(item["system"]), int(item["measure"]))
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(f"Invalid page/system/measure in correction item: {item}") from exc
         result = [override for override in result if _measure_key(override) != key]
         if op == "set_measure_span":
             result.append(_set_measure_span_override(item))
@@ -158,15 +173,21 @@ def measure_construction_overrides(
     for item in items:
         if not isinstance(item, dict) or item.get("op") != "force_measure":
             continue
+        try:
+            page = int(item["page"])
+            system = int(item["system"])
+            measure = int(item["interval"])
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(f"Invalid page/system/interval in force_measure item: {item}") from exc
         override: MeasureOverride = {
-            "page": int(item["page"]),
-            "system": int(item["system"]),
-            "measure": int(item["interval"]),
+            "page": page,
+            "system": system,
+            "measure": measure,
             "force_measure": True,
             "comment": _manual_comment(item, "manual measure-construction force_measure"),
             "source": item.get("source", "manual:measure_construction"),
         }
-        if "skip" in item:
+        if "skip" in item and item["skip"] is not None:
             override["skip"] = int(item["skip"])
         if "set_number" in item and item["set_number"] is not None:
             override["set_number"] = int(item["set_number"])
@@ -213,19 +234,28 @@ def merge_measure_overrides(*payloads: Optional[Payload]) -> Payload:
     The returned payload includes both `measure_overrides` and `overrides` for
     compatibility with current final-numbering code and older debug helpers.
     """
-    merged: List[MeasureOverride] = []
+    auto_or_legacy: List[MeasureOverride] = []
+    mmr_measure_span_payloads: List[Payload] = []
+    measure_construction_payloads: List[Payload] = []
+
     for payload in payloads:
         if not payload:
             continue
         correction_type = payload.get("correction_type")
         if correction_type == "mmr_measure_span":
-            merged = apply_mmr_measure_span_corrections(merged, payload)
+            mmr_measure_span_payloads.append(payload)
         elif correction_type == "measure_construction":
-            merged.extend(measure_construction_overrides(payload))
+            measure_construction_payloads.append(payload)
         elif correction_type == "barline_construction":
             continue
         else:
-            merged.extend(normalise_measure_overrides(payload))
+            auto_or_legacy.extend(normalise_measure_overrides(payload))
+
+    merged: List[MeasureOverride] = auto_or_legacy
+    for payload in measure_construction_payloads:
+        merged.extend(measure_construction_overrides(payload))
+    for payload in mmr_measure_span_payloads:
+        merged = apply_mmr_measure_span_corrections(merged, payload)
 
     return {"measure_overrides": merged, "overrides": deepcopy(merged)}
 

--- a/tests/test_manual_corrections.py
+++ b/tests/test_manual_corrections.py
@@ -16,13 +16,9 @@ FIXTURE_DIR = Path(__file__).parent / "fixtures" / "manual_corrections"
 
 
 def test_normalise_measure_overrides_accepts_legacy_and_current_keys():
-    legacy = {
-        "overrides": [{"page": "1", "system": "2", "measure": "3", "skip": "4"}]
-    }
+    legacy = {"overrides": [{"page": "1", "system": "2", "measure": "3", "skip": "4"}]}
     current = {
-        "measure_overrides": [
-            {"page": "5", "system": "6", "measure": "7", "skip": "8"}
-        ]
+        "measure_overrides": [{"page": "5", "system": "6", "measure": "7", "skip": "8"}]
     }
 
     assert normalise_measure_overrides(legacy) == [
@@ -35,9 +31,7 @@ def test_normalise_measure_overrides_accepts_legacy_and_current_keys():
 
 def test_normalise_measure_overrides_keeps_none_without_crashing():
     payload = {
-        "overrides": [
-            {"page": None, "system": "2", "measure": "3", "skip": None}
-        ]
+        "overrides": [{"page": None, "system": "2", "measure": "3", "skip": None}]
     }
 
     assert normalise_measure_overrides(payload) == [
@@ -64,7 +58,9 @@ def test_mmr_measure_span_corrections_suppress_and_set_span():
             },
         ]
     }
-    manual_payload = json.loads((FIXTURE_DIR / "mmr_measure_span_basic.json").read_text())
+    manual_payload = json.loads(
+        (FIXTURE_DIR / "mmr_measure_span_basic.json").read_text()
+    )
 
     merged = merge_measure_overrides(auto_payload, manual_payload)
 
@@ -95,7 +91,9 @@ def test_merge_measure_overrides_applies_manual_last_regardless_of_payload_order
             {"page": 40, "system": 2, "measure": 1, "skip": 2},
         ]
     }
-    manual_payload = json.loads((FIXTURE_DIR / "mmr_measure_span_basic.json").read_text())
+    manual_payload = json.loads(
+        (FIXTURE_DIR / "mmr_measure_span_basic.json").read_text()
+    )
 
     auto_first = merge_measure_overrides(auto_payload, manual_payload)
     manual_first = merge_measure_overrides(manual_payload, auto_payload)

--- a/tests/test_manual_corrections.py
+++ b/tests/test_manual_corrections.py
@@ -27,6 +27,14 @@ def test_normalise_measure_overrides_accepts_legacy_and_current_keys():
     ]
 
 
+def test_normalise_measure_overrides_keeps_none_without_crashing():
+    payload = {"overrides": [{"page": None, "system": "2", "measure": "3", "skip": None}]}
+
+    assert normalise_measure_overrides(payload) == [
+        {"page": None, "system": 2, "measure": 3, "skip": None}
+    ]
+
+
 def test_mmr_measure_span_corrections_suppress_and_set_span():
     auto_payload = {
         "measure_overrides": [
@@ -68,6 +76,43 @@ def test_mmr_measure_span_corrections_suppress_and_set_span():
         },
     ]
     assert merged["overrides"] == merged["measure_overrides"]
+
+
+def test_merge_measure_overrides_applies_manual_last_regardless_of_payload_order():
+    auto_payload = {
+        "measure_overrides": [
+            {"page": 32, "system": 0, "measure": 0, "skip": 10},
+            {"page": 40, "system": 2, "measure": 1, "skip": 2},
+        ]
+    }
+    manual_payload = json.loads((FIXTURE_DIR / "mmr_measure_span_basic.json").read_text())
+
+    auto_first = merge_measure_overrides(auto_payload, manual_payload)
+    manual_first = merge_measure_overrides(manual_payload, auto_payload)
+
+    assert manual_first == auto_first
+    assert manual_first["measure_overrides"] == [
+        {"page": 40, "system": 2, "measure": 1, "skip": 2},
+        {
+            "page": 41,
+            "system": 8,
+            "measure": 0,
+            "skip": 2,
+            "comment": "synthetic explicit MMR measure span",
+            "source": "manual:mmr_measure_span",
+        },
+    ]
+
+
+def test_mmr_suppress_matches_string_typed_existing_override_keys():
+    auto_overrides = [{"page": "1", "system": "0", "measure": "0", "skip": "9"}]
+    manual_payload = {
+        "schema_version": 1,
+        "correction_type": "mmr_measure_span",
+        "items": [{"op": "suppress", "page": 1, "system": 0, "measure": 0}],
+    }
+
+    assert apply_mmr_measure_span_corrections(auto_overrides, manual_payload) == []
 
 
 def test_mmr_set_measure_span_replaces_existing_override():
@@ -119,6 +164,17 @@ def test_mmr_measure_span_must_be_at_least_one():
         )
 
 
+def test_mmr_malformed_item_reports_descriptive_error():
+    payload = {
+        "schema_version": 1,
+        "correction_type": "mmr_measure_span",
+        "items": [{"op": "suppress", "page": 1, "system": 0}],
+    }
+
+    with pytest.raises(ValueError, match="page/system/measure"):
+        apply_mmr_measure_span_corrections([], payload)
+
+
 def test_measure_construction_force_measure_is_separate_from_future_grouping_ops():
     payload = {
         "schema_version": 1,
@@ -153,6 +209,17 @@ def test_measure_construction_force_measure_is_separate_from_future_grouping_ops
     assert merge_measure_overrides(payload)["measure_overrides"] == measure_construction_overrides(
         payload
     )
+
+
+def test_measure_construction_malformed_item_reports_descriptive_error():
+    payload = {
+        "schema_version": 1,
+        "correction_type": "measure_construction",
+        "items": [{"op": "force_measure", "page": 52, "system": 0}],
+    }
+
+    with pytest.raises(ValueError, match="page/system/interval"):
+        measure_construction_overrides(payload)
 
 
 def test_barline_construction_add_and_remove_are_not_measure_overrides():

--- a/tests/test_manual_corrections.py
+++ b/tests/test_manual_corrections.py
@@ -17,9 +17,7 @@ FIXTURE_DIR = Path(__file__).parent / "fixtures" / "manual_corrections"
 
 def test_normalise_measure_overrides_accepts_legacy_and_current_keys():
     legacy = {"overrides": [{"page": "1", "system": "2", "measure": "3", "skip": "4"}]}
-    current = {
-        "measure_overrides": [{"page": "5", "system": "6", "measure": "7", "skip": "8"}]
-    }
+    current = {"measure_overrides": [{"page": "5", "system": "6", "measure": "7", "skip": "8"}]}
 
     assert normalise_measure_overrides(legacy) == [
         {"page": 1, "system": 2, "measure": 3, "skip": 4}
@@ -30,9 +28,7 @@ def test_normalise_measure_overrides_accepts_legacy_and_current_keys():
 
 
 def test_normalise_measure_overrides_keeps_none_without_crashing():
-    payload = {
-        "overrides": [{"page": None, "system": "2", "measure": "3", "skip": None}]
-    }
+    payload = {"overrides": [{"page": None, "system": "2", "measure": "3", "skip": None}]}
 
     assert normalise_measure_overrides(payload) == [
         {"page": None, "system": 2, "measure": 3, "skip": None}
@@ -58,9 +54,7 @@ def test_mmr_measure_span_corrections_suppress_and_set_span():
             },
         ]
     }
-    manual_payload = json.loads(
-        (FIXTURE_DIR / "mmr_measure_span_basic.json").read_text()
-    )
+    manual_payload = json.loads((FIXTURE_DIR / "mmr_measure_span_basic.json").read_text())
 
     merged = merge_measure_overrides(auto_payload, manual_payload)
 
@@ -91,9 +85,7 @@ def test_merge_measure_overrides_applies_manual_last_regardless_of_payload_order
             {"page": 40, "system": 2, "measure": 1, "skip": 2},
         ]
     }
-    manual_payload = json.loads(
-        (FIXTURE_DIR / "mmr_measure_span_basic.json").read_text()
-    )
+    manual_payload = json.loads((FIXTURE_DIR / "mmr_measure_span_basic.json").read_text())
 
     auto_first = merge_measure_overrides(auto_payload, manual_payload)
     manual_first = merge_measure_overrides(manual_payload, auto_payload)

--- a/tests/test_manual_corrections.py
+++ b/tests/test_manual_corrections.py
@@ -16,8 +16,14 @@ FIXTURE_DIR = Path(__file__).parent / "fixtures" / "manual_corrections"
 
 
 def test_normalise_measure_overrides_accepts_legacy_and_current_keys():
-    legacy = {"overrides": [{"page": "1", "system": "2", "measure": "3", "skip": "4"}]}
-    current = {"measure_overrides": [{"page": "5", "system": "6", "measure": "7", "skip": "8"}]}
+    legacy = {
+        "overrides": [{"page": "1", "system": "2", "measure": "3", "skip": "4"}]
+    }
+    current = {
+        "measure_overrides": [
+            {"page": "5", "system": "6", "measure": "7", "skip": "8"}
+        ]
+    }
 
     assert normalise_measure_overrides(legacy) == [
         {"page": 1, "system": 2, "measure": 3, "skip": 4}
@@ -28,7 +34,11 @@ def test_normalise_measure_overrides_accepts_legacy_and_current_keys():
 
 
 def test_normalise_measure_overrides_keeps_none_without_crashing():
-    payload = {"overrides": [{"page": None, "system": "2", "measure": "3", "skip": None}]}
+    payload = {
+        "overrides": [
+            {"page": None, "system": "2", "measure": "3", "skip": None}
+        ]
+    }
 
     assert normalise_measure_overrides(payload) == [
         {"page": None, "system": 2, "measure": 3, "skip": None}
@@ -206,8 +216,8 @@ def test_measure_construction_force_measure_is_separate_from_future_grouping_ops
             "source": "manual:measure_construction",
         }
     ]
-    assert merge_measure_overrides(payload)["measure_overrides"] == measure_construction_overrides(
-        payload
+    assert merge_measure_overrides(payload)["measure_overrides"] == (
+        measure_construction_overrides(payload)
     )
 
 

--- a/tools/gt_relabel_gui/app_manual.js
+++ b/tools/gt_relabel_gui/app_manual.js
@@ -3,6 +3,7 @@ let currentIndex = 0;
 let currentPage = null;
 
 let measures = [];
+let baseMmrOverrides = [];
 let barlines = [];
 let correctionsByType = {
   mmr_measure_span: [],
@@ -52,6 +53,9 @@ let drawStart = null;
 let spaceDown = false;
 
 const COLOR_MEASURE = "#3aa3ff";
+const COLOR_BASE_MMR = "#46c46b";
+const COLOR_MANUAL = "#b35cff";
+const COLOR_SUPPRESSED = "#ff3b30";
 const COLOR_BARLINE = "#46c46b";
 const COLOR_SELECTED = "#ff8a00";
 const COLOR_DRAFT = "#ff3b30";
@@ -71,9 +75,7 @@ const OPS = {
 
 function fetchJSON(url) {
   return fetch(url).then((response) => {
-    if (!response.ok) {
-      throw new Error(`${response.status} ${response.statusText}`);
-    }
+    if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
     return response.json();
   });
 }
@@ -93,12 +95,18 @@ function pageValue() {
   return currentIndex;
 }
 
+function measureKey(page, system, measure) {
+  return `${page}:${system}:${measure}`;
+}
+
+function selectedMeasureKey() {
+  if (!selectedMeasure) return null;
+  return measureKey(pageValue(), selectedMeasure.system, selectedMeasure.measure);
+}
+
 function setDirty(correctionType, isDirty) {
-  if (isDirty) {
-    dirtyTypes.add(correctionType);
-  } else {
-    dirtyTypes.delete(correctionType);
-  }
+  if (isDirty) dirtyTypes.add(correctionType);
+  else dirtyTypes.delete(correctionType);
   dirtyStatus.textContent = dirtyTypes.size
     ? `Unsaved: ${Array.from(dirtyTypes).join(", ")}`
     : "";
@@ -112,6 +120,7 @@ function updateOps() {
     option.textContent = label;
     opSelect.appendChild(option);
   });
+  selectedItemIndex = null;
   updateControlState();
 }
 
@@ -121,9 +130,7 @@ function updateControlState() {
   measureSpanRow.style.display =
     type === "mmr_measure_span" && op === "set_measure_span" ? "flex" : "none";
   drawModeBtn.disabled = !(type === "barline_construction");
-  if (drawModeBtn.disabled && mode === "draw") {
-    setMode("select");
-  }
+  if (drawModeBtn.disabled && mode === "draw") setMode("select");
   renderItems();
   updateSelectionMeta();
   draw();
@@ -152,17 +159,11 @@ function resetView() {
 }
 
 function imgToCanvas(pt) {
-  return {
-    x: pt.x * viewScale + viewOffset.x,
-    y: pt.y * viewScale + viewOffset.y,
-  };
+  return { x: pt.x * viewScale + viewOffset.x, y: pt.y * viewScale + viewOffset.y };
 }
 
 function canvasToImg(pt) {
-  return {
-    x: (pt.x - viewOffset.x) / viewScale,
-    y: (pt.y - viewOffset.y) / viewScale,
-  };
+  return { x: (pt.x - viewOffset.x) / viewScale, y: (pt.y - viewOffset.y) / viewScale };
 }
 
 function normalizeBox(box) {
@@ -206,13 +207,20 @@ function drawLabel(box, text, color) {
 function draw() {
   if (!image.complete) return;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  const drawWidth = image.width * viewScale;
-  const drawHeight = image.height * viewScale;
-  ctx.drawImage(image, viewOffset.x, viewOffset.y, drawWidth, drawHeight);
+  ctx.drawImage(image, viewOffset.x, viewOffset.y, image.width * viewScale, image.height * viewScale);
 
   measures.forEach((measure) => {
-    drawBox(measure.bbox, COLOR_MEASURE, 1.5);
-    drawLabel(measure.bbox, `S${measure.system} M${measure.measure}`, COLOR_MEASURE);
+    const effective = effectiveMmrState(measure);
+    let color = COLOR_MEASURE;
+    let label = `S${measure.system} M${measure.measure}`;
+    if (effective.baseSpan > 1) color = COLOR_BASE_MMR;
+    if (effective.manualOp === "set_measure_span") color = COLOR_MANUAL;
+    if (effective.manualOp === "suppress") color = COLOR_SUPPRESSED;
+    if (effective.baseSpan > 1 || effective.effectiveSpan > 1 || effective.manualOp) {
+      label += ` b${effective.baseSpan}->e${effective.effectiveSpan}`;
+    }
+    drawBox(measure.bbox, color, effective.manualOp ? 2.5 : 1.5, Boolean(effective.manualOp));
+    drawLabel(measure.bbox, label, color);
   });
 
   barlines.forEach((barline, index) => {
@@ -220,12 +228,8 @@ function draw() {
     drawLabel(barline.bbox, `B${index + 1}`, COLOR_BARLINE);
   });
 
-  if (selectedMeasure) {
-    drawBox(selectedMeasure.bbox, COLOR_SELECTED, 3, true);
-  }
-  if (selectedBarline) {
-    drawBox(selectedBarline.bbox, COLOR_SELECTED, 3, true);
-  }
+  if (selectedMeasure) drawBox(selectedMeasure.bbox, COLOR_SELECTED, 3, true);
+  if (selectedBarline) drawBox(selectedBarline.bbox, COLOR_SELECTED, 3, true);
   if (draftBBox) {
     drawBox(draftBBox, COLOR_DRAFT, 2);
     drawLabel(draftBBox, "draft", COLOR_DRAFT);
@@ -248,35 +252,69 @@ function pointInImageBox(imgPt, box) {
 
 function pickMeasure(imgPt) {
   for (let i = measures.length - 1; i >= 0; i--) {
-    if (pointInImageBox(imgPt, measures[i].bbox)) {
-      return measures[i];
-    }
+    if (pointInImageBox(imgPt, measures[i].bbox)) return measures[i];
   }
   return null;
 }
 
 function pickBarline(imgPt) {
   for (let i = barlines.length - 1; i >= 0; i--) {
-    if (pointInImageBox(imgPt, barlines[i].bbox)) {
-      return barlines[i];
-    }
+    if (pointInImageBox(imgPt, barlines[i].bbox)) return barlines[i];
   }
   return null;
+}
+
+function baseMmrMap() {
+  const page = pageValue();
+  const result = new Map();
+  baseMmrOverrides.forEach((item) => {
+    if (String(item.page) !== String(page)) return;
+    result.set(measureKey(item.page, item.system, item.measure), item);
+  });
+  return result;
+}
+
+function manualMmrMap() {
+  const result = new Map();
+  itemsForCurrentPage("mmr_measure_span").forEach((item) => {
+    result.set(measureKey(item.page, item.system, item.measure), item);
+  });
+  return result;
+}
+
+function effectiveMmrState(measure) {
+  const page = pageValue();
+  const key = measureKey(page, measure.system, measure.measure);
+  const base = baseMmrMap().get(key);
+  const manual = manualMmrMap().get(key);
+  const baseSkip = base && base.skip !== undefined ? parseInt(base.skip, 10) : 0;
+  const baseSpan = Number.isFinite(baseSkip) ? baseSkip + 1 : 1;
+  let effectiveSpan = baseSpan;
+  let manualOp = null;
+  if (manual) {
+    manualOp = manual.op;
+    if (manual.op === "suppress") effectiveSpan = 1;
+    if (manual.op === "set_measure_span") effectiveSpan = parseInt(manual.measure_span, 10);
+  }
+  return {
+    base,
+    manual,
+    baseSpan,
+    effectiveSpan: Number.isFinite(effectiveSpan) ? effectiveSpan : 1,
+    manualOp,
+  };
 }
 
 function updateSelectionMeta() {
   const parts = [];
   if (selectedMeasure) {
+    const state = effectiveMmrState(selectedMeasure);
     parts.push(
-      `measure: page=${pageValue()} system=${selectedMeasure.system} measure=${selectedMeasure.measure}`
+      `measure: page=${pageValue()} system=${selectedMeasure.system} measure=${selectedMeasure.measure} base=${state.baseSpan} effective=${state.effectiveSpan}`
     );
   }
-  if (selectedBarline) {
-    parts.push(`barline bbox=[${selectedBarline.bbox.join(", ")}]`);
-  }
-  if (draftBBox) {
-    parts.push(`draft bbox=[${draftBBox.join(", ")}]`);
-  }
+  if (selectedBarline) parts.push(`barline bbox=[${selectedBarline.bbox.join(", ")}]`);
+  if (draftBBox) parts.push(`draft bbox=[${draftBBox.join(", ")}]`);
   selectionMeta.textContent = parts.length ? parts.join(" | ") : "No selection";
 }
 
@@ -306,10 +344,29 @@ function replaceItemsForCurrentPage(correctionType, pageItems) {
   correctionsByType[correctionType] = kept.concat(pageItems);
 }
 
-function renderItems() {
+function renderMmrRows() {
+  const selectedKey = selectedMeasureKey();
+  measures.forEach((measure) => {
+    const state = effectiveMmrState(measure);
+    const div = document.createElement("div");
+    const key = measureKey(pageValue(), measure.system, measure.measure);
+    div.className = "list-item" + (key === selectedKey ? " active" : "");
+    const status = state.manualOp || (state.baseSpan > 1 ? "base" : "normal");
+    div.textContent = `S${measure.system} M${measure.measure} | base=${state.baseSpan} effective=${state.effectiveSpan} | ${status}`;
+    div.onclick = () => selectMeasure(measure);
+    itemList.appendChild(div);
+  });
+  if (!measures.length) {
+    const div = document.createElement("div");
+    div.className = "small";
+    div.textContent = "No measure boxes loaded from the numbering artifact.";
+    itemList.appendChild(div);
+  }
+}
+
+function renderManualItems() {
   const type = currentType();
   const items = itemsForCurrentPage(type);
-  itemList.innerHTML = "";
   items.forEach((item, index) => {
     const div = document.createElement("div");
     div.className = "list-item" + (index === selectedItemIndex ? " active" : "");
@@ -323,13 +380,24 @@ function renderItems() {
   if (!items.length) {
     const div = document.createElement("div");
     div.className = "small";
-    div.textContent = "No items for this page/type.";
+    div.textContent = "No manual correction items for this page/type.";
     itemList.appendChild(div);
   }
 }
 
+function renderItems() {
+  itemList.innerHTML = "";
+  if (currentType() === "mmr_measure_span") renderMmrRows();
+  else renderManualItems();
+}
+
 function currentReason() {
   return reasonInput.value.trim() || "manual correction";
+}
+
+function removeManualMmrForSelected(pageItems) {
+  const key = selectedMeasureKey();
+  return pageItems.filter((item) => measureKey(item.page, item.system, item.measure) !== key);
 }
 
 function addCorrectionItem() {
@@ -358,6 +426,13 @@ function addCorrectionItem() {
       }
       item.measure_span = span;
     }
+    replaceItemsForCurrentPage(type, removeManualMmrForSelected(itemsForCurrentPage(type)).concat([item]));
+    setDirty(type, true);
+    renderItems();
+    updateSelectionMeta();
+    draw();
+    saveStatus.textContent = `Staged ${item.op}. Save writes corrections only; re-run evaluation separately.`;
+    return;
   }
 
   if (type === "barline_construction") {
@@ -366,12 +441,7 @@ function addCorrectionItem() {
       saveStatus.textContent = "Select a barline or draw a bbox first.";
       return;
     }
-    item = {
-      op,
-      page,
-      bbox: bbox.map((value) => Math.round(value)),
-      reason: currentReason(),
-    };
+    item = { op, page, bbox: bbox.map((value) => Math.round(value)), reason: currentReason() };
   }
 
   if (type === "measure_construction") {
@@ -395,15 +465,22 @@ function addCorrectionItem() {
   setDirty(type, true);
   selectedItemIndex = pageItems.length - 1;
   renderItems();
-  saveStatus.textContent = `Added ${item.op}.`;
+  saveStatus.textContent = `Added ${item.op}. Save writes corrections only; re-run evaluation separately.`;
 }
 
 function deleteSelectedItem() {
   const type = currentType();
-  const pageItems = itemsForCurrentPage(type);
-  if (selectedItemIndex === null || !pageItems[selectedItemIndex]) {
+  if (type === "mmr_measure_span" && selectedMeasure) {
+    replaceItemsForCurrentPage(type, removeManualMmrForSelected(itemsForCurrentPage(type)));
+    setDirty(type, true);
+    renderItems();
+    updateSelectionMeta();
+    draw();
+    saveStatus.textContent = "Removed manual MMR correction for selected measure.";
     return;
   }
+  const pageItems = itemsForCurrentPage(type);
+  if (selectedItemIndex === null || !pageItems[selectedItemIndex]) return;
   pageItems.splice(selectedItemIndex, 1);
   selectedItemIndex = null;
   replaceItemsForCurrentPage(type, pageItems);
@@ -434,16 +511,50 @@ function loadNumbering(path) {
     const systems = pageData.systems || [];
     systems.forEach((system, systemIndex) => {
       (system.measures || []).forEach((measure, measureIndex) => {
-        if (!measure.bbox) return;
+        const bbox = measure.bbox || measure.measure_bbox || measure.bounds;
+        if (!Array.isArray(bbox) || bbox.length !== 4) return;
         measures.push({
-          bbox: measure.bbox.map((value) => Math.round(value)),
+          bbox: bbox.map((value) => Math.round(value)),
           number: measure.number,
           system: system.index ?? system.system ?? systemIndex,
-          measure: measure.index ?? measure.measure ?? measureIndex,
+          measure: measure.index ?? measure.measure ?? measure.measure_number ?? measureIndex,
         });
       });
     });
   });
+}
+
+function normalizeMmrRecords(data) {
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data.measure_overrides)) return data.measure_overrides;
+  if (Array.isArray(data.overrides)) return data.overrides;
+  if (Array.isArray(data.items)) return data.items;
+  return [];
+}
+
+function mmrPathFromPage(page) {
+  return page.mmr || page.mmr_results || page.measure_overrides || page.overrides || null;
+}
+
+function loadMmr(path) {
+  baseMmrOverrides = [];
+  if (!path) return Promise.resolve();
+  return fetchJSON(`/api/template?path=${encodeURIComponent(path)}`)
+    .then((data) => {
+      baseMmrOverrides = normalizeMmrRecords(data)
+        .filter((item) => item && item.system !== undefined && item.measure !== undefined)
+        .map((item) => ({
+          ...item,
+          page: item.page !== undefined ? item.page : pageValue(),
+          system: parseInt(item.system, 10),
+          measure: parseInt(item.measure, 10),
+          skip: item.skip !== undefined ? parseInt(item.skip, 10) : 0,
+        }));
+    })
+    .catch((error) => {
+      baseMmrOverrides = [];
+      saveStatus.textContent = `MMR base load failed: ${error.message}`;
+    });
 }
 
 function barlinePathFromPage(page) {
@@ -465,6 +576,17 @@ function loadBarlines(path) {
     });
 }
 
+function selectMeasure(measure) {
+  selectedMeasure = measure;
+  selectedBarline = null;
+  selectedItemIndex = null;
+  const state = effectiveMmrState(measure);
+  measureSpanInput.value = String(state.effectiveSpan || state.baseSpan || 1);
+  updateSelectionMeta();
+  renderItems();
+  draw();
+}
+
 function loadPage() {
   currentPage = pages[currentIndex];
   selectedMeasure = null;
@@ -472,7 +594,7 @@ function loadPage() {
   selectedItemIndex = null;
   draftBBox = null;
   saveStatus.textContent = "";
-  pageMeta.textContent = `${currentPage.name || currentIndex} | page=${pageValue()}`;
+  pageMeta.textContent = `${currentPage.name || currentIndex} | page=${pageValue()} | Save only writes correction JSON`;
 
   image.onload = () => {
     resetView();
@@ -482,6 +604,7 @@ function loadPage() {
 
   Promise.all([
     loadNumbering(currentPage.numbering),
+    loadMmr(mmrPathFromPage(currentPage)),
     loadBarlines(barlinePathFromPage(currentPage)),
     loadCorrections(),
   ]).then(() => {
@@ -506,14 +629,12 @@ function saveCurrentType() {
     body: JSON.stringify(payload),
   })
     .then((response) => {
-      if (!response.ok) {
-        throw new Error(`${response.status} ${response.statusText}`);
-      }
+      if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
       return response.json();
     })
     .then((data) => {
       setDirty(type, false);
-      saveStatus.textContent = `Saved ${type}: ${data.output}`;
+      saveStatus.textContent = `Saved ${type}: ${data.output}. Re-run evaluation separately.`;
     })
     .catch((error) => {
       saveStatus.textContent = `Save failed: ${error.message}`;
@@ -522,12 +643,15 @@ function saveCurrentType() {
 
 function switchPage(nextIndex) {
   if (nextIndex === currentIndex) return;
+  const activeType = currentType();
   const savePromises = Array.from(dirtyTypes).map((type) => {
     typeSelect.value = type;
     updateOps();
     return saveCurrentType();
   });
   Promise.all(savePromises).then(() => {
+    typeSelect.value = activeType;
+    updateOps();
     currentIndex = nextIndex;
     loadPage();
   });
@@ -539,10 +663,7 @@ addItemBtn.onclick = addCorrectionItem;
 deleteItemBtn.onclick = deleteSelectedItem;
 saveBtn.onclick = saveCurrentType;
 
-typeSelect.onchange = () => {
-  selectedItemIndex = null;
-  updateOps();
-};
+typeSelect.onchange = updateOps;
 opSelect.onchange = updateControlState;
 
 prevBtn.onclick = () => switchPage(Math.max(0, currentIndex - 1));
@@ -566,10 +687,15 @@ canvas.addEventListener("mousedown", (event) => {
   }
 
   const imgPt = canvasToImg(pt);
-  selectedMeasure = pickMeasure(imgPt);
-  selectedBarline = pickBarline(imgPt);
-  updateSelectionMeta();
-  draw();
+  const measure = pickMeasure(imgPt);
+  if (measure) selectMeasure(measure);
+  else {
+    selectedMeasure = null;
+    selectedBarline = pickBarline(imgPt);
+    updateSelectionMeta();
+    renderItems();
+    draw();
+  }
 });
 
 canvas.addEventListener("mousemove", (event) => {
@@ -577,10 +703,7 @@ canvas.addEventListener("mousemove", (event) => {
   const pt = { x: event.clientX - rect.left, y: event.clientY - rect.top };
 
   if (isPanning) {
-    viewOffset = {
-      x: panOrigin.x + (pt.x - panStart.x),
-      y: panOrigin.y + (pt.y - panStart.y),
-    };
+    viewOffset = { x: panOrigin.x + (pt.x - panStart.x), y: panOrigin.y + (pt.y - panStart.y) };
     draw();
     return;
   }
@@ -626,9 +749,7 @@ canvas.addEventListener(
 
 window.addEventListener("keydown", (event) => {
   const tag = event.target && event.target.tagName ? event.target.tagName.toLowerCase() : "";
-  if (tag === "input" || tag === "select" || tag === "textarea") {
-    return;
-  }
+  if (tag === "input" || tag === "select" || tag === "textarea") return;
   if (event.key === " ") spaceDown = true;
   if (event.key === "ArrowLeft") prevBtn.click();
   if (event.key === "ArrowRight") nextBtn.click();

--- a/tools/gt_relabel_gui/app_manual.js
+++ b/tools/gt_relabel_gui/app_manual.js
@@ -209,8 +209,10 @@ function draw() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.drawImage(image, viewOffset.x, viewOffset.y, image.width * viewScale, image.height * viewScale);
 
+  const baseMap = baseMmrMap();
+  const manualMap = manualMmrMap();
   measures.forEach((measure) => {
-    const effective = effectiveMmrState(measure);
+    const effective = effectiveMmrState(measure, baseMap, manualMap);
     let color = COLOR_MEASURE;
     let label = `S${measure.system} M${measure.measure}`;
     if (effective.baseSpan > 1) color = COLOR_BASE_MMR;
@@ -282,11 +284,11 @@ function manualMmrMap() {
   return result;
 }
 
-function effectiveMmrState(measure) {
+function effectiveMmrState(measure, baseMap = null, manualMap = null) {
   const page = pageValue();
   const key = measureKey(page, measure.system, measure.measure);
-  const base = baseMmrMap().get(key);
-  const manual = manualMmrMap().get(key);
+  const base = (baseMap || baseMmrMap()).get(key);
+  const manual = (manualMap || manualMmrMap()).get(key);
   const baseSkip = base && base.skip !== undefined ? parseInt(base.skip, 10) : 0;
   const baseSpan = Number.isFinite(baseSkip) ? baseSkip + 1 : 1;
   let effectiveSpan = baseSpan;
@@ -346,8 +348,10 @@ function replaceItemsForCurrentPage(correctionType, pageItems) {
 
 function renderMmrRows() {
   const selectedKey = selectedMeasureKey();
+  const baseMap = baseMmrMap();
+  const manualMap = manualMmrMap();
   measures.forEach((measure) => {
-    const state = effectiveMmrState(measure);
+    const state = effectiveMmrState(measure, baseMap, manualMap);
     const div = document.createElement("div");
     const key = measureKey(pageValue(), measure.system, measure.measure);
     div.className = "list-item" + (key === selectedKey ? " active" : "");
@@ -525,6 +529,7 @@ function loadNumbering(path) {
 }
 
 function normalizeMmrRecords(data) {
+  if (!data) return [];
   if (Array.isArray(data)) return data;
   if (Array.isArray(data.measure_overrides)) return data.measure_overrides;
   if (Array.isArray(data.overrides)) return data.overrides;
@@ -638,6 +643,7 @@ function saveCurrentType() {
     })
     .catch((error) => {
       saveStatus.textContent = `Save failed: ${error.message}`;
+      throw error;
     });
 }
 
@@ -649,19 +655,27 @@ function switchPage(nextIndex) {
     updateOps();
     return saveCurrentType();
   });
-  Promise.all(savePromises).then(() => {
-    typeSelect.value = activeType;
-    updateOps();
-    currentIndex = nextIndex;
-    loadPage();
-  });
+  Promise.all(savePromises)
+    .then(() => {
+      typeSelect.value = activeType;
+      updateOps();
+      currentIndex = nextIndex;
+      loadPage();
+    })
+    .catch((error) => {
+      console.error("Page switch aborted due to save failure:", error);
+      typeSelect.value = activeType;
+      updateOps();
+    });
 }
 
 selectModeBtn.onclick = () => setMode("select");
 drawModeBtn.onclick = () => setMode("draw");
 addItemBtn.onclick = addCorrectionItem;
 deleteItemBtn.onclick = deleteSelectedItem;
-saveBtn.onclick = saveCurrentType;
+saveBtn.onclick = () => {
+  saveCurrentType().catch(() => {});
+};
 
 typeSelect.onchange = updateOps;
 opSelect.onchange = updateControlState;

--- a/tools/gt_relabel_gui/index_manual.html
+++ b/tools/gt_relabel_gui/index_manual.html
@@ -5,14 +5,14 @@
     <title>Manual Correction Editor</title>
     <style>
       body { margin: 0; font-family: Arial, sans-serif; display: flex; height: 100vh; }
-      #sidebar { width: 390px; border-right: 1px solid #ccc; padding: 12px; overflow-y: auto; }
+      #sidebar { width: 430px; border-right: 1px solid #ccc; padding: 12px; overflow-y: auto; }
       #main { flex: 1; display: flex; flex-direction: column; }
       #toolbar { padding: 8px; border-bottom: 1px solid #ccc; display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
       #canvas { flex: 1; background: #111; cursor: default; }
       .btn { padding: 6px 10px; border: 1px solid #999; background: #f5f5f5; cursor: pointer; }
       .btn.active { background: #cde8ff; border-color: #2b78c5; }
       .btn:disabled { color: #aaa; cursor: not-allowed; }
-      .list-item { padding: 5px; border-bottom: 1px solid #eee; cursor: pointer; }
+      .list-item { padding: 5px; border-bottom: 1px solid #eee; cursor: pointer; font-family: monospace; font-size: 12px; }
       .list-item.active { background: #eef6ff; }
       .small { font-size: 12px; color: #555; }
       .row { margin-top: 8px; display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
@@ -21,8 +21,8 @@
       .dot { width: 10px; height: 10px; display: inline-block; border: 1px solid #333; }
       #pageList, #itemList { max-height: 24vh; overflow-y: auto; border: 1px solid #eee; }
       input[type="number"] { width: 80px; }
-      input[type="text"] { width: 340px; }
-      select { max-width: 230px; }
+      input[type="text"] { width: 360px; }
+      select { max-width: 260px; }
       code { font-size: 11px; }
     </style>
   </head>
@@ -67,22 +67,26 @@
       <div class="row">
         <button id="selectModeBtn" class="btn active">Select</button>
         <button id="drawModeBtn" class="btn">Draw bbox</button>
-        <button id="addItemBtn" class="btn">Add item</button>
-        <button id="deleteItemBtn" class="btn">Delete item</button>
+        <button id="addItemBtn" class="btn">Stage correction</button>
+        <button id="deleteItemBtn" class="btn">Remove staged</button>
       </div>
       <div class="small" id="selectionMeta">No selection</div>
 
       <hr />
-      <div><strong>Items for current page/type</strong></div>
+      <div><strong>Base / effective result for current page/type</strong></div>
+      <div class="small">
+        MMR rows show <code>base</code> from the configured MMR artifact and <code>effective</code> after manual corrections.
+      </div>
       <div id="itemList"></div>
 
       <hr />
       <div><strong>Legend</strong></div>
       <div class="legend">
-        <span><span class="dot" style="background:#3aa3ff;"></span>Measure</span>
-        <span><span class="dot" style="background:#46c46b;"></span>Barline</span>
+        <span><span class="dot" style="background:#3aa3ff;"></span>Normal measure</span>
+        <span><span class="dot" style="background:#46c46b;"></span>Base MMR/barline</span>
+        <span><span class="dot" style="background:#b35cff;"></span>Manual override</span>
+        <span><span class="dot" style="background:#ff3b30;"></span>Suppressed/draft</span>
         <span><span class="dot" style="background:#ff8a00;"></span>Selected</span>
-        <span><span class="dot" style="background:#ff3b30;"></span>Draft bbox</span>
       </div>
 
       <hr />
@@ -93,14 +97,14 @@
       <div class="small">
         Zoom: mouse wheel<br />
         Pan: space+drag or middle mouse<br />
-        Draw bbox: choose Draw bbox, then drag on canvas<br />
+        Save writes correction JSON only. Re-run evaluation separately.<br />
         Output: <code>data/evaluation2/manual_corrections/</code>
       </div>
     </div>
     <div id="main">
       <div id="toolbar">
         <span class="small">
-          Exports the #201 durable JSON schema. Future grouping operations are intentionally not editable here.
+          Uses base artifact + manual correction + effective view. Future grouping operations are intentionally not editable here.
         </span>
       </div>
       <canvas id="canvas"></canvas>

--- a/tools/gt_relabel_gui/manual_config_builder.py
+++ b/tools/gt_relabel_gui/manual_config_builder.py
@@ -3,7 +3,7 @@
 
 Usage:
   python3 tools/gt_relabel_gui/manual_config_builder.py \
-    IMAGE NUMBERING NAME PAGE OUTPUT
+    IMAGE NUMBERING NAME PAGE OUTPUT [MMR] [BARLINES]
 """
 
 from __future__ import annotations
@@ -14,19 +14,24 @@ from pathlib import Path
 
 
 def main() -> None:
-    if len(sys.argv) != 6:
-        raise SystemExit("usage: manual_config_builder.py IMAGE NUMBERING NAME PAGE OUTPUT")
-    image, numbering, name, page, output = sys.argv[1:]
-    payload = {
-        "pages": [
-            {
-                "name": name,
-                "page": int(page),
-                "image": image,
-                "numbering": numbering,
-            }
-        ]
+    if len(sys.argv) not in {6, 7, 8}:
+        raise SystemExit(
+            "usage: manual_config_builder.py IMAGE NUMBERING NAME PAGE OUTPUT [MMR] [BARLINES]"
+        )
+    image, numbering, name, page, output = sys.argv[1:6]
+    mmr = sys.argv[6] if len(sys.argv) >= 7 else None
+    barlines = sys.argv[7] if len(sys.argv) >= 8 else None
+    page_config = {
+        "name": name,
+        "page": int(page),
+        "image": image,
+        "numbering": numbering,
     }
+    if mmr:
+        page_config["mmr"] = mmr
+    if barlines:
+        page_config["barlines"] = barlines
+    payload = {"pages": [page_config]}
     output_path = Path(output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Follow-up to merged PR #209 for issue #201 manual correction workflow.

This PR covers both #209 review follow-up and manual GUI usability improvements.

Changes:

- Use branch `task/issue201-manual-gui-effective` targeting `develop`.
- Make `merge_measure_overrides` order-independent across payload categories.
- Normalize string-typed measure override keys before comparing them.
- Avoid crashing on `None` during normal measure override normalization.
- Raise clearer `ValueError`s for malformed MMR correction keys and malformed `force_measure` items.
- Add regression tests for order-independent merge, string-key suppression, `None` normalization, and malformed manual items.
- Add optional base MMR artifact support to the manual GUI config builder.
- Show MMR rows as `base=<span>` and `effective=<span>`.
- Apply existing saved manual correction JSON to the effective view on load.
- Initialize the measure-span input from the selected measure's effective/base span.
- Precompute MMR lookup maps during draw/render loops.
- Keep the current page when autosave fails during page navigation.
- Clarify that Save writes only manual correction JSON; evaluation rerun is separate.

## Review follow-up from #209

This PR absorbs the unresolved review threads from #209 after it was merged early:

- `merge_measure_overrides` order-dependence.
- string-typed `page/system/measure` keys when matching overrides.
- `None` values during measure override normalization.
- descriptive errors for malformed MMR correction items.
- descriptive errors for malformed measure-construction `force_measure` items.

## Review follow-up on #214

Addressed current GUI review comments:

- page navigation handles autosave failure and keeps the current page.
- draw/render precompute MMR maps once per render loop.
- `normalizeMmrRecords` accepts null/undefined defensively.

## Validation

Latest local validation reported by reviewer:

```text
PYTHONPATH=. python3 -m pytest tests/test_manual_corrections.py tests/test_numbering_overrides.py
=> 13 passed

make lint
=> passed after applying ruff format locally
```

GUI smoke test should use an actual MMR override artifact as the optional 6th argument to `manual_config_builder.py`.
