### PR TITLE
Define manual correction GUI pipeline workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ notes for current instructions.
 | User-facing pipeline entrypoint design | [`docs/refactors/issue226/ISSUE226_USER_FACING_ENTRYPOINT.md`](refactors/issue226/ISSUE226_USER_FACING_ENTRYPOINT.md) |
 | User-facing output profile contract package | [`docs/refactors/issue227/ISSUE227_OUTPUT_PROFILES.md`](refactors/issue227/ISSUE227_OUTPUT_PROFILES.md) |
 | Final score-number overlay format | [`docs/refactors/issue228/ISSUE228_FINAL_OVERLAY_FORMAT.md`](refactors/issue228/ISSUE228_FINAL_OVERLAY_FORMAT.md) |
+| Manual correction GUI pipeline workflow | [`docs/refactors/issue229/ISSUE229_MANUAL_CORRECTION_WORKFLOW.md`](refactors/issue229/ISSUE229_MANUAL_CORRECTION_WORKFLOW.md) |
 | Issue #120 artifact retention rules | [`docs/ISSUE120_ARTIFACT_RETENTION.md`](ISSUE120_ARTIFACT_RETENTION.md) |
 | Issue #120 evaluation contract | [`docs/ISSUE120_EVALUATION_CONTRACT.md`](ISSUE120_EVALUATION_CONTRACT.md) |
 | Stage E full-pipeline report | [`docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md`](ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md) |
@@ -114,6 +115,13 @@ notes for current instructions.
   final applied numbering, with MMR/manual corrections reflected semantically,
   review/debug overlay details excluded from the final PDF, and label position
   and size tuned against real page geometry.
+
+- **Issue #229 Manual Correction GUI Pipeline Workflow**  
+  [`docs/refactors/issue229/ISSUE229_MANUAL_CORRECTION_WORKFLOW.md`](refactors/issue229/ISSUE229_MANUAL_CORRECTION_WORKFLOW.md)  
+  Defines the review-package-to-GUI handoff boundary, same-coordinate-space
+  artifact requirements, correction output paths, corrected-final regeneration
+  semantics, user operation flow, and the minimum conditions for returning to
+  the #215 real-artifact GUI smoke test.
 
 ### Issue #120 / Stage E / Detector Contract Documentation
 

