### PR TITLE
Define empty system output contract for numbering JSON

### DIFF
--- a/src/measure_numbering/serialization.py
+++ b/src/measure_numbering/serialization.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 
 def _serialize_staves(staves):
     return [
-        {"bbox": [staff.bbox.x1, staff.bbox.y1, staff.bbox.x2, staff.bbox.y2]}
-        for staff in staves
+        {"bbox": [staff.bbox.x1, staff.bbox.y1, staff.bbox.x2, staff.bbox.y2]} for staff in staves
     ]
 
 
@@ -31,18 +30,13 @@ def score_to_dict(score) -> dict:
         for system in page.systems:
             staves = _serialize_staves(system.staves)
             if not system.measures:
-                page_data["empty_systems"].append(
-                    {"staves": staves, "reason": "no_measures"}
-                )
+                page_data["empty_systems"].append({"staves": staves, "reason": "no_measures"})
                 continue
 
             page_data["systems"].append(
                 {
                     "staves": staves,
-                    "measures": [
-                        _serialize_measure(measure)
-                        for measure in system.measures
-                    ],
+                    "measures": [_serialize_measure(measure) for measure in system.measures],
                 }
             )
         data["pages"].append(page_data)

--- a/src/measure_numbering/serialization.py
+++ b/src/measure_numbering/serialization.py
@@ -39,9 +39,7 @@ def score_to_dict(score) -> dict:
             page_data["systems"].append(
                 {
                     "staves": staves,
-                    "measures": [
-                        _serialize_measure(measure) for measure in system.measures
-                    ],
+                    "measures": [_serialize_measure(measure) for measure in system.measures],
                 }
             )
         data["pages"].append(page_data)

--- a/src/measure_numbering/serialization.py
+++ b/src/measure_numbering/serialization.py
@@ -39,7 +39,10 @@ def score_to_dict(score) -> dict:
             page_data["systems"].append(
                 {
                     "staves": staves,
-                    "measures": [_serialize_measure(measure) for measure in system.measures],
+                    "measures": [
+                        _serialize_measure(measure)
+                        for measure in system.measures
+                    ],
                 }
             )
         data["pages"].append(page_data)

--- a/src/measure_numbering/serialization.py
+++ b/src/measure_numbering/serialization.py
@@ -1,0 +1,48 @@
+"""Serialization helpers for measure numbering results."""
+
+from __future__ import annotations
+
+
+def _serialize_staves(staves):
+    return [
+        {"bbox": [staff.bbox.x1, staff.bbox.y1, staff.bbox.x2, staff.bbox.y2]}
+        for staff in staves
+    ]
+
+
+def _serialize_measure(measure):
+    return {
+        "number": measure.number,
+        "bbox": [measure.bbox.x1, measure.bbox.y1, measure.bbox.x2, measure.bbox.y2],
+    }
+
+
+def score_to_dict(score) -> dict:
+    """Convert a Score object tree into the numbering JSON contract."""
+    data = {"pages": []}
+    for page in score.pages:
+        page_data = {
+            "page_number": page.page_number,
+            "width": page.width,
+            "height": page.height,
+            "systems": [],
+            "empty_systems": [],
+        }
+        for system in page.systems:
+            staves = _serialize_staves(system.staves)
+            if not system.measures:
+                page_data["empty_systems"].append(
+                    {"staves": staves, "reason": "no_measures"}
+                )
+                continue
+
+            page_data["systems"].append(
+                {
+                    "staves": staves,
+                    "measures": [
+                        _serialize_measure(measure) for measure in system.measures
+                    ],
+                }
+            )
+        data["pages"].append(page_data)
+    return data

--- a/src/pipeline/utils/io.py
+++ b/src/pipeline/utils/io.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
-from src.measure_numbering.serialization import score_to_dict
+from src.measure_numbering.serialization import score_to_dict as score_to_dict
 
 
 def ensure_dir(path: Path) -> None:

