### PR TITLE
Guard one-bar rest false MMR override

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,12 @@ This document provides a set of rules and guidelines for AI agents (such as Jule
 ### Environment & Execution
 - **Check Environments First**: Before executing any code, you **MUST** read `docs/ENVIRONMENTS.md`. This project uses a mix of Docker containers (`pdf_score_dev_gpu`, `homr_eval_gpu`, etc.) and host-based virtual environments (`.venv_pdf`, etc.). Identify the correct environment for your task.
 - **Docker Preference**: Prefer running tasks inside the appropriate Docker container whenever possible to ensure reproducibility. For local PR validation helpers, see `docs/dev/codex_local_automation.md`.
+- **Persistent Pipeline Container**: For repeated full-pipeline / Issue #94 / Issue #120 / MMR evaluation work using `pdfscore_pipeline_gpu`, prefer a named long-lived container instead of repeated `docker run --rm` invocations. Create it once, then use `docker exec` for tests and evals:
+    - Create when absent: `docker run -dit --gpus all --name pdfscore_pipeline_gpu_dev -v "$PWD":/workspace -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_gpu bash`
+    - Start when stopped: `docker start pdfscore_pipeline_gpu_dev`
+    - Execute commands: `docker exec -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_gpu_dev /opt/venv_pipeline/bin/python <script-or-module>`
+    - Remove only with explicit user approval: `docker rm -f pdfscore_pipeline_gpu_dev`.
+- **Pipeline Runtime Image Is Not a Pytest Environment**: Do not assume `pytest` is installed in `pdfscore_pipeline_gpu` or `/opt/venv_pipeline`. For issue-specific lightweight checks inside this runtime, prefer Python standard-library `unittest` or self-check scripts. If `pytest` is required, use the correct dev/test environment or get explicit approval before installing packages in a container.
 - **Host Execution**: Some tools (e.g., `gui_helper`) are designed to run on the host. Follow the specific instructions in `docs/ENVIRONMENTS.md`.
 
 ### Standard Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,12 +50,14 @@ This document provides a set of rules and guidelines for AI agents (such as Jule
 ### Environment & Execution
 - **Check Environments First**: Before executing any code, you **MUST** read `docs/ENVIRONMENTS.md`. This project uses a mix of Docker containers (`pdf_score_dev_gpu`, `homr_eval_gpu`, etc.) and host-based virtual environments (`.venv_pdf`, etc.). Identify the correct environment for your task.
 - **Docker Preference**: Prefer running tasks inside the appropriate Docker container whenever possible to ensure reproducibility. For local PR validation helpers, see `docs/dev/codex_local_automation.md`.
-- **Persistent Pipeline Container**: For repeated full-pipeline / Issue #94 / Issue #120 / MMR evaluation work using `pdfscore_pipeline_gpu`, prefer a named long-lived container instead of repeated `docker run --rm` invocations. Create it once, then use `docker exec` for tests and evals:
-    - Create when absent: `docker run -dit --gpus all --name pdfscore_pipeline_gpu_dev -v "$PWD":/workspace -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_gpu bash`
-    - Start when stopped: `docker start pdfscore_pipeline_gpu_dev`
-    - Execute commands: `docker exec -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_gpu_dev /opt/venv_pipeline/bin/python <script-or-module>`
-    - Remove only with explicit user approval: `docker rm -f pdfscore_pipeline_gpu_dev`.
-- **Pipeline Runtime Image Is Not a Pytest Environment**: Do not assume `pytest` is installed in `pdfscore_pipeline_gpu` or `/opt/venv_pipeline`. For issue-specific lightweight checks inside this runtime, prefer Python standard-library `unittest` or self-check scripts. If `pytest` is required, use the correct dev/test environment or get explicit approval before installing packages in a container.
+- **Pytest-Capable Persistent Pipeline Container**: For repeated full-pipeline / Issue #94 / Issue #120 / MMR evaluation work that also needs repository tests, prefer a named long-lived pytest-capable container instead of repeated `docker run --rm` invocations. The base image remains `pdfscore_pipeline_gpu`, but the persistent local container may have `pytest` installed once in `/opt/venv_pipeline` for validation.
+    - Create when absent: `docker run -dit --gpus all --name pdfscore_pipeline_pytest_dev -v "$PWD":/workspace -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_gpu bash`
+    - Start when stopped: `docker start pdfscore_pipeline_pytest_dev`
+    - Install pytest once if missing: `docker exec -w /workspace pdfscore_pipeline_pytest_dev /opt/venv_pipeline/bin/python -m pip install pytest`
+    - Run pytest: `docker exec -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_pytest_dev /opt/venv_pipeline/bin/python -m pytest <tests-or-options>`
+    - Run pipeline/eval commands: `docker exec -w /workspace -e PYTHONPATH=/workspace pdfscore_pipeline_pytest_dev /opt/venv_pipeline/bin/python <script-or-module>`
+    - Remove only with explicit user approval: `docker rm -f pdfscore_pipeline_pytest_dev`.
+- **Do Not Drop Pytest Coverage Due to Runtime Image Defaults**: If `pdfscore_pipeline_gpu` lacks `pytest`, do not rewrite tests away from pytest or skip tests solely for that reason. Use the pytest-capable persistent container above, or a documented dev/test environment. Only use `unittest` or ad-hoc self-check scripts when they are the better test form for the issue, not as a workaround for a missing test runner.
 - **Host Execution**: Some tools (e.g., `gui_helper`) are designed to run on the host. Follow the specific instructions in `docs/ENVIRONMENTS.md`.
 
 ### Standard Commands

--- a/src/measure_numbering/mmr.py
+++ b/src/measure_numbering/mmr.py
@@ -252,25 +252,67 @@ class MMROCREngine:
 
         MMR overrides represent multi-measure rests only. A strong printed
         "1" should not become skip=0; it is used as veto evidence instead.
+
+        Raw "1" OCR boxes that are part of a merged multi-digit candidate
+        are excluded so true 10-19 MMR counts do not become veto evidence.
         """
         if not ocr_result:
             return []
 
+        def _bounds(item: List) -> Tuple[float, float, float, float]:
+            points = item[0]
+            xs = [p[0] for p in points]
+            ys = [p[1] for p in points]
+            return min(xs), min(ys), max(xs), max(ys)
+
+        def _contains(
+            outer: Tuple[float, float, float, float],
+            inner: Tuple[float, float, float, float],
+        ) -> bool:
+            ox1, oy1, ox2, oy2 = outer
+            ix1, iy1, ix2, iy2 = inner
+            return ox1 <= ix1 and oy1 <= iy1 and ix2 <= ox2 and iy2 <= oy2
+
+        def _has_multidigit_candidate(item: List) -> bool:
+            _box_points, text, _confidence = item
+            clean_text = re.sub(r"^[EP](\d)", r"\1", text)
+            clean_text = re.sub(r"[.,;]", "", clean_text)
+            blacklisted = self._has_blacklisted_text(text)
+            for n_str in self._extract_numeric_candidates(clean_text, blacklisted):
+                try:
+                    if int(n_str) >= 2:
+                        return True
+                except (TypeError, ValueError):
+                    pass
+            return False
+
+        candidate_items = self._candidate_items(ocr_result)
+        merged_multidigit_bounds = [
+            _bounds(item)
+            for item, source in candidate_items
+            if source == "merged" and _has_multidigit_candidate(item)
+        ]
+
         evidence = []
-        for item, source in self._candidate_items(ocr_result):
+        for item, source in candidate_items:
             _box_points, text, confidence = item
+            if source == "raw" and any(
+                _contains(bounds, _bounds(item)) for bounds in merged_multidigit_bounds
+            ):
+                continue
+
             clean_text = re.sub(r"^[EP](\d)", r"\1", text)
             clean_text = re.sub(r"[.,;]", "", clean_text)
             blacklisted = self._has_blacklisted_text(text)
             nums_found = self._extract_numeric_candidates(clean_text, blacklisted)
             for n_str in nums_found:
                 try:
-                    if int(n_str) == 1:
-                        evidence.append(
-                            {"text": text, "confidence": float(confidence), "source": source}
-                        )
-                except ValueError:
-                    pass
+                    val = int(n_str)
+                    conf = float(confidence)
+                except (TypeError, ValueError):
+                    continue
+                if val == 1:
+                    evidence.append({"text": text, "confidence": conf, "source": source})
         return evidence
 
     def select_best_candidate(
@@ -376,11 +418,19 @@ class MMRProcessor:
         self.rescue_threshold = rescue_threshold
 
     def _count_high_confidence_one_bar_evidence(self, ocr_result: List) -> int:
-        return sum(
-            1
-            for evidence in self.ocr.collect_one_bar_evidence(ocr_result)
-            if evidence["confidence"] >= self.ONE_BAR_VETO_MIN_CONFIDENCE
-        )
+        collector = getattr(self.ocr, "collect_one_bar_evidence", None)
+        if collector is None:
+            return 0
+
+        count = 0
+        for evidence in collector(ocr_result):
+            try:
+                confidence = float(evidence["confidence"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if confidence >= self.ONE_BAR_VETO_MIN_CONFIDENCE:
+                count += 1
+        return count
 
     def _should_veto_one_bar_rest(
         self,
@@ -516,7 +566,7 @@ class MMRProcessor:
                 )
 
         variant_results = []
-        one_bar_evidence_count = 0
+        one_bar_evidences = {}
 
         for mode, angle in variants:
             stave_results = []
@@ -535,7 +585,10 @@ class MMRProcessor:
                     continue
 
                 ocr_res, _ = self.ocr.ocr_engine(proc_img)
-                one_bar_evidence_count += self._count_high_confidence_one_bar_evidence(ocr_res)
+                variant_key = (mode, angle)
+                one_bar_evidences[variant_key] = one_bar_evidences.get(
+                    variant_key, 0
+                ) + self._count_high_confidence_one_bar_evidence(ocr_res)
                 num, score, dbg = self.ocr.select_best_candidate(ocr_res, ox2 - ox1, oy2 - oy1)
                 stave_results.append((num, score, dbg))
 
@@ -554,6 +607,7 @@ class MMRProcessor:
                         variant_debug = f"variant={mode}:{angle}"
                     variant_results.append((current_num, best_score, variant_debug))
 
+        one_bar_evidence_count = max(one_bar_evidences.values(), default=0)
         if not variant_results:
             return None, 0, "", one_bar_evidence_count
 

--- a/src/measure_numbering/mmr.py
+++ b/src/measure_numbering/mmr.py
@@ -247,6 +247,32 @@ class MMROCREngine:
             return re.findall(r"(?<![A-Za-z])\d+(?![A-Za-z])", text)
         return re.findall(r"\d+", text)
 
+    def collect_one_bar_evidence(self, ocr_result: List) -> List[Dict]:
+        """Return OCR evidence for printed one-bar rest markers.
+
+        MMR overrides represent multi-measure rests only. A strong printed
+        "1" should not become skip=0; it is used as veto evidence instead.
+        """
+        if not ocr_result:
+            return []
+
+        evidence = []
+        for item, source in self._candidate_items(ocr_result):
+            _box_points, text, confidence = item
+            clean_text = re.sub(r"^[EP](\d)", r"\1", text)
+            clean_text = re.sub(r"[.,;]", "", clean_text)
+            blacklisted = self._has_blacklisted_text(text)
+            nums_found = self._extract_numeric_candidates(clean_text, blacklisted)
+            for n_str in nums_found:
+                try:
+                    if int(n_str) == 1:
+                        evidence.append(
+                            {"text": text, "confidence": float(confidence), "source": source}
+                        )
+                except ValueError:
+                    pass
+        return evidence
+
     def select_best_candidate(
         self, ocr_result: List, img_width: int, img_height: int
     ) -> Tuple[Optional[int], float, str]:
@@ -321,6 +347,11 @@ class MMROCREngine:
 class MMRProcessor:
     """Integrated processor for batch MMR detection."""
 
+    ONE_BAR_VETO_PROB_MAX = 0.60
+    ONE_BAR_VETO_SCORE_MAX = 0.0
+    ONE_BAR_VETO_MIN_EVIDENCE = 2
+    ONE_BAR_VETO_MIN_CONFIDENCE = 0.80
+
     def __init__(
         self,
         model_path: Path,
@@ -343,6 +374,27 @@ class MMRProcessor:
 
         self.threshold = threshold
         self.rescue_threshold = rescue_threshold
+
+    def _count_high_confidence_one_bar_evidence(self, ocr_result: List) -> int:
+        return sum(
+            1
+            for evidence in self.ocr.collect_one_bar_evidence(ocr_result)
+            if evidence["confidence"] >= self.ONE_BAR_VETO_MIN_CONFIDENCE
+        )
+
+    def _should_veto_one_bar_rest(
+        self,
+        found_num: Optional[int],
+        prob: float,
+        final_score: float,
+        one_bar_evidence_count: int,
+    ) -> bool:
+        return bool(
+            found_num
+            and self.threshold < prob < self.ONE_BAR_VETO_PROB_MAX
+            and final_score < self.ONE_BAR_VETO_SCORE_MAX
+            and one_bar_evidence_count >= self.ONE_BAR_VETO_MIN_EVIDENCE
+        )
 
     def process_pages(
         self,
@@ -381,14 +433,25 @@ class MMRProcessor:
 
                         prob = self.classifier.predict(crop)
                         if prob > self.rescue_threshold:
-                            found_num, final_score, final_debug = self._detect_number(
-                                image, system, x1, y1, x2, y2, prob, w_img, h_img
+                            found_num, final_score, final_debug, one_bar_evidence_count = (
+                                self._detect_number(
+                                    image, system, x1, y1, x2, y2, prob, w_img, h_img
+                                )
                             )
 
                             is_valid = False
                             status_label = ""
+                            one_bar_vetoed = False
                             if found_num:
-                                if prob > self.threshold:
+                                one_bar_vetoed = self._should_veto_one_bar_rest(
+                                    found_num,
+                                    prob,
+                                    final_score,
+                                    one_bar_evidence_count,
+                                )
+                                if one_bar_vetoed:
+                                    status_label = "one_bar_veto"
+                                elif prob > self.threshold:
                                     is_valid, status_label = True, "found"
                                 elif final_score > 60:
                                     is_valid, status_label = True, "rescue"
@@ -417,6 +480,18 @@ class MMRProcessor:
                                         f"R{found_num}",
                                         f"P{prob:.2f}",
                                     )
+                            elif one_bar_vetoed:
+                                logger.info(
+                                    "  [VETO] P%s S%s M%s: Prob=%.2f -> OCR=%s "
+                                    "(score=%.1f, one_bar_evidence=%s)",
+                                    page_num,
+                                    sys_idx,
+                                    measure["number"],
+                                    prob,
+                                    found_num,
+                                    final_score,
+                                    one_bar_evidence_count,
+                                )
                             elif prob > self.threshold:
                                 if debug_img is not None:
                                     self._draw_debug(
@@ -441,6 +516,7 @@ class MMRProcessor:
                 )
 
         variant_results = []
+        one_bar_evidence_count = 0
 
         for mode, angle in variants:
             stave_results = []
@@ -459,6 +535,9 @@ class MMRProcessor:
                     continue
 
                 ocr_res, _ = self.ocr.ocr_engine(proc_img)
+                one_bar_evidence_count += self._count_high_confidence_one_bar_evidence(
+                    ocr_res
+                )
                 num, score, dbg = self.ocr.select_best_candidate(ocr_res, ox2 - ox1, oy2 - oy1)
                 stave_results.append((num, score, dbg))
 
@@ -478,10 +557,10 @@ class MMRProcessor:
                     variant_results.append((current_num, best_score, variant_debug))
 
         if not variant_results:
-            return None, 0, ""
+            return None, 0, "", one_bar_evidence_count
 
         found_number, best_score, best_debug = max(variant_results, key=lambda x: x[1])
-        return found_number, best_score, best_debug
+        return found_number, best_score, best_debug, one_bar_evidence_count
 
     def _draw_debug(self, img, x1, y1, x2, y2, status, text, details):
         colors = {"found": (0, 255, 0), "rescue": (0, 165, 255), "skip": (0, 255, 255)}
@@ -489,3 +568,30 @@ class MMRProcessor:
         cv2.rectangle(img, (x1, y1), (x2, y2), color, 2)
         label = f"{text} ({details})" if details else text
         cv2.putText(img, label, (x1, y1 - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1)
+
+
+def run_mmr_batch(
+    pages_data: List[Dict],
+    image_paths: List[Path],
+    model_path: Path,
+    device: torch.device,
+    debug_root: Optional[Path] = None,
+    rapidocr_instance: Optional[RapidOCR] = None,
+    threshold: float = 0.5,
+    rescue_threshold: float = 0.1,
+    enable_rotation_tta: bool = False,
+) -> List[Dict[str, List[Dict]]]:
+    ocr_engine = None
+    if rapidocr_instance is not None:
+        ocr_engine = MMROCREngine(
+            enable_rotation_tta=enable_rotation_tta, ocr_engine=rapidocr_instance
+        )
+    processor = MMRProcessor(
+        model_path,
+        device,
+        ocr_engine=ocr_engine,
+        threshold=threshold,
+        rescue_threshold=rescue_threshold,
+        enable_rotation_tta=enable_rotation_tta,
+    )
+    return processor.process_pages(pages_data, image_paths, debug_root)

--- a/src/measure_numbering/mmr.py
+++ b/src/measure_numbering/mmr.py
@@ -535,9 +535,7 @@ class MMRProcessor:
                     continue
 
                 ocr_res, _ = self.ocr.ocr_engine(proc_img)
-                one_bar_evidence_count += self._count_high_confidence_one_bar_evidence(
-                    ocr_res
-                )
+                one_bar_evidence_count += self._count_high_confidence_one_bar_evidence(ocr_res)
                 num, score, dbg = self.ocr.select_best_candidate(ocr_res, ox2 - ox1, oy2 - oy1)
                 stave_results.append((num, score, dbg))
 

--- a/src/measure_numbering/mmr.py
+++ b/src/measure_numbering/mmr.py
@@ -484,7 +484,7 @@ class MMRProcessor:
                         prob = self.classifier.predict(crop)
                         if prob > self.rescue_threshold:
                             found_num, final_score, final_debug, one_bar_evidence_count = (
-                                self._detect_number(
+                                self._detect_number_with_evidence(
                                     image, system, x1, y1, x2, y2, prob, w_img, h_img
                                 )
                             )
@@ -557,6 +557,12 @@ class MMRProcessor:
         return results
 
     def _detect_number(self, image, system, x1, y1, x2, y2, prob, w_img, h_img):
+        found_number, best_score, best_debug, _one_bar_evidence_count = (
+            self._detect_number_with_evidence(image, system, x1, y1, x2, y2, prob, w_img, h_img)
+        )
+        return found_number, best_score, best_debug
+
+    def _detect_number_with_evidence(self, image, system, x1, y1, x2, y2, prob, w_img, h_img):
         variants = [("standard", 0)]
         if prob > self.threshold:
             variants = [("standard", 0), ("no_dilate", 0), ("heavy_dilate", 0)]

--- a/tests/test_issue213_mmr_one_bar_veto.py
+++ b/tests/test_issue213_mmr_one_bar_veto.py
@@ -1,3 +1,4 @@
+import unittest
 from pathlib import Path
 
 import torch
@@ -9,56 +10,70 @@ def _box(x1, y1, x2, y2):
     return [[x1, y1], [x2, y1], [x2, y2], [x1, y2]]
 
 
-def test_collect_one_bar_evidence_keeps_single_one_and_ignores_eleven():
-    ocr = MMROCREngine(ocr_engine=object())
-    ocr_result = [
-        [_box(0, 0, 10, 20), "1", 0.99],
-        [_box(100, 0, 120, 20), "(1.", 0.82],
-        [_box(300, 0, 340, 20), "11.", 0.70],
-        [_box(500, 0, 520, 20), "B", 0.90],
-    ]
+class Issue213OneBarVetoTest(unittest.TestCase):
+    def test_collect_one_bar_evidence_keeps_single_one_and_ignores_eleven(self):
+        ocr = MMROCREngine(ocr_engine=object())
+        ocr_result = [
+            [_box(0, 0, 10, 20), "1", 0.99],
+            [_box(100, 0, 120, 20), "(1.", 0.82],
+            [_box(300, 0, 340, 20), "11.", 0.70],
+            [_box(500, 0, 520, 20), "B", 0.90],
+        ]
 
-    evidence = ocr.collect_one_bar_evidence(ocr_result)
+        evidence = ocr.collect_one_bar_evidence(ocr_result)
 
-    assert [item["text"] for item in evidence] == ["1", "(1."]
-    assert [item["source"] for item in evidence] == ["raw", "raw"]
+        self.assertEqual([item["text"] for item in evidence], ["1", "(1."])
+        self.assertEqual([item["source"] for item in evidence], ["raw", "raw"])
+
+    def test_one_bar_veto_targets_marginal_cnn_negative_ocr_score_only(self):
+        processor = MMRProcessor(
+            model_path=Path("unused"),
+            device=torch.device("cpu"),
+            classifier=object(),
+            ocr_engine=MMROCREngine(ocr_engine=object()),
+        )
+
+        self.assertTrue(
+            processor._should_veto_one_bar_rest(
+                found_num=11,
+                prob=0.5410270690917969,
+                final_score=-27.44786803610333,
+                one_bar_evidence_count=2,
+            )
+        )
+        self.assertFalse(
+            processor._should_veto_one_bar_rest(
+                found_num=11,
+                prob=0.999,
+                final_score=-27.44786803610333,
+                one_bar_evidence_count=2,
+            )
+        )
+        self.assertFalse(
+            processor._should_veto_one_bar_rest(
+                found_num=11,
+                prob=0.5410270690917969,
+                final_score=0.1,
+                one_bar_evidence_count=2,
+            )
+        )
+        self.assertFalse(
+            processor._should_veto_one_bar_rest(
+                found_num=11,
+                prob=0.5410270690917969,
+                final_score=-27.44786803610333,
+                one_bar_evidence_count=1,
+            )
+        )
+        self.assertFalse(
+            processor._should_veto_one_bar_rest(
+                found_num=None,
+                prob=0.5410270690917969,
+                final_score=-27.44786803610333,
+                one_bar_evidence_count=2,
+            )
+        )
 
 
-def test_one_bar_veto_targets_marginal_cnn_negative_ocr_score_only():
-    processor = MMRProcessor(
-        model_path=Path("unused"),
-        device=torch.device("cpu"),
-        classifier=object(),
-        ocr_engine=MMROCREngine(ocr_engine=object()),
-    )
-
-    assert processor._should_veto_one_bar_rest(
-        found_num=11,
-        prob=0.5410270690917969,
-        final_score=-27.44786803610333,
-        one_bar_evidence_count=2,
-    )
-    assert not processor._should_veto_one_bar_rest(
-        found_num=11,
-        prob=0.999,
-        final_score=-27.44786803610333,
-        one_bar_evidence_count=2,
-    )
-    assert not processor._should_veto_one_bar_rest(
-        found_num=11,
-        prob=0.5410270690917969,
-        final_score=0.1,
-        one_bar_evidence_count=2,
-    )
-    assert not processor._should_veto_one_bar_rest(
-        found_num=11,
-        prob=0.5410270690917969,
-        final_score=-27.44786803610333,
-        one_bar_evidence_count=1,
-    )
-    assert not processor._should_veto_one_bar_rest(
-        found_num=None,
-        prob=0.5410270690917969,
-        final_score=-27.44786803610333,
-        one_bar_evidence_count=2,
-    )
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue213_mmr_one_bar_veto.py
+++ b/tests/test_issue213_mmr_one_bar_veto.py
@@ -1,4 +1,3 @@
-import unittest
 from pathlib import Path
 
 import torch
@@ -10,70 +9,56 @@ def _box(x1, y1, x2, y2):
     return [[x1, y1], [x2, y1], [x2, y2], [x1, y2]]
 
 
-class Issue213OneBarVetoTest(unittest.TestCase):
-    def test_collect_one_bar_evidence_keeps_single_one_and_ignores_eleven(self):
-        ocr = MMROCREngine(ocr_engine=object())
-        ocr_result = [
-            [_box(0, 0, 10, 20), "1", 0.99],
-            [_box(100, 0, 120, 20), "(1.", 0.82],
-            [_box(300, 0, 340, 20), "11.", 0.70],
-            [_box(500, 0, 520, 20), "B", 0.90],
-        ]
+def test_collect_one_bar_evidence_keeps_single_one_and_ignores_eleven():
+    ocr = MMROCREngine(ocr_engine=object())
+    ocr_result = [
+        [_box(0, 0, 10, 20), "1", 0.99],
+        [_box(100, 0, 120, 20), "(1.", 0.82],
+        [_box(300, 0, 340, 20), "11.", 0.70],
+        [_box(500, 0, 520, 20), "B", 0.90],
+    ]
 
-        evidence = ocr.collect_one_bar_evidence(ocr_result)
+    evidence = ocr.collect_one_bar_evidence(ocr_result)
 
-        self.assertEqual([item["text"] for item in evidence], ["1", "(1."])
-        self.assertEqual([item["source"] for item in evidence], ["raw", "raw"])
-
-    def test_one_bar_veto_targets_marginal_cnn_negative_ocr_score_only(self):
-        processor = MMRProcessor(
-            model_path=Path("unused"),
-            device=torch.device("cpu"),
-            classifier=object(),
-            ocr_engine=MMROCREngine(ocr_engine=object()),
-        )
-
-        self.assertTrue(
-            processor._should_veto_one_bar_rest(
-                found_num=11,
-                prob=0.5410270690917969,
-                final_score=-27.44786803610333,
-                one_bar_evidence_count=2,
-            )
-        )
-        self.assertFalse(
-            processor._should_veto_one_bar_rest(
-                found_num=11,
-                prob=0.999,
-                final_score=-27.44786803610333,
-                one_bar_evidence_count=2,
-            )
-        )
-        self.assertFalse(
-            processor._should_veto_one_bar_rest(
-                found_num=11,
-                prob=0.5410270690917969,
-                final_score=0.1,
-                one_bar_evidence_count=2,
-            )
-        )
-        self.assertFalse(
-            processor._should_veto_one_bar_rest(
-                found_num=11,
-                prob=0.5410270690917969,
-                final_score=-27.44786803610333,
-                one_bar_evidence_count=1,
-            )
-        )
-        self.assertFalse(
-            processor._should_veto_one_bar_rest(
-                found_num=None,
-                prob=0.5410270690917969,
-                final_score=-27.44786803610333,
-                one_bar_evidence_count=2,
-            )
-        )
+    assert [item["text"] for item in evidence] == ["1", "(1."]
+    assert [item["source"] for item in evidence] == ["raw", "raw"]
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_one_bar_veto_targets_marginal_cnn_negative_ocr_score_only():
+    processor = MMRProcessor(
+        model_path=Path("unused"),
+        device=torch.device("cpu"),
+        classifier=object(),
+        ocr_engine=MMROCREngine(ocr_engine=object()),
+    )
+
+    assert processor._should_veto_one_bar_rest(
+        found_num=11,
+        prob=0.5410270690917969,
+        final_score=-27.44786803610333,
+        one_bar_evidence_count=2,
+    )
+    assert not processor._should_veto_one_bar_rest(
+        found_num=11,
+        prob=0.999,
+        final_score=-27.44786803610333,
+        one_bar_evidence_count=2,
+    )
+    assert not processor._should_veto_one_bar_rest(
+        found_num=11,
+        prob=0.5410270690917969,
+        final_score=0.1,
+        one_bar_evidence_count=2,
+    )
+    assert not processor._should_veto_one_bar_rest(
+        found_num=11,
+        prob=0.5410270690917969,
+        final_score=-27.44786803610333,
+        one_bar_evidence_count=1,
+    )
+    assert not processor._should_veto_one_bar_rest(
+        found_num=None,
+        prob=0.5410270690917969,
+        final_score=-27.44786803610333,
+        one_bar_evidence_count=2,
+    )

--- a/tests/test_issue213_mmr_one_bar_veto.py
+++ b/tests/test_issue213_mmr_one_bar_veto.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import numpy as np
 import torch
 
 from src.measure_numbering.mmr import MMROCREngine, MMRProcessor
@@ -22,6 +23,83 @@ def test_collect_one_bar_evidence_keeps_single_one_and_ignores_eleven():
 
     assert [item["text"] for item in evidence] == ["1", "(1."]
     assert [item["source"] for item in evidence] == ["raw", "raw"]
+
+
+def test_collect_one_bar_evidence_ignores_one_merged_into_multidigit():
+    ocr = MMROCREngine(ocr_engine=object())
+    ocr_result = [
+        [_box(0, 0, 10, 20), "1", 0.99],
+        [_box(15, 0, 25, 20), "5", 0.98],
+    ]
+
+    assert ocr.collect_one_bar_evidence(ocr_result) == []
+
+
+def test_count_one_bar_evidence_is_compatible_with_minimal_injected_ocr():
+    class MinimalOCR:
+        pass
+
+    processor = MMRProcessor(
+        model_path=Path("unused"),
+        device=torch.device("cpu"),
+        classifier=object(),
+        ocr_engine=MinimalOCR(),
+    )
+
+    assert processor._count_high_confidence_one_bar_evidence([]) == 0
+
+
+class OneEvidencePerVariantOCR:
+    enable_rotation_tta = False
+
+    def __init__(self):
+        self.variant = None
+
+    def mask_hbar_candidates(self, img, staff_top_rel, staff_height):
+        return img
+
+    def preprocess_variant(self, img, mode="standard", angle=0):
+        self.variant = (mode, angle)
+        return img
+
+    def ocr_engine(self, proc_img):
+        return [
+            [_box(0, 0, 10, 20), "1", 0.99],
+            [_box(300, 0, 340, 20), "11.", 0.70],
+        ], None
+
+    def collect_one_bar_evidence(self, ocr_result):
+        return MMROCREngine(ocr_engine=object()).collect_one_bar_evidence(ocr_result)
+
+    def select_best_candidate(self, ocr_res, img_width, img_height):
+        return 11, -1.0, f"variant={self.variant}"
+
+
+def test_detect_number_uses_max_one_bar_evidence_across_variants_not_sum():
+    processor = MMRProcessor(
+        model_path=Path("unused"),
+        device=torch.device("cpu"),
+        classifier=object(),
+        ocr_engine=OneEvidencePerVariantOCR(),
+    )
+    image = np.zeros((200, 200, 3), dtype=np.uint8)
+    system = {"staves": [{"bbox": [0, 50, 200, 100]}]}
+
+    found_num, final_score, _debug, one_bar_evidence_count = processor._detect_number(
+        image=image,
+        system=system,
+        x1=20,
+        y1=40,
+        x2=120,
+        y2=110,
+        prob=0.99,
+        w_img=200,
+        h_img=200,
+    )
+
+    assert found_num == 11
+    assert final_score == -1.0
+    assert one_bar_evidence_count == 1
 
 
 def test_one_bar_veto_targets_marginal_cnn_negative_ocr_score_only():

--- a/tests/test_issue213_mmr_one_bar_veto.py
+++ b/tests/test_issue213_mmr_one_bar_veto.py
@@ -75,6 +75,31 @@ class OneEvidencePerVariantOCR:
         return 11, -1.0, f"variant={self.variant}"
 
 
+def test_detect_number_preserves_three_value_contract():
+    processor = MMRProcessor(
+        model_path=Path("unused"),
+        device=torch.device("cpu"),
+        classifier=object(),
+        ocr_engine=OneEvidencePerVariantOCR(),
+    )
+    image = np.zeros((200, 200, 3), dtype=np.uint8)
+    system = {"staves": [{"bbox": [0, 50, 200, 100]}]}
+
+    result = processor._detect_number(
+        image=image,
+        system=system,
+        x1=20,
+        y1=40,
+        x2=120,
+        y2=110,
+        prob=0.99,
+        w_img=200,
+        h_img=200,
+    )
+
+    assert result == (11, -1.0, "variant=('standard', 0),variant=standard:0")
+
+
 def test_detect_number_uses_max_one_bar_evidence_across_variants_not_sum():
     processor = MMRProcessor(
         model_path=Path("unused"),
@@ -85,7 +110,7 @@ def test_detect_number_uses_max_one_bar_evidence_across_variants_not_sum():
     image = np.zeros((200, 200, 3), dtype=np.uint8)
     system = {"staves": [{"bbox": [0, 50, 200, 100]}]}
 
-    found_num, final_score, _debug, one_bar_evidence_count = processor._detect_number(
+    found_num, final_score, _debug, one_bar_evidence_count = processor._detect_number_with_evidence(
         image=image,
         system=system,
         x1=20,

--- a/tests/test_issue213_mmr_one_bar_veto.py
+++ b/tests/test_issue213_mmr_one_bar_veto.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import torch
+
+from src.measure_numbering.mmr import MMROCREngine, MMRProcessor
+
+
+def _box(x1, y1, x2, y2):
+    return [[x1, y1], [x2, y1], [x2, y2], [x1, y2]]
+
+
+def test_collect_one_bar_evidence_keeps_single_one_and_ignores_eleven():
+    ocr = MMROCREngine(ocr_engine=object())
+    ocr_result = [
+        [_box(0, 0, 10, 20), "1", 0.99],
+        [_box(100, 0, 120, 20), "(1.", 0.82],
+        [_box(300, 0, 340, 20), "11.", 0.70],
+        [_box(500, 0, 520, 20), "B", 0.90],
+    ]
+
+    evidence = ocr.collect_one_bar_evidence(ocr_result)
+
+    assert [item["text"] for item in evidence] == ["1", "(1."]
+    assert [item["source"] for item in evidence] == ["raw", "raw"]
+
+
+def test_one_bar_veto_targets_marginal_cnn_negative_ocr_score_only():
+    processor = MMRProcessor(
+        model_path=Path("unused"),
+        device=torch.device("cpu"),
+        classifier=object(),
+        ocr_engine=MMROCREngine(ocr_engine=object()),
+    )
+
+    assert processor._should_veto_one_bar_rest(
+        found_num=11,
+        prob=0.5410270690917969,
+        final_score=-27.44786803610333,
+        one_bar_evidence_count=2,
+    )
+    assert not processor._should_veto_one_bar_rest(
+        found_num=11,
+        prob=0.999,
+        final_score=-27.44786803610333,
+        one_bar_evidence_count=2,
+    )
+    assert not processor._should_veto_one_bar_rest(
+        found_num=11,
+        prob=0.5410270690917969,
+        final_score=0.1,
+        one_bar_evidence_count=2,
+    )
+    assert not processor._should_veto_one_bar_rest(
+        found_num=11,
+        prob=0.5410270690917969,
+        final_score=-27.44786803610333,
+        one_bar_evidence_count=1,
+    )
+    assert not processor._should_veto_one_bar_rest(
+        found_num=None,
+        prob=0.5410270690917969,
+        final_score=-27.44786803610333,
+        one_bar_evidence_count=2,
+    )


### PR DESCRIPTION
## Summary

Fixes #213.

Adds a narrow one-bar-rest veto for the remaining post-#211 MMR false positive on `page_033 [32,0,0]`.

The target case is a normal one-measure rest with a printed `1`. The existing MMR OCR path correctly ignores `val < 2` as an MMR candidate, but it did not use strong `1` OCR evidence to suppress a weak `11` candidate. As a result, `CNN(0.54)+OCR(-27.4): 11` became `skip=10` and produced the final FP.

This PR changes the behavior to:

- keep existing `val >= 2` MMR candidate selection unchanged;
- collect `val == 1` OCR evidence separately;
- exclude raw `1` OCR boxes that participate in merged multi-digit candidates;
- count one-bar evidence per TTA variant and use the per-variant maximum instead of summing across variants;
- keep the existing `_detect_number()` 3-value return contract and use `_detect_number_with_evidence()` only inside `process_pages()`;
- veto an override only when the detection is marginal and low-quality:
  - `found_num` exists;
  - `threshold < prob < 0.60`;
  - best OCR score `< 0.0`;
  - high-confidence one-bar evidence count `>= 2`;
- never emit `found_num=1` / `skip=0` as an override.

Also documents the pytest-capable persistent pipeline container workflow in `AGENTS.md`, so future MMR/pipeline tasks do not drop pytest coverage just because the base runtime image lacks pytest.

## Scope

In scope:

- `src/measure_numbering/mmr.py` one-bar-rest evidence collection and narrow veto.
- Focused pytest regression tests for one-bar evidence, TTA evidence aggregation, injected OCR compatibility, and `_detect_number()` return-contract preservation.
- `AGENTS.md` workflow note for `pdfscore_pipeline_pytest_dev`.

Out of scope:

- Remaining FN OCR candidate extraction.
- #197 grouping/layout cases.
- #201 manual correction workflow.
- CNN retraining or broad threshold changes.

## Validation

Review-response pytest in pytest-capable persistent pipeline container:

```text
platform linux -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: /workspace
configfile: pyproject.toml
collected 7 items

tests/test_issue213_mmr_one_bar_veto.py ......                           [ 85%]
tests/test_issue208_mmr_variant_aggregation.py .                         [100%]

7 passed in 4.31s
```

Lint / formatting:

```text
uvx ruff check . && uvx ruff format --check .
All checks passed!
369 files already formatted
```

Diff check / changed files:

```text
M       AGENTS.md
M       src/measure_numbering/mmr.py
A       tests/test_issue213_mmr_one_bar_veto.py
```

MMR-only eval with `pdfscore_pipeline_gpu` / `/opt/venv_pipeline/bin/python`:

```text
Total Pages:         68
Total Base Measures: 3325
Total Expected:      182
Total Detected:      177
Matched (TP):        171
Missed (FN):         5
Skip Mismatch:       6
Unexpected (FP):     0
Precision:           0.9661
Recall:              0.9396
F1-Score:            0.9526
```

Target veto was exercised during eval:

```text
[VETO] P33 S0 M1: Prob=0.54 -> OCR=11 (score=-27.4, one_bar_evidence=2)
```

JSON summary:

```json
{
  "total_pages": 68,
  "total_base_measures": 3325,
  "total_expected": 182,
  "total_detected": 177,
  "matched_tp": 171,
  "missed_fn": 5,
  "skip_mismatch": 6,
  "unexpected_fp": 0,
  "precision": 0.9661016949152542,
  "recall": 0.9395604395604396,
  "f1_score": 0.9526462395543176
}
```

## Notes

The previous investigation branch `investigate/issue213-page033-mmr-fp` contains temporary probe helpers and is intentionally not used for this PR. This PR branch is clean from `develop` and changes only:

```text
AGENTS.md
src/measure_numbering/mmr.py
tests/test_issue213_mmr_one_bar_veto.py
```