--- a/docs/refactors/issue229/ISSUE229_MANUAL_CORRECTION_WORKFLOW.md
+++ b/docs/refactors/issue229/ISSUE229_MANUAL_CORRECTION_WORKFLOW.md
@@ -1,0 +1,450 @@
+# Issue 229: Manual Correction GUI Pipeline Workflow
+
+## Status
+
+- Parent epic: #225
+- Task issue: #229
+- Base branch: `develop`
+- Depends on: #226 user-facing CLI entrypoint, #227 output profile contract, #228 final overlay contract
+- Related smoke issue: #215
+- Scope of this document: workflow boundary from review-profile pipeline output to manual correction GUI and back to corrected final applied numbering.
+
+This document records the design outcome for #229. It intentionally does not implement the profile materializer, GUI adapter, correction-application command, final renderer, detector/OCR/MMR behavior, or a real-artifact smoke test. The goal is to define the boundary that those follow-up implementation issues should target.
+
+## Document lifecycle
+
+This file is an issue-scoped design handoff, not the permanent home for user documentation.
+
+After the user-facing review/correction workflow is implemented and accepted, the stable parts of this design should move into formal documentation such as the root `README.md`, `docs/ENVIRONMENTS.md`, a future user guide, or a standing correction-workflow document. At that point, this issue-specific file and its `docs/README.md` index entry should be removed.
+
+Permanent repository behavior must not depend on a document whose only discoverable name is tied to a completed issue number.
+
+## Decision summary
+
+The normal manual-correction workflow must start from a review output package, not from arbitrary `logs/` paths or page-number-only matching.
+
+Primary handoff:
+
+```text
+OUTPUT_DIR/review/manual_correction_input.json
+```
+
+Default correction location:
+
+```text
+OUTPUT_DIR/review/corrections/
+```
+
+The handoff file must bind all page artifacts to the same score identity, run identity, rendered page image, and coordinate space. The GUI should consume this handoff, or an adapter generated from it, rather than independently discovering `page_003` artifacts from unrelated log roots.
+
+Corrected final output is produced by applying saved corrections before final applied numbering is rendered. The final PDF remains governed by #228: it contains only user-facing row-start labels and must not display correction provenance, MMR evidence, barline geometry, warnings, or GUI state.
+
+## Current implementation inventory
+
+### Current pipeline run layout
+
+The current config-driven pipeline writes an implementation-oriented run directory:
+
+```text
+run_dir/
+  pipeline.log
+  manifest.json
+  filters.json
+  inputs/
+    images/
+  intermediate/
+    <page_id>/
+      numbering_base.json
+      barlines_corrected.json        # only retained in some debug/apply paths
+      overrides_mmr.json
+      overrides_combined.json        # debug only
+  outputs/
+    numbering_final.json
+    <page_id>/
+      numbering_final.json
+      numbering_overlay.png
+```
+
+Important current behavior:
+
+- `run_pipeline()` still exposes `output_root/run_id` as its internal execution layout.
+- Rendered source images are written under `run_dir/inputs/images/` when image persistence is enabled.
+- Page-level base numbering is written under `run_dir/intermediate/<page_id>/numbering_base.json`.
+- MMR evidence is written under `run_dir/intermediate/<page_id>/overrides_mmr.json`.
+- Page-level final numbering is written under `run_dir/outputs/<page_id>/numbering_final.json`.
+- Combined final numbering is written under `run_dir/outputs/numbering_final.json` when multiple pages are present.
+- The current `numbering_overlay.png` is a review overlay, not the #228 final PDF.
+- `manifest.json` and `filters.json` are internal/debug-oriented sources from which a review-facing summary and warning subset can be materialized.
+
+### Current correction inputs consumed by the pipeline
+
+The current pipeline already has narrow correction hooks, but they are config-first and not yet user-workflow-first:
+
+- `inputs.measure_overrides` is loaded before final numbering and merged with auto MMR overrides during final numbering.
+- `inputs.barline_overrides` is loaded before base numbering when `steps.apply_barline_overrides` is enabled.
+- MMR measure-span corrections, measure-construction `force_measure`, and barline add/remove corrections are represented by separate helper concepts.
+- Manual corrections are applied semantically before the final applied numbering is rendered.
+
+This is enough for a correction workflow, but not enough for a clean user boundary because a user still has to know internal config keys and artifact paths.
+
+### Current manual GUI entrypoints
+
+Current manual GUI implementation:
+
+```text
+tools/gt_relabel_gui/manual_config_builder.py
+tools/gt_relabel_gui/server.py --mode manual --config CONFIG --root ROOT
+```
+
+Current manual GUI page config shape:
+
+```json
+{
+  "pages": [
+    {
+      "name": "page_003",
+      "page": 3,
+      "image": ".../source.png",
+      "numbering": ".../numbering_final.json",
+      "mmr": ".../overrides_mmr.json",
+      "barlines": ".../barlines.json"
+    }
+  ],
+  "manual_outputs": {
+    "mmr_measure_span": ".../mmr_measure_spans.json",
+    "barline_construction": ".../barline_construction_overrides.json",
+    "measure_construction": ".../measure_construction_overrides.json"
+  }
+}
+```
+
+Current GUI behavior:
+
+- loads the configured source image;
+- loads measure boxes from the configured numbering artifact;
+- optionally loads base MMR records and barline boxes;
+- displays MMR rows as `base=<span>` and `effective=<span>`;
+- supports `set_measure_span` / `suppress` for MMR measure-span correction;
+- supports `add_barline` / `remove_barline` for barline construction correction;
+- supports `force_measure` for narrow measure-construction correction;
+- saves correction JSON only; evaluation or rerun is explicitly separate;
+- allows `manual_outputs` to override the default legacy save paths.
+
+Current limitations for #229:
+
+- `manual_config_builder.py` only packages paths supplied by the caller. It does not validate same score, same run, same page, or same coordinate space.
+- The GUI consumes a one-off config shape, not `review/manual_correction_input.json` directly.
+- The GUI does not currently treat `review_overlay.png` as a first-class layer. It redraws boxes from JSON on top of the source image.
+- The GUI default output paths still point at `data/evaluation2/manual_corrections/` unless overridden.
+- There is no user-facing command that starts from `review/manual_correction_input.json`, saves under `review/corrections/`, and then regenerates corrected final applied numbering.
+
+## Comparison with #227 review profile contract
+
+#227 defines the desired review profile surface:
+
+```text
+OUTPUT_DIR/
+  final/
+    <output-name>_score_numbered.pdf
+  review/
+    run_summary.json
+    resolved_config.yaml
+    warnings.json
+    score_numbering.json
+    manual_correction_input.json
+    corrections/
+      measure_overrides.json
+    pages/
+      <page_id>/
+        source.png
+        review_overlay.png
+        final_page.png
+        numbering_final.json
+        barlines_review.json
+        mmr_overrides.json
+        correction_template.json
+```
+
+### Directly adopt from #227
+
+#229 should adopt these #227 decisions without renaming them:
+
+- `review/manual_correction_input.json` is the primary pipeline-to-GUI handoff.
+- `review/corrections/` is the default user-editable correction area.
+- `review/pages/<page_id>/source.png` is the source image used by GUI coordinates.
+- `review/pages/<page_id>/numbering_final.json` is the GUI measure/numbering source.
+- `review/pages/<page_id>/barlines_review.json` is the GUI barline geometry source when available.
+- `review/pages/<page_id>/mmr_overrides.json` is MMR evidence for correction.
+- `review/pages/<page_id>/review_overlay.png` is the user inspection overlay.
+- `coordinate_space` metadata is required.
+- `final/` remains clean and contains only the #228 final score-numbered PDF.
+
+### Missing from current pipeline output
+
+The current internal pipeline output does not yet directly provide the #227 review package. A materializer or adapter must fill the gap.
+
+Required materialization gaps:
+
+| Required review artifact | Current source | Gap |
+| --- | --- | --- |
+| `review/run_summary.json` | `manifest.json`, `filters.json`, final paths | Needs stable user-facing summary extraction. |
+| `review/resolved_config.yaml` | loaded config + CLI/profile defaults | Needs config-resolution materialization. |
+| `review/warnings.json` | `filters.json`, page statuses, pipeline warnings | Needs curated warning subset. |
+| `review/score_numbering.json` | `outputs/numbering_final.json` | Needs copy/normalization into review. |
+| `review/manual_correction_input.json` | no direct current equivalent | Needs new materializer output. |
+| `review/pages/<page_id>/source.png` | `inputs/images/<page_id>.png` or original input image path | Needs stable package-local copy/reference and image metadata. |
+| `review/pages/<page_id>/review_overlay.png` | `outputs/<page_id>/numbering_overlay.png` | Needs rename/copy; current overlay is review-only. |
+| `review/pages/<page_id>/numbering_final.json` | `outputs/<page_id>/numbering_final.json` | Needs package-local copy/reference. |
+| `review/pages/<page_id>/barlines_review.json` | `intermediate/<page_id>/barlines_corrected.json` or resolved raw barlines | Needs normalized review-level barline geometry; may be unavailable unless retained. |
+| `review/pages/<page_id>/mmr_overrides.json` | `intermediate/<page_id>/overrides_mmr.json` | Needs package-local copy/reference. |
+| coordinate-space metadata | implicit in image size / render config | Needs explicit metadata. |
+| correction output target | legacy defaults or ad hoc paths | Needs package-local `review/corrections/` paths and overwrite policy. |
+
+## GUI input boundary
+
+### Required handoff properties
+
+`review/manual_correction_input.json` must be self-contained enough for a GUI or adapter to open review artifacts without path guessing.
+
+Required top-level fields:
+
+```json
+{
+  "schema": "pdfscorebar.manual_correction_input.v1",
+  "input_pdf": "score.pdf",
+  "output_dir": ".",
+  "output_name": "score",
+  "run_id": "optional-run-id",
+  "final_pdf": "final/score_score_numbered.pdf",
+  "score_numbering": "review/score_numbering.json",
+  "coordinate_space": {
+    "type": "rendered_page_image",
+    "origin": "top_left",
+    "units": "pixels",
+    "dpi": 300,
+    "image_size_source": "per_page"
+  },
+  "correction_outputs": {
+    "measure_overrides": "review/corrections/measure_overrides.json",
+    "barline_overrides": "review/corrections/barline_overrides.json",
+    "mmr_measure_span_staging": "review/corrections/mmr_measure_spans.json",
+    "measure_construction_staging": "review/corrections/measure_construction_overrides.json",
+    "barline_construction_staging": "review/corrections/barline_construction_overrides.json"
+  },
+  "save_policy": {
+    "default": "keep_existing_user_edits",
+    "overwrite_requires_explicit_user_action": true
+  },
+  "pages": []
+}
+```
+
+Required per-page fields:
+
+```json
+{
+  "page_id": "page_003",
+  "page_number": 3,
+  "source_image": "review/pages/page_003/source.png",
+  "source_image_size": {"width": 3600, "height": 4680},
+  "review_overlay": "review/pages/page_003/review_overlay.png",
+  "numbering_final": "review/pages/page_003/numbering_final.json",
+  "barlines_review": "review/pages/page_003/barlines_review.json",
+  "mmr_overrides": "review/pages/page_003/mmr_overrides.json",
+  "coordinate_space": {
+    "same_as": "source_image",
+    "origin": "top_left",
+    "units": "pixels"
+  }
+}
+```
+
+The per-page `source_image`, `numbering_final`, `mmr_overrides`, and `barlines_review` entries must all refer to artifacts from the same review package and same rendered image coordinate space.
+
+### Prohibited normal workflow
+
+The normal user workflow must not do any of the following:
+
+- infer source image, numbering, MMR, and barline paths by matching only `page_003`;
+- mix artifacts from different `logs/issue*/` roots;
+- mix different scores or different rendered image sizes in one GUI page config;
+- require a user to inspect `manifest.json` or Stage E output directories to find correction inputs;
+- write normal correction output to `data/evaluation2/manual_corrections/` unless the user explicitly chooses a legacy/developer path;
+- overwrite existing user correction files without explicit user action.
+
+### Transitional adapter
+
+The current GUI does not have to be rewritten before #215 can be re-smoked. A small adapter can translate `review/manual_correction_input.json` into the current GUI config shape.
+
+Adapter responsibility:
+
+1. Read `OUTPUT_DIR/review/manual_correction_input.json`.
+2. Validate every referenced page artifact is under the same `OUTPUT_DIR` or explicitly recorded as external.
+3. Validate coordinate metadata is present and image sizes match expected page geometry when the data is available.
+4. Produce the current GUI config shape with `image`, `numbering`, `mmr`, and `barlines` fields mapped from the review package.
+5. Override GUI manual outputs to package-local correction paths under `review/corrections/`.
+6. Refuse or warn on missing recommended artifacts rather than silently substituting unrelated `logs/` paths.
+
+The adapter is transitional. The long-term GUI may read `manual_correction_input.json` directly.
+
+## Correction output design
+
+Manual correction storage has two levels:
+
+1. GUI staging files, matching the current #201 GUI/helper categories.
+2. Canonical pipeline correction inputs consumed by rerun/corrected-final generation.
+
+Recommended package layout:
+
+```text
+review/corrections/
+  mmr_measure_spans.json
+  measure_construction_overrides.json
+  barline_construction_overrides.json
+  measure_overrides.json
+  barline_overrides.json
+  correction_summary.json
+```
+
+Roles:
+
+| File | Role |
+| --- | --- |
+| `mmr_measure_spans.json` | GUI staging file for `mmr_measure_span` items. Current helper can translate `set_measure_span` and `suppress`. |
+| `measure_construction_overrides.json` | GUI staging file for narrow `force_measure` items. Future grouping/divisi operations remain out of scope. |
+| `barline_construction_overrides.json` | GUI staging file for `add_barline` / `remove_barline` items. |
+| `measure_overrides.json` | Canonical measure-numbering correction input for final numbering rerun. Produced by merging/normalizing MMR measure-span and measure-construction staging files with existing automatic MMR evidence as needed. |
+| `barline_overrides.json` | Canonical barline correction input consumed before base numbering when barline correction is applied. |
+| `correction_summary.json` | Optional review metadata: saved files, corrected pages, timestamps, warnings, and whether canonical files are up to date. |
+
+The #227-reserved `review/corrections/measure_overrides.json` remains the default canonical measure correction path. Barline corrections require a separate canonical `barline_overrides.json` because they are applied earlier than measure numbering and are not measure overrides.
+
+## Corrected final output regeneration
+
+The corrected pipeline path should be explicit and reproducible.
+
+Conceptual command shape for a later implementation:
+
+```bash
+pdfscorebar apply-corrections OUTPUT_DIR \
+  --corrections review/corrections/measure_overrides.json \
+  --barline-corrections review/corrections/barline_overrides.json \
+  --profile review
+```
+
+A later implementation may instead use a `pdfscorebar run ... --corrections ...` form, but it must preserve these semantics:
+
+1. Read the original review package metadata, including input PDF, pages, render settings, output name, and resolved config.
+2. Read saved manual correction staging/canonical files from `review/corrections/`.
+3. Apply barline corrections before base measure construction when `barline_overrides.json` is present.
+4. Apply measure corrections before final applied numbering is rendered.
+5. Regenerate `review/score_numbering.json` and `review/pages/<page_id>/numbering_final.json` from the corrected applied numbering.
+6. Regenerate `final/<output-name>_score_numbered.pdf` using the #228 final overlay renderer.
+7. Record correction input paths, correction timestamp, and corrected-output status in `review/run_summary.json`.
+8. Keep correction provenance, before/after details, MMR evidence, and debug geometry out of `final/`.
+
+The workflow may either update the same `OUTPUT_DIR` or create a separate corrected output directory. If it updates the same directory, it must not silently discard previous correction files or hide which correction set produced the current final PDF.
+
+## User operation flow
+
+Intended user flow:
+
+1. Run the pipeline with review artifacts enabled:
+
+   ```bash
+   pdfscorebar run score.pdf --output-dir out/score --profile review
+   ```
+
+2. Inspect `out/score/review/run_summary.json`, `out/score/review/README.md`, or the review overlay pages to find pages requiring correction.
+
+3. Start the correction GUI from the review handoff:
+
+   ```bash
+   pdfscorebar correct out/score/review/manual_correction_input.json
+   ```
+
+   Transitional implementation may run an adapter first and then launch:
+
+   ```bash
+   python3 tools/gt_relabel_gui/server.py --mode manual --config <adapted-config.json> --root out/score
+   ```
+
+4. In the GUI, review the source image, optional review overlay, final numbering boxes, MMR base/effective spans, and review-level barline geometry.
+
+5. Stage corrections:
+
+   - `set_measure_span` or `suppress` for MMR span mistakes;
+   - `add_barline` or `remove_barline` for barline construction mistakes;
+   - `force_measure` only for the currently supported narrow measure-construction exception.
+
+6. Save correction JSON under `review/corrections/`.
+
+7. Materialize or validate canonical correction inputs:
+
+   ```text
+   review/corrections/measure_overrides.json
+   review/corrections/barline_overrides.json
+   ```
+
+8. Regenerate corrected final applied numbering and the final score-numbered PDF.
+
+9. Open:
+
+   ```text
+   final/<output-name>_score_numbered.pdf
+   ```
+
+The final PDF shows only row-start labels from corrected final applied numbering. It does not show correction provenance or review/debug geometry.
+
+## Minimum conditions for returning to #215
+
+#215 can be re-smoked once there is a same-package input that avoids the artifact mismatch found in the first attempt.
+
+Minimum conditions:
+
+1. One review package contains matching `source.png`, `numbering_final.json`, `mmr_overrides.json`, and `barlines_review.json` for the same score, run, page, and rendered image coordinate space.
+2. `review/manual_correction_input.json` or a deterministic adapter config references only those same-package artifacts.
+3. The GUI output paths are redirected to `review/corrections/`, not the legacy `data/evaluation2/manual_corrections/` defaults.
+4. Coordinate-space metadata is present and can be checked by the adapter or smoke script.
+5. At least one page can load MMR base/effective rows from same-package MMR evidence.
+6. At least one `set_measure_span` or `suppress` item can be staged and saved.
+7. At least one barline `add_barline` or `remove_barline` item can be staged and saved.
+8. Saved correction JSON can be translated or passed to the current helper layer as canonical `measure_overrides.json` and `barline_overrides.json` inputs.
+9. The rerun/corrected-final handoff is documented even if final PDF regeneration is implemented in a later issue.
+
+The first #215 attempt confirmed GUI startup and MMR base/effective display, but did not validate stage/save because the image, numbering, MMR, and barline artifacts came from mismatched score/run/page roots. That issue should remain open until the corrected same-package smoke test is completed.
+
+## Follow-up implementation split
+
+This design should be implemented in small follow-up issues/PRs.
+
+| Follow-up | Scope | Notes |
+| --- | --- | --- |
+| Profile materializer for correction handoff | Create `review/manual_correction_input.json`, copy/reference page artifacts, write coordinate metadata, preserve correction files. | May be combined with the broader #227 materializer only if the PR remains small. |
+| Manual GUI handoff adapter | Convert `review/manual_correction_input.json` to current GUI config or teach GUI to read it directly. | Must reject arbitrary logs path matching as the normal route. |
+| Correction canonicalizer | Convert GUI staging files into `measure_overrides.json` and `barline_overrides.json`. | Should use existing #201 helper semantics and unit tests. |
+| Corrected rerun / apply-corrections command | Apply saved corrections and regenerate corrected final applied numbering and final PDF. | Must keep final PDF clean per #228. |
+| #215 re-smoke | Run the real-artifact GUI smoke using same-package artifacts. | Confirms stage/save and rerun handoff; does not replace #229 design. |
+
+## Non-goals for #229
+
+#229 does not:
+
+- replace #215 real-artifact smoke testing;
+- perform GUI large-scale UI redesign;
+- change detector, OCR, MMR classifier, or system grouping algorithms;
+- implement #228 final overlay rendering;
+- make the current per-measure review overlay a final deliverable;
+- make arbitrary `logs/` path discovery a supported user workflow;
+- promise backwards compatibility for all legacy experiment paths.
+
+## Acceptance mapping
+
+| #229 acceptance | Design outcome |
+| --- | --- |
+| #215 result is considered | The first attempt is classified as blocked by mismatched artifacts, so #229 defines same-package handoff conditions and leaves #215 open for re-smoke. |
+| Required GUI artifacts are defined | `manual_correction_input.json` top-level and per-page requirements define source image, numbering, MMR, barlines, overlays, coordinate metadata, and correction targets. |
+| Correction output path is defined | `review/corrections/` layout separates GUI staging files from canonical `measure_overrides.json` and `barline_overrides.json`. |
+| Corrected final output path is defined | Saved corrections are applied before final applied numbering and #228 final PDF rendering. |
+| User workflow is documented | The operation flow covers review run, page inspection, GUI launch, save, canonicalization, and corrected final output. |
+| Follow-up implementation can be split | Materializer, adapter, canonicalizer, corrected rerun, and #215 re-smoke are listed separately. |