--- a/src/pipeline/utils/io.py
+++ b/src/pipeline/utils/io.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
+from src.measure_numbering.serialization import score_to_dict
+
 
 def ensure_dir(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
@@ -22,28 +24,3 @@ def write_json(path: Path, payload: Any) -> None:
 
 def write_manifest(path: Path, manifest: Dict[str, Any]) -> None:
     write_json(path, manifest)
-
-
-def score_to_dict(score) -> dict:
-    """Converts the Score object tree into a serializable dictionary."""
-    data = {"pages": []}
-    for p in score.pages:
-        page_data = {
-            "page_number": p.page_number,
-            "width": p.width,
-            "height": p.height,
-            "systems": [],
-        }
-        for s in p.systems:
-            sys_data = {
-                "staves": [
-                    {"bbox": [st.bbox.x1, st.bbox.y1, st.bbox.x2, st.bbox.y2]} for st in s.staves
-                ],
-                "measures": [],
-            }
-            for m in s.measures:
-                m_data = {"number": m.number, "bbox": [m.bbox.x1, m.bbox.y1, m.bbox.x2, m.bbox.y2]}
-                sys_data["measures"].append(m_data)
-            page_data["systems"].append(sys_data)
-        data["pages"].append(page_data)
-    return data

--- a/tests/test_issue217_empty_system_output_contract.py
+++ b/tests/test_issue217_empty_system_output_contract.py
@@ -1,7 +1,7 @@
 import unittest
 
+from src.measure_numbering.serialization import score_to_dict
 from src.measure_numbering.types import BBox, Barline, Measure, Page, Score, Staff, System
-from tools.add_measure_numbers import score_to_dict
 
 
 class TestIssue217EmptySystemOutputContract(unittest.TestCase):
@@ -62,7 +62,11 @@ class TestIssue217EmptySystemOutputContract(unittest.TestCase):
                     page_number=1,
                     width=1000,
                     height=2000,
-                    systems=[self.make_empty_system(), self.make_numbered_system(), self.make_empty_system()],
+                    systems=[
+                        self.make_empty_system(),
+                        self.make_numbered_system(),
+                        self.make_empty_system(),
+                    ],
                 )
             ]
         )

