### PR TITLE
Improve MMR OCR fallback for residual FN after #213

### DIFF
--- a/src/measure_numbering/mmr.py
+++ b/src/measure_numbering/mmr.py
@@ -651,6 +651,45 @@ class MMRProcessor:
                         variant_debug = "variant=unmasked_fallback_standard:0"
                     variant_results.append((current_num, best_score, variant_debug))
 
+        if not variant_results and prob > self.threshold:
+            fallback_results = []
+            for stave in system.get("staves", []):
+                s_bbox = stave["bbox"]
+                margin_y = 120
+                ox1 = int(max(0, x1 - 180))
+                ox2 = int(min(w_img, x2 + 60))
+                oy1 = int(max(0, s_bbox[1] - margin_y))
+                oy2 = int(min(h_img, s_bbox[3] + margin_y))
+                stave_crop = image[oy1:oy2, ox1:ox2]
+
+                proc_img = self.ocr.preprocess_variant(stave_crop, mode="standard", angle=0)
+                if proc_img is None:
+                    continue
+
+                ocr_res, _ = self.ocr.ocr_engine(proc_img)
+                variant_key = ("left_wide_unmasked_fallback_standard", 0)
+                one_bar_evidences[variant_key] = one_bar_evidences.get(
+                    variant_key, 0
+                ) + self._count_high_confidence_one_bar_evidence(ocr_res)
+
+                num, score, dbg = self.ocr.select_best_candidate(ocr_res, ox2 - ox1, oy2 - oy1)
+                if num is not None and score > self.UNMASKED_FALLBACK_MIN_SCORE:
+                    fallback_results.append((num, score, dbg))
+
+            if fallback_results:
+                counts = Counter([r[0] for r in fallback_results])
+                current_num = counts.most_common(1)[0][0]
+                if not (current_num > 20 and (x2 - x1) < 100):
+                    _, best_score, best_dbg = max(
+                        [r for r in fallback_results if r[0] == current_num],
+                        key=lambda x: x[1],
+                    )
+                    if best_dbg:
+                        variant_debug = f"{best_dbg},variant=left_wide_unmasked_fallback_standard:0"
+                    else:
+                        variant_debug = "variant=left_wide_unmasked_fallback_standard:0"
+                    variant_results.append((current_num, best_score, variant_debug))
+
         one_bar_evidence_count = max(one_bar_evidences.values(), default=0)
         if not variant_results:
             return None, 0, "", one_bar_evidence_count

--- a/src/measure_numbering/mmr.py
+++ b/src/measure_numbering/mmr.py
@@ -393,6 +393,7 @@ class MMRProcessor:
     ONE_BAR_VETO_SCORE_MAX = 0.0
     ONE_BAR_VETO_MIN_EVIDENCE = 2
     ONE_BAR_VETO_MIN_CONFIDENCE = 0.80