--- a/docs/refactors/issue229/ISSUE229_MANUAL_CORRECTION_WORKFLOW.md
+++ b/docs/refactors/issue229/ISSUE229_MANUAL_CORRECTION_WORKFLOW.md
@@ -70,6 +70,7 @@ Important current behavior:
 - `run_pipeline()` still exposes `output_root/run_id` as its internal execution layout.
 - Rendered source images are written under `run_dir/inputs/images/` when image persistence is enabled.
 - Page-level base numbering is written under `run_dir/intermediate/<page_id>/numbering_base.json`.
+- Review-level barline geometry should be materialized from `run_dir/intermediate/<page_id>/barlines_corrected.json` when available, or from explicitly resolved raw barline geometry retained by the pipeline.
 - MMR evidence is written under `run_dir/intermediate/<page_id>/overrides_mmr.json`.
 - Page-level final numbering is written under `run_dir/outputs/<page_id>/numbering_final.json`.
 - Combined final numbering is written under `run_dir/outputs/numbering_final.json` when multiple pages are present.
@@ -171,6 +172,7 @@ OUTPUT_DIR/
 
 - `review/manual_correction_input.json` is the primary pipeline-to-GUI handoff.
 - `review/corrections/` is the default user-editable correction area.
+- `review/corrections/measure_overrides.json` remains the #227-compatible `correction_output` target.
 - `review/pages/<page_id>/source.png` is the source image used by GUI coordinates.
 - `review/pages/<page_id>/numbering_final.json` is the GUI measure/numbering source.
 - `review/pages/<page_id>/barlines_review.json` is the GUI barline geometry source when available.