--- a/tests/test_issue217_empty_system_output_contract.py
+++ b/tests/test_issue217_empty_system_output_contract.py
@@ -1,0 +1,81 @@
+import unittest
+
+from src.measure_numbering.types import BBox, Barline, Measure, Page, Score, Staff, System
+from tools.add_measure_numbers import score_to_dict
+
+
+class TestIssue217EmptySystemOutputContract(unittest.TestCase):
+    def make_numbered_system(self):
+        staff = Staff(bbox=BBox(0, 100, 1000, 180))
+        first_bar = Barline(bbox=BBox(100, 100, 102, 180))
+        second_bar = Barline(bbox=BBox(300, 100, 302, 180))
+        third_bar = Barline(bbox=BBox(500, 100, 502, 180))
+        return System(
+            staves=[staff],
+            measures=[
+                Measure(
+                    number=1,
+                    start_bar=first_bar,
+                    end_bar=second_bar,
+                    bbox=BBox(100, 100, 300, 180),
+                ),
+                Measure(
+                    number=2,
+                    start_bar=second_bar,
+                    end_bar=third_bar,
+                    bbox=BBox(300, 100, 500, 180),
+                ),
+            ],
+        )
+
+    def make_empty_system(self):
+        return System(staves=[Staff(bbox=BBox(10, 10, 200, 40))], measures=[])
+
+    def test_score_to_dict_separates_empty_systems_from_numbered_systems(self):
+        score = Score(
+            pages=[
+                Page(
+                    page_number=1,
+                    width=1000,
+                    height=2000,
+                    systems=[self.make_empty_system(), self.make_numbered_system()],
+                )
+            ]
+        )
+
+        data = score_to_dict(score)
+        page = data["pages"][0]
+
+        self.assertEqual(len(page["systems"]), 1)
+        self.assertEqual([m["number"] for m in page["systems"][0]["measures"]], [1, 2])
+
+        self.assertIn("empty_systems", page)
+        self.assertEqual(len(page["empty_systems"]), 1)
+        self.assertEqual(page["empty_systems"][0]["reason"], "no_measures")
+        self.assertEqual(page["empty_systems"][0]["staves"][0]["bbox"], [10, 10, 200, 40])
+        self.assertNotIn("measures", page["empty_systems"][0])
+
+    def test_serialized_system_ranges_do_not_include_empty_systems(self):
+        score = Score(
+            pages=[
+                Page(
+                    page_number=1,
+                    width=1000,
+                    height=2000,
+                    systems=[self.make_empty_system(), self.make_numbered_system(), self.make_empty_system()],
+                )
+            ]
+        )
+
+        page = score_to_dict(score)["pages"][0]
+        measure_ranges = [
+            [system["measures"][0]["number"], system["measures"][-1]["number"]]
+            for system in page["systems"]
+        ]
+
+        self.assertEqual(measure_ranges, [[1, 2]])
+        self.assertEqual(len(page["empty_systems"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue217_empty_system_output_contract.py
+++ b/tests/test_issue217_empty_system_output_contract.py
@@ -1,7 +1,7 @@
 import unittest
 
 from src.measure_numbering.serialization import score_to_dict
-from src.measure_numbering.types import BBox, Barline, Measure, Page, Score, Staff, System
+from src.measure_numbering.types import Barline, BBox, Measure, Page, Score, Staff, System
 
 
 class TestIssue217EmptySystemOutputContract(unittest.TestCase):

--- a/tools/add_measure_numbers.py
+++ b/tools/add_measure_numbers.py
@@ -97,12 +97,20 @@ def score_to_dict(score: Score) -> dict:
             "width": p.width,
             "height": p.height,
             "systems": [],
+            "empty_systems": [],
         }
         for s in p.systems:
+            staves = [
+                {"bbox": [st.bbox.x1, st.bbox.y1, st.bbox.x2, st.bbox.y2]} for st in s.staves
+            ]
+            if not s.measures:
+                page_data["empty_systems"].append(
+                    {"staves": staves, "reason": "no_measures"}
+                )
+                continue
+
             sys_data = {
-                "staves": [
-                    {"bbox": [st.bbox.x1, st.bbox.y1, st.bbox.x2, st.bbox.y2]} for st in s.staves
-                ],
+                "staves": staves,
                 "measures": [],
             }
             for m in s.measures:

--- a/tools/add_measure_numbers.py
+++ b/tools/add_measure_numbers.py
@@ -10,6 +10,7 @@ project_root = Path(__file__).parent.parent
 sys.path.append(str(project_root))
 
 from src.measure_numbering.pipeline import MeasureNumberingPipeline
+from src.measure_numbering.serialization import score_to_dict
 from src.measure_numbering.types import Score
 
 logger = logging.getLogger(__name__)
@@ -87,41 +88,6 @@ def render_overlay(score: Score, image_path: Path, output_path: Path):
 
     cv2.imwrite(str(output_path), overlay)
     logger.info(f"Overlay saved to: {output_path}")
-
-
-def score_to_dict(score: Score) -> dict:
-    data = {"pages": []}
-    for p in score.pages:
-        page_data = {
-            "page_number": p.page_number,
-            "width": p.width,
-            "height": p.height,
-            "systems": [],
-            "empty_systems": [],
-        }
-        for s in p.systems:
-            staves = [
-                {"bbox": [st.bbox.x1, st.bbox.y1, st.bbox.x2, st.bbox.y2]} for st in s.staves
-            ]
-            if not s.measures:
-                page_data["empty_systems"].append(
-                    {"staves": staves, "reason": "no_measures"}
-                )
-                continue
-
-            sys_data = {
-                "staves": staves,
-                "measures": [],
-            }
-            for m in s.measures:
-                m_data = {
-                    "number": m.number,
-                    "bbox": [m.bbox.x1, m.bbox.y1, m.bbox.x2, m.bbox.y2],
-                }
-                sys_data["measures"].append(m_data)
-            page_data["systems"].append(sys_data)
-        data["pages"].append(page_data)
-    return data
 
 
 def normalize_barlines(raw_data):


### PR DESCRIPTION
## Summary

Fixes #217.

This PR defines the output contract for systems that have staff/layout information but no numbered measures.

The previous behavior serialized all layout systems into `pages[].systems[]`, including systems with `measures=[]`. During the #197 full visual review, the review summary converted those empty systems into `range=[None, None]`, which made the numbering output ambiguous.

This PR changes the `score_to_dict()` serialization contract so that:

- `pages[].systems[]` contains only measure-bearing systems.
- layout systems with no measures are separated into `pages[].empty_systems[]`.
- empty systems keep their staff bounding boxes and `reason="no_measures"` for review/debug use.
- `empty_systems[]` entries intentionally do not include a `measures` field.

This keeps numbering output and layout/debug information distinct without discarding empty system evidence.

## Design intent

`range=[None, None]` should not be treated as a valid measure range representation. Empty systems are not ranges; they are layout systems with no numbered measures. The output should express that directly.

## Validation

User environment validation:

```bash
PYTHONPATH=. python3 -m pytest \
  tests/test_issue217_empty_system_output_contract.py

PYTHONPATH=. python3 -m pytest \
  tests/test_issue217_empty_system_output_contract.py \
  tests/test_numbering_overrides.py \
  tests/test_manual_corrections.py \
  tests/test_issue197_system_grouping_connector_evidence.py \
  tests/test_issue197_system_connector_evidence_extractor.py

make lint
```

Observed result from user: passed. Lint-only formatting fixes were applied before push.

## Notes

This PR intentionally does not change staff detection, system grouping, or numbering logic. It only changes the serialized `numbering.json` contract and adds regression tests for that contract.