+    UNMASKED_FALLBACK_MIN_SCORE = 0.0
 
     def __init__(
         self,
@@ -611,6 +612,43 @@ class MMRProcessor:
                         variant_debug = f"{best_dbg},variant={mode}:{angle}"
                     else:
                         variant_debug = f"variant={mode}:{angle}"
+                    variant_results.append((current_num, best_score, variant_debug))
+
+        if not variant_results and prob > self.threshold:
+            fallback_results = []
+            for stave in system.get("staves", []):
+                s_bbox = stave["bbox"]
+                margin_y = 80
+                ox1, ox2 = int(max(0, x1 - 30)), int(min(w_img, x2 + 30))
+                oy1, oy2 = int(max(0, s_bbox[1] - margin_y)), int(min(h_img, s_bbox[3] + 80))
+                stave_crop = image[oy1:oy2, ox1:ox2]
+
+                proc_img = self.ocr.preprocess_variant(stave_crop, mode="standard", angle=0)
+                if proc_img is None:
+                    continue
+
+                ocr_res, _ = self.ocr.ocr_engine(proc_img)
+                variant_key = ("unmasked_fallback_standard", 0)
+                one_bar_evidences[variant_key] = one_bar_evidences.get(
+                    variant_key, 0
+                ) + self._count_high_confidence_one_bar_evidence(ocr_res)
+
+                num, score, dbg = self.ocr.select_best_candidate(ocr_res, ox2 - ox1, oy2 - oy1)
+                if num is not None and score > self.UNMASKED_FALLBACK_MIN_SCORE:
+                    fallback_results.append((num, score, dbg))
+
+            if fallback_results:
+                counts = Counter([r[0] for r in fallback_results])
+                current_num = counts.most_common(1)[0][0]
+                if not (current_num > 20 and (x2 - x1) < 100):
+                    _, best_score, best_dbg = max(
+                        [r for r in fallback_results if r[0] == current_num],
+                        key=lambda x: x[1],
+                    )
+                    if best_dbg:
+                        variant_debug = f"{best_dbg},variant=unmasked_fallback_standard:0"
+                    else:
+                        variant_debug = "variant=unmasked_fallback_standard:0"
                     variant_results.append((current_num, best_score, variant_debug))
 
         one_bar_evidence_count = max(one_bar_evidences.values(), default=0)

--- a/src/measure_numbering/mmr.py
+++ b/src/measure_numbering/mmr.py
@@ -619,25 +619,29 @@ class MMRProcessor:
                         variant_debug = f"variant={mode}:{angle}"
                     variant_results.append((current_num, best_score, variant_debug))
 
-        if not variant_results and prob > self.threshold:
+        if not variant_results:
             fallback_configs = [
                 {
                     "name": "unmasked_fallback_standard",
                     "margin_y": 80,
                     "dx1": -30,
                     "dx2": 30,
+                    "min_prob": self.rescue_threshold,
                 },
                 {
                     "name": "left_wide_unmasked_fallback_standard",
                     "margin_y": 120,
                     "dx1": -180,
                     "dx2": 60,
+                    "min_prob": self.threshold,
                 },
             ]
 
             for cfg in fallback_configs:
                 if variant_results:
                     break
+                if prob <= cfg["min_prob"]:
+                    continue
 
                 fallback_results = []
                 name = cfg["name"]

--- a/src/measure_numbering/mmr.py
+++ b/src/measure_numbering/mmr.py
@@ -583,9 +583,14 @@ class MMRProcessor:
                 ox1, ox2 = int(max(0, x1 - 30)), int(min(w_img, x2 + 30))
                 oy1, oy2 = int(max(0, s_bbox[1] - margin_y)), int(min(h_img, s_bbox[3] + 80))
                 stave_crop = image[oy1:oy2, ox1:ox2]
+                if stave_crop is None or stave_crop.size == 0:
+                    continue
+
                 stave_crop = self.ocr.mask_hbar_candidates(
                     stave_crop, margin_y, s_bbox[3] - s_bbox[1]
                 )
+                if stave_crop is None or stave_crop.size == 0:
+                    continue
 
                 proc_img = self.ocr.preprocess_variant(stave_crop, mode=mode, angle=angle)
                 if proc_img is None:
@@ -615,80 +620,68 @@ class MMRProcessor:
                     variant_results.append((current_num, best_score, variant_debug))
 
         if not variant_results and prob > self.threshold:
-            fallback_results = []
-            for stave in system.get("staves", []):
-                s_bbox = stave["bbox"]
-                margin_y = 80
-                ox1, ox2 = int(max(0, x1 - 30)), int(min(w_img, x2 + 30))
-                oy1, oy2 = int(max(0, s_bbox[1] - margin_y)), int(min(h_img, s_bbox[3] + 80))
-                stave_crop = image[oy1:oy2, ox1:ox2]
+            fallback_configs = [
+                {
+                    "name": "unmasked_fallback_standard",
+                    "margin_y": 80,
+                    "dx1": -30,
+                    "dx2": 30,
+                },
+                {
+                    "name": "left_wide_unmasked_fallback_standard",
+                    "margin_y": 120,
+                    "dx1": -180,
+                    "dx2": 60,
+                },
+            ]
 
-                proc_img = self.ocr.preprocess_variant(stave_crop, mode="standard", angle=0)
-                if proc_img is None:
-                    continue
+            for cfg in fallback_configs:
+                if variant_results:
+                    break
 
-                ocr_res, _ = self.ocr.ocr_engine(proc_img)
-                variant_key = ("unmasked_fallback_standard", 0)
-                one_bar_evidences[variant_key] = one_bar_evidences.get(
-                    variant_key, 0
-                ) + self._count_high_confidence_one_bar_evidence(ocr_res)
+                fallback_results = []
+                name = cfg["name"]
+                margin_y = cfg["margin_y"]
+                dx1 = cfg["dx1"]
+                dx2 = cfg["dx2"]
 
-                num, score, dbg = self.ocr.select_best_candidate(ocr_res, ox2 - ox1, oy2 - oy1)
-                if num is not None and score > self.UNMASKED_FALLBACK_MIN_SCORE:
-                    fallback_results.append((num, score, dbg))
+                for stave in system.get("staves", []):
+                    s_bbox = stave["bbox"]
+                    ox1 = int(max(0, x1 + dx1))
+                    ox2 = int(min(w_img, x2 + dx2))
+                    oy1 = int(max(0, s_bbox[1] - margin_y))
+                    oy2 = int(min(h_img, s_bbox[3] + margin_y))
+                    stave_crop = image[oy1:oy2, ox1:ox2]
+                    if stave_crop is None or stave_crop.size == 0:
+                        continue
 
-            if fallback_results:
-                counts = Counter([r[0] for r in fallback_results])
-                current_num = counts.most_common(1)[0][0]
-                if not (current_num > 20 and (x2 - x1) < 100):
-                    _, best_score, best_dbg = max(
-                        [r for r in fallback_results if r[0] == current_num],
-                        key=lambda x: x[1],
-                    )
-                    if best_dbg:
-                        variant_debug = f"{best_dbg},variant=unmasked_fallback_standard:0"
-                    else:
-                        variant_debug = "variant=unmasked_fallback_standard:0"
-                    variant_results.append((current_num, best_score, variant_debug))
+                    proc_img = self.ocr.preprocess_variant(stave_crop, mode="standard", angle=0)
+                    if proc_img is None:
+                        continue
 
-        if not variant_results and prob > self.threshold:
-            fallback_results = []
-            for stave in system.get("staves", []):
-                s_bbox = stave["bbox"]
-                margin_y = 120
-                ox1 = int(max(0, x1 - 180))
-                ox2 = int(min(w_img, x2 + 60))
-                oy1 = int(max(0, s_bbox[1] - margin_y))
-                oy2 = int(min(h_img, s_bbox[3] + margin_y))
-                stave_crop = image[oy1:oy2, ox1:ox2]
+                    ocr_res, _ = self.ocr.ocr_engine(proc_img)
+                    variant_key = (name, 0)
+                    one_bar_evidences[variant_key] = one_bar_evidences.get(
+                        variant_key, 0
+                    ) + self._count_high_confidence_one_bar_evidence(ocr_res)
 
-                proc_img = self.ocr.preprocess_variant(stave_crop, mode="standard", angle=0)
-                if proc_img is None:
-                    continue
+                    num, score, dbg = self.ocr.select_best_candidate(ocr_res, ox2 - ox1, oy2 - oy1)
+                    if num is not None and score > self.UNMASKED_FALLBACK_MIN_SCORE:
+                        fallback_results.append((num, score, dbg))
 
-                ocr_res, _ = self.ocr.ocr_engine(proc_img)
-                variant_key = ("left_wide_unmasked_fallback_standard", 0)
-                one_bar_evidences[variant_key] = one_bar_evidences.get(
-                    variant_key, 0
-                ) + self._count_high_confidence_one_bar_evidence(ocr_res)
-
-                num, score, dbg = self.ocr.select_best_candidate(ocr_res, ox2 - ox1, oy2 - oy1)
-                if num is not None and score > self.UNMASKED_FALLBACK_MIN_SCORE:
-                    fallback_results.append((num, score, dbg))
-
-            if fallback_results:
-                counts = Counter([r[0] for r in fallback_results])
-                current_num = counts.most_common(1)[0][0]
-                if not (current_num > 20 and (x2 - x1) < 100):
-                    _, best_score, best_dbg = max(
-                        [r for r in fallback_results if r[0] == current_num],
-                        key=lambda x: x[1],
-                    )
-                    if best_dbg:
-                        variant_debug = f"{best_dbg},variant=left_wide_unmasked_fallback_standard:0"
-                    else:
-                        variant_debug = "variant=left_wide_unmasked_fallback_standard:0"
-                    variant_results.append((current_num, best_score, variant_debug))
+                if fallback_results:
+                    counts = Counter([r[0] for r in fallback_results])
+                    current_num = counts.most_common(1)[0][0]
+                    if not (current_num > 20 and (x2 - x1) < 100):
+                        _, best_score, best_dbg = max(
+                            [r for r in fallback_results if r[0] == current_num],
+                            key=lambda x: x[1],
+                        )
+                        if best_dbg:
+                            variant_debug = f"{best_dbg},variant={name}:0"
+                        else:
+                            variant_debug = f"variant={name}:0"
+                        variant_results.append((current_num, best_score, variant_debug))
 
         one_bar_evidence_count = max(one_bar_evidences.values(), default=0)
         if not variant_results:

--- a/tests/test_issue212_mmr_unmasked_fallback.py
+++ b/tests/test_issue212_mmr_unmasked_fallback.py
@@ -222,3 +222,39 @@ def test_left_wide_unmasked_fallback_rejects_negative_score_candidate():
     assert found_num is None
     assert score == 0
     assert debug == ""
+
+
+class RaisesOnEmptyCropOCR(MaskedEmptyUnmaskedNumberOCR):
+    def mask_hbar_candidates(self, img, staff_top_rel, staff_height):
+        return img
+
+    def preprocess_variant(self, img, mode="standard", angle=0):
+        if img is None or img.size == 0:
+            raise AssertionError("empty crop should be skipped before preprocessing")
+        return img
+
+    def ocr_engine(self, proc_img):
+        return [], None
+
+
+def test_fallback_paths_skip_empty_crops_before_preprocessing():
+    processor = _processor(RaisesOnEmptyCropOCR())
+    image = np.zeros((220, 220, 3), dtype=np.uint8)
+    system = {"staves": [{"bbox": [0, 40, 200, 140]}]}
+
+    found_num, score, debug, one_bar_evidence_count = processor._detect_number_with_evidence(
+        image=image,
+        system=system,
+        x1=500,
+        y1=50,
+        x2=540,
+        y2=130,
+        prob=0.99,
+        w_img=220,
+        h_img=220,
+    )
+
+    assert found_num is None
+    assert score == 0
+    assert debug == ""
+    assert one_bar_evidence_count == 0

--- a/tests/test_issue212_mmr_unmasked_fallback.py
+++ b/tests/test_issue212_mmr_unmasked_fallback.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from src.measure_numbering.mmr import MMROCREngine, MMRProcessor
+
+
+def _box(x1, y1, x2, y2):
+    return [[x1, y1], [x2, y1], [x2, y2], [x1, y2]]
+
+
+class MaskedEmptyUnmaskedNumberOCR:
+    enable_rotation_tta = False
+
+    def mask_hbar_candidates(self, img, staff_top_rel, staff_height):
+        masked = img.copy()
+        masked[:] = 255
+        return masked
+
+    def preprocess_variant(self, img, mode="standard", angle=0):
+        return img
+
+    def ocr_engine(self, proc_img):
+        if int(proc_img[0, 0, 0]) == 255:
+            return [], None
+        return [[_box(45, 45, 95, 125), "3", 0.99]], None
+
+    def collect_one_bar_evidence(self, ocr_result):
+        return MMROCREngine(ocr_engine=object()).collect_one_bar_evidence(ocr_result)
+
+    def select_best_candidate(self, ocr_res, img_width, img_height):
+        return MMROCREngine(ocr_engine=object()).select_best_candidate(
+            ocr_res, img_width, img_height
+        )
+
+
+class MaskedNumberUnmaskedDifferentNumberOCR:
+    enable_rotation_tta = False
+
+    def mask_hbar_candidates(self, img, staff_top_rel, staff_height):
+        masked = img.copy()
+        masked[:] = 255
+        return masked
+
+    def preprocess_variant(self, img, mode="standard", angle=0):
+        return img
+
+    def ocr_engine(self, proc_img):
+        if int(proc_img[0, 0, 0]) == 255:
+            return [[_box(45, 45, 95, 125), "3", 0.99]], None
+        return [[_box(45, 45, 95, 125), "4", 0.99]], None
+
+    def collect_one_bar_evidence(self, ocr_result):
+        return MMROCREngine(ocr_engine=object()).collect_one_bar_evidence(ocr_result)
+
+    def select_best_candidate(self, ocr_res, img_width, img_height):
+        return MMROCREngine(ocr_engine=object()).select_best_candidate(
+            ocr_res, img_width, img_height
+        )
+
+
+class MaskedEmptyUnmaskedLowScoreOCR(MaskedEmptyUnmaskedNumberOCR):
+    def ocr_engine(self, proc_img):
+        if int(proc_img[0, 0, 0]) == 255:
+            return [], None
+        return [[_box(0, 0, 10, 10), "9", 0.99]], None
+
+
+def _processor(ocr_engine):
+    return MMRProcessor(
+        model_path=Path("unused"),
+        device=torch.device("cpu"),
+        classifier=object(),
+        ocr_engine=ocr_engine,
+    )
+
+
+def test_unmasked_current_crop_fallback_recovers_number_when_masked_has_no_candidate():
+    processor = _processor(MaskedEmptyUnmaskedNumberOCR())
+    image = np.zeros((220, 220, 3), dtype=np.uint8)
+    system = {"staves": [{"bbox": [0, 40, 200, 140]}]}
+
+    found_num, score, debug, one_bar_evidence_count = processor._detect_number_with_evidence(
+        image=image,
+        system=system,
+        x1=20,
+        y1=50,
+        x2=140,
+        y2=130,
+        prob=0.99,
+        w_img=220,
+        h_img=220,
+    )
+
+    assert found_num == 3
+    assert score > 0
+    assert "unmasked_fallback_standard" in debug
+    assert one_bar_evidence_count == 0
+
+
+def test_unmasked_fallback_is_not_used_when_masked_path_has_candidate():
+    processor = _processor(MaskedNumberUnmaskedDifferentNumberOCR())
+    image = np.zeros((220, 220, 3), dtype=np.uint8)
+    system = {"staves": [{"bbox": [0, 40, 200, 140]}]}
+
+    found_num, _score, debug, _one_bar_evidence_count = processor._detect_number_with_evidence(
+        image=image,
+        system=system,
+        x1=20,
+        y1=50,
+        x2=140,
+        y2=130,
+        prob=0.99,
+        w_img=220,
+        h_img=220,
+    )
+
+    assert found_num == 3
+    assert "unmasked_fallback_standard" not in debug
+
+
+def test_unmasked_fallback_rejects_non_positive_score_candidate():
+    processor = _processor(MaskedEmptyUnmaskedLowScoreOCR())
+    image = np.zeros((220, 220, 3), dtype=np.uint8)
+    system = {"staves": [{"bbox": [0, 40, 200, 140]}]}
+
+    found_num, score, debug, _one_bar_evidence_count = processor._detect_number_with_evidence(
+        image=image,
+        system=system,
+        x1=20,
+        y1=50,
+        x2=140,
+        y2=130,
+        prob=0.99,
+        w_img=220,
+        h_img=220,
+    )
+
+    assert found_num is None
+    assert score == 0
+    assert debug == ""

--- a/tests/test_issue212_mmr_unmasked_fallback.py
+++ b/tests/test_issue212_mmr_unmasked_fallback.py
@@ -140,3 +140,85 @@ def test_unmasked_fallback_rejects_non_positive_score_candidate():
     assert found_num is None
     assert score == 0
     assert debug == ""
+
+
+class CurrentEmptyLeftWideNumberOCR:
+    enable_rotation_tta = False
+
+    def mask_hbar_candidates(self, img, staff_top_rel, staff_height):
+        masked = img.copy()
+        masked[:] = 255
+        return masked
+
+    def preprocess_variant(self, img, mode="standard", angle=0):
+        return img
+
+    def ocr_engine(self, proc_img):
+        h, w = proc_img.shape[:2]
+        if int(proc_img[0, 0, 0]) == 255:
+            return [], None
+        if w < 300:
+            return [], None
+        return [[_box(w * 0.45, h * 0.25, w * 0.55, h * 0.45), "S3", 0.99]], None
+
+    def collect_one_bar_evidence(self, ocr_result):
+        return MMROCREngine(ocr_engine=object()).collect_one_bar_evidence(ocr_result)
+
+    def select_best_candidate(self, ocr_res, img_width, img_height):
+        return MMROCREngine(ocr_engine=object()).select_best_candidate(
+            ocr_res, img_width, img_height
+        )
+
+
+class CurrentEmptyLeftWideLowScoreOCR(CurrentEmptyLeftWideNumberOCR):
+    def ocr_engine(self, proc_img):
+        h, w = proc_img.shape[:2]
+        if int(proc_img[0, 0, 0]) == 255:
+            return [], None
+        if w < 300:
+            return [], None
+        return [[_box(w * 0.90, h * 0.05, w * 0.98, h * 0.20), "31", 0.99]], None
+
+
+def test_left_wide_unmasked_fallback_recovers_positive_score_candidate():
+    processor = _processor(CurrentEmptyLeftWideNumberOCR())
+    image = np.zeros((260, 420, 3), dtype=np.uint8)
+    system = {"staves": [{"bbox": [0, 50, 400, 160]}]}
+
+    found_num, score, debug, _one_bar_evidence_count = processor._detect_number_with_evidence(
+        image=image,
+        system=system,
+        x1=180,
+        y1=70,
+        x2=300,
+        y2=150,
+        prob=0.99,
+        w_img=420,
+        h_img=260,
+    )
+
+    assert found_num == 3
+    assert score > 0
+    assert "left_wide_unmasked_fallback_standard" in debug
+
+
+def test_left_wide_unmasked_fallback_rejects_negative_score_candidate():
+    processor = _processor(CurrentEmptyLeftWideLowScoreOCR())
+    image = np.zeros((260, 420, 3), dtype=np.uint8)
+    system = {"staves": [{"bbox": [0, 50, 400, 160]}]}
+
+    found_num, score, debug, _one_bar_evidence_count = processor._detect_number_with_evidence(
+        image=image,
+        system=system,
+        x1=180,
+        y1=70,
+        x2=300,
+        y2=150,
+        prob=0.99,
+        w_img=420,
+        h_img=260,
+    )
+
+    assert found_num is None
+    assert score == 0
+    assert debug == ""

--- a/tests/test_issue212_mmr_unmasked_fallback.py
+++ b/tests/test_issue212_mmr_unmasked_fallback.py
@@ -258,3 +258,49 @@ def test_fallback_paths_skip_empty_crops_before_preprocessing():
     assert score == 0
     assert debug == ""
     assert one_bar_evidence_count == 0
+
+
+def test_current_unmasked_fallback_runs_in_rescue_band():
+    processor = _processor(MaskedEmptyUnmaskedNumberOCR())
+    image = np.zeros((220, 220, 3), dtype=np.uint8)
+    system = {"staves": [{"bbox": [0, 40, 200, 140]}]}
+
+    found_num, score, debug, one_bar_evidence_count = processor._detect_number_with_evidence(
+        image=image,
+        system=system,
+        x1=20,
+        y1=50,
+        x2=140,
+        y2=130,
+        prob=0.20,
+        w_img=220,
+        h_img=220,
+    )
+
+    assert found_num == 3
+    assert score > 0
+    assert "unmasked_fallback_standard" in debug
+    assert one_bar_evidence_count == 0
+
+
+def test_left_wide_unmasked_fallback_stays_above_main_threshold():
+    processor = _processor(CurrentEmptyLeftWideNumberOCR())
+    image = np.zeros((260, 420, 3), dtype=np.uint8)
+    system = {"staves": [{"bbox": [0, 50, 400, 160]}]}
+
+    found_num, score, debug, one_bar_evidence_count = processor._detect_number_with_evidence(
+        image=image,
+        system=system,
+        x1=180,
+        y1=70,
+        x2=300,
+        y2=150,
+        prob=0.20,
+        w_img=420,
+        h_img=260,
+    )
+
+    assert found_num is None
+    assert score == 0
+    assert debug == ""
+    assert one_bar_evidence_count == 0


### PR DESCRIPTION
## Summary

This PR implements the bounded production fixes validated in #212 after the #213 one-bar veto merge.

Changes:

- Add current-crop unmasked OCR fallback for MMR numbering when masked OCR variants produce no numeric candidate.
- Add score-gated left-wide unmasked OCR fallback, also only after the prior fallback paths fail.
- Add targeted tests for fallback recovery, fallback non-use when existing masked OCR succeeds, negative-score rejection, and #213 one-bar veto preservation.

This PR intentionally does not attempt to solve the remaining three residual FN with broader component/OCR heuristics. Those have been split to #221.

## Validation

Targeted tests:

```text
PYTHONPATH=. pytest tests/test_issue212_mmr_unmasked_fallback.py tests/test_issue213_mmr_one_bar_veto.py
11 passed
```

Lint:

```text
make lint
All checks passed!
370 files already formatted
```

Full 68-page MMR eval using `pdfscore_pipeline_pytest_dev` and `tools/issue94/eval_all_mmr.py`:

```text
Total Pages:         68
Total Base Measures: 3325
Total Expected:      182
Total Detected:      179
Matched (TP):        173
Missed (FN):         3
Skip Mismatch:       6
Unexpected (FP):     0
Precision:           0.9664804469
Recall:              0.9505494505
F1-Score:            0.9584487535
```

Comparison against post-#213 baseline:

```text
Post-#213 baseline: TP=171, FN=5, mismatch=6, FP=0, F1=0.9526
Candidate:          TP=173, FN=3, mismatch=6, FP=0, F1=0.9584
```

Recovered residual FN:

```text
page_042 [41,8,0] via current-crop unmasked fallback
page_002 [1,5,2] via score-gated left-wide unmasked fallback
```

No new missed keys, no new mismatch keys, no unexpected detections.

#213 one-bar veto remains preserved:

```text
[VETO] P33 S0 M1: Prob=0.54 -> OCR=11 (score=-27.4, one_bar_evidence=2)
```

## Residual / follow-up

Remaining FN are intentionally left for #221:

```text
page_001 [0,2,2] expected_num=4
page_004 [3,2,2] expected_num=3
page_009 [8,0,0] expected_num=3
```

Reason:

- `page_001`: expected `4` did not appear in crop/component diagnostics; wrong candidates such as `2`, `3`, `9`, `13`, `86`, `131`, `191` appeared.
- `page_004`: no expected `3` appeared; OCR stayed empty or non-numeric.
- `page_009`: `3` appeared once in a diagnostic line-removal variant, but with score `-53.65` and as a visually unsafe wide-crop artifact; expanded/left-wide variants also repeatedly read `31`.

## Risk

The new fallbacks are deliberately ordered after the existing masked OCR paths and are score-gated. Broad crop expansion and target-specific remapping are not included.

Closes #212
Refs #221