@@ -195,7 +197,7 @@ Required materialization gaps:
 | `review/pages/<page_id>/source.png` | `inputs/images/<page_id>.png` or original input image path | Needs stable package-local copy/reference and image metadata. |
 | `review/pages/<page_id>/review_overlay.png` | `outputs/<page_id>/numbering_overlay.png` | Needs rename/copy; current overlay is review-only. |
 | `review/pages/<page_id>/numbering_final.json` | `outputs/<page_id>/numbering_final.json` | Needs package-local copy/reference. |
-| `review/pages/<page_id>/barlines_review.json` | `intermediate/<page_id>/barlines_corrected.json` or resolved raw barlines | Needs normalized review-level barline geometry; may be unavailable unless retained. |
+| `review/pages/<page_id>/barlines_review.json` | `intermediate/<page_id>/barlines_corrected.json` or explicitly resolved raw barlines | Needs normalized review-level barline geometry; must not be guessed from unrelated logs roots. |
 | `review/pages/<page_id>/mmr_overrides.json` | `intermediate/<page_id>/overrides_mmr.json` | Needs package-local copy/reference. |
 | coordinate-space metadata | implicit in image size / render config | Needs explicit metadata. |
 | correction output target | legacy defaults or ad hoc paths | Needs package-local `review/corrections/` paths and overwrite policy. |
@@ -224,12 +226,13 @@ Required top-level fields:
     "dpi": 300,
     "image_size_source": "per_page"
   },
+  "correction_output": "review/corrections/measure_overrides.json",
   "correction_outputs": {
     "measure_overrides": "review/corrections/measure_overrides.json",
     "barline_overrides": "review/corrections/barline_overrides.json",
-    "mmr_measure_span_staging": "review/corrections/mmr_measure_spans.json",
-    "measure_construction_staging": "review/corrections/measure_construction_overrides.json",
-    "barline_construction_staging": "review/corrections/barline_construction_overrides.json"
+    "mmr_measure_span": "review/corrections/mmr_measure_spans.json",
+    "measure_construction": "review/corrections/measure_construction_overrides.json",
+    "barline_construction": "review/corrections/barline_construction_overrides.json"
   },
   "save_policy": {
     "default": "keep_existing_user_edits",
@@ -238,6 +241,8 @@ Required top-level fields:
   "pages": []
 }
 ```
+
+`correction_output` preserves the #227 singular field for the canonical measure-correction file. `correction_outputs` is the #229 extension that carries barline-correction and GUI staging targets. A transitional adapter should accept #227-style handoffs that only contain `correction_output`, but #229 review packages should emit both fields so implementation code can start without guessing output paths.
 
 Required per-page fields:
 
@@ -259,7 +264,7 @@ Required per-page fields:
 }
 ```
 
-The per-page `source_image`, `numbering_final`, `mmr_overrides`, and `barlines_review` entries must all refer to artifacts from the same review package and same rendered image coordinate space.
+The per-page `source_image`, `review_overlay`, `numbering_final`, `mmr_overrides`, and `barlines_review` entries must all refer to artifacts from the same review package and same rendered image coordinate space. For the #215 smoke path, `review_overlay`, `mmr_overrides`, and `barlines_review` are required, not merely recommended, because that smoke must verify both MMR and barline correction paths.
 
 ### Prohibited normal workflow
 
@@ -281,9 +286,11 @@ Adapter responsibility:
 1. Read `OUTPUT_DIR/review/manual_correction_input.json`.
 2. Validate every referenced page artifact is under the same `OUTPUT_DIR` or explicitly recorded as external.
 3. Validate coordinate metadata is present and image sizes match expected page geometry when the data is available.
-4. Produce the current GUI config shape with `image`, `numbering`, `mmr`, and `barlines` fields mapped from the review package.
-5. Override GUI manual outputs to package-local correction paths under `review/corrections/`.
-6. Refuse or warn on missing recommended artifacts rather than silently substituting unrelated `logs/` paths.
+4. Validate that the correction-smoke path has same-package `source_image`, `numbering_final`, `mmr_overrides`, `barlines_review`, and `review_overlay` entries.
+5. Produce the current GUI config shape with `image`, `numbering`, `mmr`, and `barlines` fields mapped from the review package.
+6. Override GUI manual outputs to package-local correction paths under `review/corrections/` using current GUI keys: `mmr_measure_span`, `measure_construction`, and `barline_construction`.
+7. Accept the #227 singular `correction_output` as the canonical measure override target, prefer #229 `correction_outputs` when present, and generate package-local staging defaults only when that can be done without overwriting user edits.
+8. Refuse or warn on missing required smoke artifacts rather than silently substituting unrelated `logs/` paths.
 
 The adapter is transitional. The long-term GUI may read `manual_correction_input.json` directly.
 
@@ -317,7 +324,7 @@ Roles:
 | `barline_overrides.json` | Canonical barline correction input consumed before base numbering when barline correction is applied. |
 | `correction_summary.json` | Optional review metadata: saved files, corrected pages, timestamps, warnings, and whether canonical files are up to date. |
 
-The #227-reserved `review/corrections/measure_overrides.json` remains the default canonical measure correction path. Barline corrections require a separate canonical `barline_overrides.json` because they are applied earlier than measure numbering and are not measure overrides.
+The #227-reserved `review/corrections/measure_overrides.json` remains the default canonical measure correction path and is exposed as the singular `correction_output` field. Barline corrections require a separate canonical `barline_overrides.json` because they are applied earlier than measure numbering and are not measure overrides.
 
 ## Corrected final output regeneration
 
@@ -402,7 +409,7 @@ The final PDF shows only row-start labels from corrected final applied numbering
 
 Minimum conditions:
 
-1. One review package contains matching `source.png`, `numbering_final.json`, `mmr_overrides.json`, and `barlines_review.json` for the same score, run, page, and rendered image coordinate space.
+1. One review package contains matching `source.png`, `review_overlay.png`, `numbering_final.json`, `mmr_overrides.json`, and `barlines_review.json` for the same score, run, page, and rendered image coordinate space.
 2. `review/manual_correction_input.json` or a deterministic adapter config references only those same-package artifacts.
 3. The GUI output paths are redirected to `review/corrections/`, not the legacy `data/evaluation2/manual_corrections/` defaults.
 4. Coordinate-space metadata is present and can be checked by the adapter or smoke script.
@@ -420,8 +427,8 @@ This design should be implemented in small follow-up issues/PRs.
 
 | Follow-up | Scope | Notes |
 | --- | --- | --- |
-| Profile materializer for correction handoff | Create `review/manual_correction_input.json`, copy/reference page artifacts, write coordinate metadata, preserve correction files. | May be combined with the broader #227 materializer only if the PR remains small. |
-| Manual GUI handoff adapter | Convert `review/manual_correction_input.json` to current GUI config or teach GUI to read it directly. | Must reject arbitrary logs path matching as the normal route. |
+| Profile materializer for correction handoff | Create `review/manual_correction_input.json`, copy/reference page artifacts, write coordinate metadata, preserve correction files. | Must emit #227-compatible `correction_output`, #229 `correction_outputs`, and `barlines_review.json` from retained corrected/raw barline geometry. |
+| Manual GUI handoff adapter | Convert `review/manual_correction_input.json` to current GUI config or teach GUI to read it directly. | Must reject arbitrary logs path matching as the normal route and map current GUI output keys without `_staging` suffix. |
 | Correction canonicalizer | Convert GUI staging files into `measure_overrides.json` and `barline_overrides.json`. | Should use existing #201 helper semantics and unit tests. |
 | Corrected rerun / apply-corrections command | Apply saved corrections and regenerate corrected final applied numbering and final PDF. | Must keep final PDF clean per #228. |
 | #215 re-smoke | Run the real-artifact GUI smoke using same-package artifacts. | Confirms stage/save and rerun handoff; does not replace #229 design. |
@@ -444,7 +451,7 @@ This design should be implemented in small follow-up issues/PRs.
 | --- | --- |
 | #215 result is considered | The first attempt is classified as blocked by mismatched artifacts, so #229 defines same-package handoff conditions and leaves #215 open for re-smoke. |
 | Required GUI artifacts are defined | `manual_correction_input.json` top-level and per-page requirements define source image, numbering, MMR, barlines, overlays, coordinate metadata, and correction targets. |
-| Correction output path is defined | `review/corrections/` layout separates GUI staging files from canonical `measure_overrides.json` and `barline_overrides.json`. |
+| Correction output path is defined | `review/corrections/` layout separates GUI staging files from canonical `measure_overrides.json` and `barline_overrides.json`, while preserving #227 `correction_output`. |
 | Corrected final output path is defined | Saved corrections are applied before final applied numbering and #228 final PDF rendering. |
 | User workflow is documented | The operation flow covers review run, page inspection, GUI launch, save, canonicalization, and corrected final output. |
 | Follow-up implementation can be split | Materializer, adapter, canonicalizer, corrected rerun, and #215 re-smoke are listed separately. |

--- a/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
+++ b/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
@@ -26,7 +26,6 @@ primary_handoff:
 required_top_level_fields:
   - schema
   - input_pdf
-  - output_dir
   - output_name
   - final_pdf
   - score_numbering
@@ -35,21 +34,42 @@ required_top_level_fields:
   - save_policy
   - pages
 
+optional_or_derivable_top_level_fields:
+  output_dir: >-
+    Optional for base v1 compatibility. For #227-style handoffs, consumers may
+    derive the package root from the manual_correction_input.json path.
+
 conditional_top_level_fields:
   issue229_review_correction_package:
+    condition: >-
+      Required when the handoff is produced for the #229 review/correction GUI
+      workflow, including the #215 real-artifact smoke path.
     required:
+      - output_dir
       - correction_outputs
+    compatibility_note: >-
+      #227-only v1 handoffs may contain only correction_output and remain valid
+      for legacy/manual-correction consumers. #229 packages extend the same v1
+      payload with correction_outputs instead of invalidating #227 examples.
 
 required_page_fields:
   - page_id
   - page_number
   - source_image
-  - source_image_size
   - review_overlay
   - numbering_final
   - barlines_review
   - mmr_overrides
   - coordinate_space
+
+conditional_page_fields:
+  issue229_review_correction_package:
+    condition: >-
+      Required for #229 review/correction packages and for #215 real-artifact
+      smoke retries. Base #227 v1 handoffs may rely on top-level coordinate
+      metadata or image probing when safe.
+    required:
+      - source_image_size
 
 recommended_page_fields:
   - correction_template
@@ -123,6 +143,8 @@ manual_gui_adapter:
     - accept_issue227_correction_output_as_measure_overrides_target
     - prefer_correction_outputs_when_present
     - generate_package_local_defaults_for_staging_paths_when_safe
+    - derive_output_dir_from_handoff_path_for_issue227_v1_when_absent
+    - tolerate_missing_page_source_image_size_for_issue227_v1_when_coordinate_metadata_is_sufficient
   current_gui_fields:
     image: source_image
     numbering: numbering_final

--- a/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
+++ b/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
@@ -12,6 +12,10 @@ primary_handoff:
   path: review/manual_correction_input.json
   schema: pdfscorebar.manual_correction_input.v1
   must_be_package_scoped: true
+  preserves_issue227_field:
+    correction_output: review/corrections/measure_overrides.json
+  extends_issue227_with:
+    correction_outputs: review/corrections/ structured output map for #229 GUI staging and canonical inputs
   prohibits:
     - page_number_only_artifact_matching
     - arbitrary_logs_path_discovery
@@ -20,12 +24,14 @@ primary_handoff:
     - mixed_coordinate_spaces
 
 required_top_level_fields:
+  - schema
   - input_pdf
   - output_dir
   - output_name
   - final_pdf
   - score_numbering
   - coordinate_space
+  - correction_output
   - correction_outputs
   - save_policy
   - pages
@@ -35,13 +41,13 @@ required_page_fields:
   - page_number
   - source_image
   - source_image_size
+  - review_overlay
   - numbering_final
+  - barlines_review
+  - mmr_overrides
   - coordinate_space
 
 recommended_page_fields:
-  - review_overlay
-  - barlines_review
-  - mmr_overrides
   - correction_template
 
 coordinate_space:
@@ -60,6 +66,8 @@ current_pipeline_sources:
   run_layout:
     source_images: run_dir/inputs/images/
     base_numbering: run_dir/intermediate/<page_id>/numbering_base.json
+    barlines_corrected: run_dir/intermediate/<page_id>/barlines_corrected.json
+    barlines_review_fallback: resolved raw barlines retained by the pipeline when corrected barlines are unavailable
     mmr_overrides: run_dir/intermediate/<page_id>/overrides_mmr.json
     combined_overrides_debug: run_dir/intermediate/<page_id>/overrides_combined.json
     page_final_numbering: run_dir/outputs/<page_id>/numbering_final.json
@@ -71,6 +79,7 @@ current_pipeline_sources:
   notes:
     - run_pipeline currently exposes output_root/run_id internally.
     - numbering_overlay.png is review output, not the #228 final PDF.
+    - barlines_review must be materialized from barlines_corrected when available, or from explicitly resolved raw barline geometry; it must not be guessed from unrelated logs roots.
     - manifest.json and filters.json should be summarized for review/debug, not exposed as normal user workflow requirements.
 
 review_profile_targets:
@@ -87,6 +96,8 @@ review_profile_targets:
 
 correction_outputs:
   directory: review/corrections/
+  issue227_compatible_field:
+    correction_output: review/corrections/measure_overrides.json
   staging_files:
     mmr_measure_span: review/corrections/mmr_measure_spans.json
     measure_construction: review/corrections/measure_construction_overrides.json
@@ -104,14 +115,23 @@ manual_gui_adapter:
   transitional: true
   input: review/manual_correction_input.json
   output: current_gt_relabel_gui_manual_config
+  compatibility:
+    - accept_issue227_correction_output_as_measure_overrides_target
+    - prefer_correction_outputs_when_present
+    - generate_package_local_defaults_for_staging_paths_when_safe
   current_gui_fields:
     image: source_image
     numbering: numbering_final
     mmr: mmr_overrides
     barlines: barlines_review
+  current_manual_output_keys:
+    mmr_measure_span: correction_outputs.staging_files.mmr_measure_span
+    measure_construction: correction_outputs.staging_files.measure_construction
+    barline_construction: correction_outputs.staging_files.barline_construction
   responsibilities:
     - validate_package_scope
     - validate_coordinate_metadata_presence
+    - validate_required_smoke_artifacts_presence
     - map_page_artifacts_to_current_gui_config
     - map_manual_outputs_to_review_corrections
     - refuse_unrelated_logs_substitution
@@ -165,10 +185,14 @@ follow_up_split:
       - review/manual_correction_input.json
       - review_page_artifact_copy_or_reference
       - coordinate_metadata
+      - issue227_compatible_correction_output
+      - issue229_correction_outputs
+      - barlines_review_materialization
   gui_adapter:
     owns:
       - current_gui_config_generation_from_handoff
       - package_scope_validation
+      - correction_output_compatibility
   correction_canonicalizer:
     owns:
       - staging_to_measure_overrides

--- a/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
+++ b/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
@@ -58,8 +58,6 @@ required_page_fields:
   - source_image
   - review_overlay
   - numbering_final
-  - barlines_review
-  - mmr_overrides
   - coordinate_space
 
 conditional_page_fields:
@@ -67,12 +65,17 @@ conditional_page_fields:
     condition: >-
       Required for #229 review/correction packages and for #215 real-artifact
       smoke retries. Base #227 v1 handoffs may rely on top-level coordinate
-      metadata or image probing when safe.
+      metadata or image probing when safe, and may omit optional review evidence
+      when a layer is disabled or not relevant to the selected correction mode.
     required:
       - source_image_size
+      - barlines_review
+      - mmr_overrides
 
 recommended_page_fields:
   - correction_template
+  - barlines_review
+  - mmr_overrides
 
 coordinate_space:
   type: rendered_page_image
@@ -145,7 +148,10 @@ manual_gui_adapter:
     - generate_package_local_defaults_for_staging_paths_when_safe
     - derive_output_dir_from_handoff_path_for_issue227_v1_when_absent
     - tolerate_missing_page_source_image_size_for_issue227_v1_when_coordinate_metadata_is_sufficient
+    - tolerate_missing_optional_mmr_or_barline_review_evidence_when_not_required_by_correction_mode
   current_gui_fields:
+    name: page_id
+    page: page_number
     image: source_image
     numbering: numbering_final
     mmr: mmr_overrides
@@ -156,6 +162,7 @@ manual_gui_adapter:
     barline_construction: correction_outputs.barline_construction
   responsibilities:
     - validate_package_scope
+    - validate_page_identity_mapping
     - validate_coordinate_metadata_presence
     - validate_required_smoke_artifacts_presence
     - map_page_artifacts_to_current_gui_config

--- a/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
+++ b/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
@@ -15,7 +15,7 @@ primary_handoff:
   preserves_issue227_field:
     correction_output: review/corrections/measure_overrides.json
   extends_issue227_with:
-    correction_outputs: review/corrections/ structured output map for #229 GUI staging and canonical inputs
+    correction_outputs: "review/corrections/ structured output map for #229 GUI staging and canonical inputs"
   prohibits:
     - page_number_only_artifact_matching
     - arbitrary_logs_path_discovery
@@ -32,9 +32,13 @@ required_top_level_fields:
   - score_numbering
   - coordinate_space
   - correction_output
-  - correction_outputs
   - save_policy
   - pages
+
+conditional_top_level_fields:
+  issue229_review_correction_package:
+    required:
+      - correction_outputs
 
 required_page_fields:
   - page_id
@@ -78,7 +82,7 @@ current_pipeline_sources:
     pipeline_log: run_dir/pipeline.log
   notes:
     - run_pipeline currently exposes output_root/run_id internally.
-    - numbering_overlay.png is review output, not the #228 final PDF.
+    - "numbering_overlay.png is review output, not the #228 final PDF."
     - barlines_review must be materialized from barlines_corrected when available, or from explicitly resolved raw barline geometry; it must not be guessed from unrelated logs roots.
     - manifest.json and filters.json should be summarized for review/debug, not exposed as normal user workflow requirements.
 
@@ -98,7 +102,7 @@ correction_outputs:
   directory: review/corrections/
   issue227_compatible_field:
     correction_output: review/corrections/measure_overrides.json
-  staging_files:
+  handoff_payload_fields:
     mmr_measure_span: review/corrections/mmr_measure_spans.json
     measure_construction: review/corrections/measure_construction_overrides.json
     barline_construction: review/corrections/barline_construction_overrides.json
@@ -125,9 +129,9 @@ manual_gui_adapter:
     mmr: mmr_overrides
     barlines: barlines_review
   current_manual_output_keys:
-    mmr_measure_span: correction_outputs.staging_files.mmr_measure_span
-    measure_construction: correction_outputs.staging_files.measure_construction
-    barline_construction: correction_outputs.staging_files.barline_construction
+    mmr_measure_span: correction_outputs.mmr_measure_span
+    measure_construction: correction_outputs.measure_construction
+    barline_construction: correction_outputs.barline_construction
   responsibilities:
     - validate_package_scope
     - validate_coordinate_metadata_presence

--- a/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
+++ b/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
@@ -149,9 +149,13 @@ manual_gui_adapter:
     - derive_output_dir_from_handoff_path_for_issue227_v1_when_absent
     - tolerate_missing_page_source_image_size_for_issue227_v1_when_coordinate_metadata_is_sufficient
     - tolerate_missing_optional_mmr_or_barline_review_evidence_when_not_required_by_correction_mode
+  derived_adapter_fields:
+    override_page_index_zero_based: page_number_minus_1
+    source_page_number_one_based: page_number
   current_gui_fields:
     name: page_id
-    page: page_number
+    page: override_page_index_zero_based
+    source_page_number: source_page_number_one_based
     image: source_image
     numbering: numbering_final
     mmr: mmr_overrides
@@ -163,6 +167,7 @@ manual_gui_adapter:
   responsibilities:
     - validate_package_scope
     - validate_page_identity_mapping
+    - validate_current_gui_zero_based_page_mapping
     - validate_coordinate_metadata_presence
     - validate_required_smoke_artifacts_presence
     - map_page_artifacts_to_current_gui_config

--- a/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
+++ b/docs/refactors/issue229/MANUAL_CORRECTION_WORKFLOW_SPEC.yaml
@@ -1,0 +1,190 @@
+schema: pdfscorebar.issue229.manual_correction_workflow_spec.v1
+issue: 229
+parent: 225
+base_branch: develop
+status: design_handoff
+
+purpose: >-
+  Define the workflow boundary from #227 review-profile pipeline output to the
+  manual correction GUI and back to corrected final applied numbering.
+
+primary_handoff:
+  path: review/manual_correction_input.json
+  schema: pdfscorebar.manual_correction_input.v1
+  must_be_package_scoped: true
+  prohibits:
+    - page_number_only_artifact_matching
+    - arbitrary_logs_path_discovery
+    - mixed_score_artifacts
+    - mixed_run_artifacts
+    - mixed_coordinate_spaces
+
+required_top_level_fields:
+  - input_pdf
+  - output_dir
+  - output_name
+  - final_pdf
+  - score_numbering
+  - coordinate_space
+  - correction_outputs
+  - save_policy
+  - pages
+
+required_page_fields:
+  - page_id
+  - page_number
+  - source_image
+  - source_image_size
+  - numbering_final
+  - coordinate_space
+
+recommended_page_fields:
+  - review_overlay
+  - barlines_review
+  - mmr_overrides
+  - correction_template
+
+coordinate_space:
+  type: rendered_page_image
+  origin: top_left
+  units: pixels
+  required_metadata:
+    - rendered_dpi_or_scale_when_available
+    - per_page_image_width
+    - per_page_image_height
+  rule: >-
+    All geometry consumed by the GUI for a page must be in the same coordinate
+    space as that page's source_image.
+
+current_pipeline_sources:
+  run_layout:
+    source_images: run_dir/inputs/images/
+    base_numbering: run_dir/intermediate/<page_id>/numbering_base.json
+    mmr_overrides: run_dir/intermediate/<page_id>/overrides_mmr.json
+    combined_overrides_debug: run_dir/intermediate/<page_id>/overrides_combined.json
+    page_final_numbering: run_dir/outputs/<page_id>/numbering_final.json
+    combined_final_numbering: run_dir/outputs/numbering_final.json
+    review_overlay: run_dir/outputs/<page_id>/numbering_overlay.png
+    filters: run_dir/filters.json
+    manifest: run_dir/manifest.json
+    pipeline_log: run_dir/pipeline.log
+  notes:
+    - run_pipeline currently exposes output_root/run_id internally.
+    - numbering_overlay.png is review output, not the #228 final PDF.
+    - manifest.json and filters.json should be summarized for review/debug, not exposed as normal user workflow requirements.
+
+review_profile_targets:
+  source_images: review/pages/<page_id>/source.png
+  review_overlay: review/pages/<page_id>/review_overlay.png
+  page_final_numbering: review/pages/<page_id>/numbering_final.json
+  combined_final_numbering: review/score_numbering.json
+  mmr_overrides: review/pages/<page_id>/mmr_overrides.json
+  barlines_review: review/pages/<page_id>/barlines_review.json
+  run_summary: review/run_summary.json
+  resolved_config: review/resolved_config.yaml
+  warnings: review/warnings.json
+  manual_handoff: review/manual_correction_input.json
+
+correction_outputs:
+  directory: review/corrections/
+  staging_files:
+    mmr_measure_span: review/corrections/mmr_measure_spans.json
+    measure_construction: review/corrections/measure_construction_overrides.json
+    barline_construction: review/corrections/barline_construction_overrides.json
+  canonical_pipeline_inputs:
+    measure_overrides: review/corrections/measure_overrides.json
+    barline_overrides: review/corrections/barline_overrides.json
+  optional_metadata:
+    correction_summary: review/corrections/correction_summary.json
+  overwrite_policy:
+    default: keep_existing_user_edits
+    overwrite_requires_explicit_user_action: true
+
+manual_gui_adapter:
+  transitional: true
+  input: review/manual_correction_input.json
+  output: current_gt_relabel_gui_manual_config
+  current_gui_fields:
+    image: source_image
+    numbering: numbering_final
+    mmr: mmr_overrides
+    barlines: barlines_review
+  responsibilities:
+    - validate_package_scope
+    - validate_coordinate_metadata_presence
+    - map_page_artifacts_to_current_gui_config
+    - map_manual_outputs_to_review_corrections
+    - refuse_unrelated_logs_substitution
+
+corrected_final_workflow:
+  correction_application_order:
+    - barline_overrides_before_base_measure_construction
+    - measure_overrides_before_final_applied_numbering
+    - final_overlay_after_corrected_final_applied_numbering
+  final_output:
+    path: final/<output-name>_score_numbered.pdf
+    source_semantics:
+      - review/score_numbering.json
+      - review/pages/<page_id>/numbering_final.json
+    must_not_include:
+      - correction_provenance
+      - before_after_numbers
+      - override_comments
+      - mmr_evidence
+      - detector_geometry
+      - barline_boxes
+      - gui_handles
+      - warnings
+  review_updates:
+    - correction_input_paths
+    - correction_timestamp
+    - corrected_output_status
+
+user_flow:
+  - run_review_profile
+  - inspect_run_summary_or_review_overlays
+  - launch_gui_from_manual_correction_input
+  - inspect_source_overlay_numbering_mmr_and_barlines
+  - stage_and_save_corrections
+  - canonicalize_correction_inputs
+  - regenerate_corrected_final_applied_numbering
+  - render_final_score_numbered_pdf
+
+issue215_resmoke_minimum_conditions:
+  - same_review_package_source_numbering_mmr_barlines
+  - coordinate_space_metadata_available
+  - gui_output_paths_under_review_corrections
+  - mmr_base_effective_rows_load_for_at_least_one_page
+  - mmr_correction_can_be_staged_and_saved
+  - barline_correction_can_be_staged_and_saved
+  - saved_json_can_be_handed_to_helper_or_pipeline
+
+follow_up_split:
+  profile_materializer:
+    owns:
+      - review/manual_correction_input.json
+      - review_page_artifact_copy_or_reference
+      - coordinate_metadata
+  gui_adapter:
+    owns:
+      - current_gui_config_generation_from_handoff
+      - package_scope_validation
+  correction_canonicalizer:
+    owns:
+      - staging_to_measure_overrides
+      - staging_to_barline_overrides
+  corrected_rerun_command:
+    owns:
+      - applying_saved_corrections
+      - regenerating_corrected_final_outputs
+  issue215_resmoke:
+    owns:
+      - real_artifact_stage_save_confirmation
+
+non_goals:
+  - replace_issue215_smoke_test
+  - gui_large_redesign
+  - detector_ocr_mmr_accuracy_changes
+  - final_overlay_renderer_implementation
+  - arbitrary_logs_path_normal_workflow
+  - repository_split_or_main_promotion

--- a/docs/refactors/issue229/WORKFLOW_DIAGRAMS.md
+++ b/docs/refactors/issue229/WORKFLOW_DIAGRAMS.md
@@ -1,0 +1,201 @@
+# Issue 229: Manual Correction Workflow Diagrams
+
+## Status
+
+- Parent epic: #225
+- Task issue: #229
+- Related design document: `ISSUE229_MANUAL_CORRECTION_WORKFLOW.md`
+- Scope of this document: visual summaries of the review-package-to-GUI boundary and corrected-final regeneration workflow.
+
+These diagrams are explanatory. They do not add implementation requirements beyond `ISSUE229_MANUAL_CORRECTION_WORKFLOW.md` and `MANUAL_CORRECTION_WORKFLOW_SPEC.yaml`.
+
+## 1. End-to-end user workflow
+
+```mermaid
+flowchart TD
+  A[User runs review profile<br/>pdfscorebar run INPUT.pdf --output-dir OUTPUT_DIR --profile review]
+  B[Pipeline internal run_dir<br/>inputs / intermediate / outputs]
+  C[Profile materializer]
+  D[OUTPUT_DIR/review package<br/>manual_correction_input.json<br/>pages/* artifacts]
+  E[Manual correction GUI<br/>or transitional adapter + current GUI]
+  F[review/corrections staging files<br/>mmr_measure_spans.json<br/>barline_construction_overrides.json<br/>measure_construction_overrides.json]
+  G[Correction canonicalizer]
+  H[Canonical correction inputs<br/>measure_overrides.json<br/>barline_overrides.json]
+  I[Corrected pipeline/rerun step]
+  J[Corrected final applied numbering<br/>review/score_numbering.json<br/>review/pages/*/numbering_final.json]
+  K[#228 final renderer]
+  L[final/&lt;output-name&gt;_score_numbered.pdf<br/>row-start labels only]
+
+  A --> B
+  B --> C
+  C --> D
+  D --> E
+  E --> F
+  F --> G
+  G --> H
+  H --> I
+  I --> J
+  J --> K
+  K --> L
+```
+
+Key point: the GUI does not search arbitrary `logs/` directories. It starts from a review package produced for one score/run/coordinate space.
+
+## 2. Artifact boundary: current internal output to review package
+
+```mermaid
+flowchart LR
+  subgraph Internal[Current implementation-oriented run_dir]
+    I1[inputs/images]
+    I2[intermediate/&lt;page_id&gt;/overrides_mmr.json]
+    I3[intermediate/&lt;page_id&gt;/barlines_corrected.json<br/>or resolved raw barlines]
+    I4[outputs/&lt;page_id&gt;/numbering_final.json]
+    I5[outputs/&lt;page_id&gt;/numbering_overlay.png]
+    I6[outputs/numbering_final.json]
+    I7[manifest.json / filters.json / pipeline.log]
+  end
+
+  M[Profile materializer<br/>normalizes, copies/references,<br/>adds metadata]
+
+  subgraph Review[OUTPUT_DIR/review]
+    R1[pages/&lt;page_id&gt;/source.png]
+    R2[pages/&lt;page_id&gt;/mmr_overrides.json]
+    R3[pages/&lt;page_id&gt;/barlines_review.json]
+    R4[pages/&lt;page_id&gt;/numbering_final.json]
+    R5[pages/&lt;page_id&gt;/review_overlay.png]
+    R6[score_numbering.json]
+    R7[run_summary.json / warnings.json]
+    R8[manual_correction_input.json]
+  end
+
+  I1 --> M --> R1
+  I2 --> M --> R2
+  I3 --> M --> R3
+  I4 --> M --> R4
+  I5 --> M --> R5
+  I6 --> M --> R6
+  I7 --> M --> R7
+  R1 --> R8
+  R2 --> R8
+  R3 --> R8
+  R4 --> R8
+  R5 --> R8
+  R6 --> R8
+```
+
+Key point: `manual_correction_input.json` is a curated handoff, not a raw dump of the internal run directory.
+
+## 3. Same-coordinate-space requirement
+
+```mermaid
+flowchart TD
+  P[One page entry in<br/>review/manual_correction_input.json]
+  S[source.png<br/>rendered page image]
+  N[numbering_final.json<br/>measure boxes]
+  M[mmr_overrides.json<br/>MMR span evidence]
+  B[barlines_review.json<br/>barline geometry]
+  O[review_overlay.png<br/>visual inspection layer]
+  C[coordinate_space metadata<br/>origin=top_left, units=pixels,<br/>image size / dpi when available]
+  G[GUI editable view]
+
+  P --> S
+  P --> N
+  P --> M
+  P --> B
+  P --> O
+  P --> C
+  S --> G
+  N --> G
+  M --> G
+  B --> G
+  O --> G
+  C --> G
+
+  X[Reject normal workflow if artifacts come from<br/>different score / different run / different page / different image scale]
+  P -. validation .-> X
+```
+
+Key point: the first #215 attempt failed this boundary because image, numbering, MMR, and barline artifacts came from mismatched roots.
+
+## 4. Correction output levels
+
+```mermaid
+flowchart TD
+  subgraph GUI[GUI save output under review/corrections]
+    A[mmr_measure_spans.json<br/>set_measure_span / suppress]
+    B[measure_construction_overrides.json<br/>force_measure]
+    C[barline_construction_overrides.json<br/>add_barline / remove_barline]
+  end
+
+  D[Correction canonicalizer]
+
+  subgraph Canonical[Canonical pipeline correction inputs]
+    E[measure_overrides.json<br/>consumed during final numbering]
+    F[barline_overrides.json<br/>consumed before base measure construction]
+  end
+
+  A --> D
+  B --> D
+  C --> D
+  D --> E
+  D --> F
+```
+
+Key point: GUI staging files mirror the current #201 GUI/helper categories. The pipeline rerun should consume canonical correction inputs.
+
+## 5. Corrected final regeneration order
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant G as Manual GUI
+  participant C as review/corrections
+  participant P as Pipeline correction step
+  participant R as Review outputs
+  participant F as Final renderer
+
+  U->>G: Stage MMR / barline / measure corrections
+  G->>C: Save staging JSON
+  C->>P: Canonicalize to measure_overrides.json and barline_overrides.json
+  P->>P: Apply barline_overrides before base measure construction
+  P->>P: Apply measure_overrides before final applied numbering
+  P->>R: Write corrected score_numbering.json and page numbering_final.json
+  R->>F: Provide corrected final applied numbering
+  F->>U: Write final/&lt;output-name&gt;_score_numbered.pdf
+```
+
+Key point: final rendering happens after corrections are applied semantically. The final PDF does not display correction provenance.
+
+## 6. #215 retry gate
+
+```mermaid
+flowchart TD
+  A[Review package exists]
+  B{Same score / run / page / coordinate space?}
+  C{manual_correction_input.json or adapter config present?}
+  D{GUI save targets under review/corrections?}
+  E{MMR base/effective rows load?}
+  F{Can save MMR correction?}
+  G{Can save barline correction?}
+  H{Saved JSON can reach helper/pipeline input?}
+  I[Proceed with #215 real-artifact smoke retry]
+  Z[Do not proceed;<br/>fix package/materializer/adapter first]
+
+  A --> B
+  B -- yes --> C
+  B -- no --> Z
+  C -- yes --> D
+  C -- no --> Z
+  D -- yes --> E
+  D -- no --> Z
+  E -- yes --> F
+  E -- no --> Z
+  F -- yes --> G
+  F -- no --> Z
+  G -- yes --> H
+  G -- no --> Z
+  H -- yes --> I
+  H -- no --> Z
+```
+
+Key point: #229 does not replace #215. It defines the prerequisites for a meaningful #215 retry.


### PR DESCRIPTION
## Summary

- Define the #229 manual correction GUI workflow boundary from `review/manual_correction_input.json` to GUI save output and corrected final applied numbering.
- Record the current internal pipeline output inventory and its gaps against the #227 review profile contract.
- Define the same-package / same-coordinate-space GUI input requirement so normal workflow does not rely on arbitrary `logs/` path discovery or page-number-only matching.
- Define `review/corrections/` as the correction area, separating current GUI staging files from canonical `measure_overrides.json` and `barline_overrides.json` pipeline inputs.
- Define the user operation flow: review-profile run, inspect pages, launch GUI from handoff, stage/save corrections, canonicalize correction files, regenerate corrected final output.
- Define the minimum conditions for returning to #215 real-artifact smoke testing.
- Add a structured YAML handoff spec and index #229 from `docs/README.md`.

## Scope

Documentation/specification-only. This PR does not implement the profile materializer, GUI adapter, correction canonicalizer, corrected rerun command, final renderer, detector/OCR/MMR changes, or the #215 real-artifact smoke test.

## Validation

Not run. Documentation/specification-only change.

Closes #229.

Parent: #225
Related: #215, #201, #226, #227, #228
