### PR TITLE
Add manual correction review package flow

### DIFF
--- a/src/pipeline/review/__init__.py
+++ b/src/pipeline/review/__init__.py
@@ -1,0 +1,1 @@
+"""Review-profile pipeline helpers."""

--- a/src/pipeline/review/manual_correction_handoff.py
+++ b/src/pipeline/review/manual_correction_handoff.py
@@ -117,7 +117,12 @@ def _validate_existing_path(
         field=field,
         required=required,
     )
-    if resolved is not None and package_root is not None and require_exists and not resolved.exists():
+    if (
+        resolved is not None
+        and package_root is not None
+        and require_exists
+        and not resolved.exists()
+    ):
         raise ManualCorrectionHandoffError(f"{field} does not exist: {raw_path}")
     return resolved
 
@@ -133,7 +138,9 @@ def _relative_for_gui(path: Optional[Path], *, package_root: Optional[Path]) -> 
     return path.as_posix()
 
 
-def _manual_output_paths(page: Dict[str, Any], *, package_root: Optional[Path]) -> Dict[str, str]:
+def _manual_output_paths(
+    page: Dict[str, Any], *, package_root: Optional[Path]
+) -> Dict[str, str]:
     configured = page.get("correction_outputs")
     if configured is not None:
         if not isinstance(configured, dict):
@@ -239,7 +246,9 @@ def validate_manual_correction_handoff(
             if resolved is not None:
                 normalized_page[field] = _relative_for_gui(resolved, package_root=package_root)
 
-        normalized_page["manual_outputs"] = _manual_output_paths(page, package_root=package_root)
+        normalized_page["manual_outputs"] = _manual_output_paths(
+            page, package_root=package_root
+        )
         normalized_pages.append(normalized_page)
 
     normalized["pages"] = normalized_pages
@@ -306,7 +315,9 @@ def write_manual_gui_config(
         require_existing_artifacts=require_existing_artifacts,
     )
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(json.dumps(config, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    output.write_text(
+        json.dumps(config, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
     return config
 
 
@@ -324,7 +335,9 @@ def _write_json_object(path: Path, payload: Dict[str, Any], *, overwrite: bool) 
     if path.exists() and not overwrite:
         raise FileExistsError(f"Refusing to overwrite existing correction file: {path}")
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
 
 
 def canonicalize_manual_correction_outputs(

--- a/src/pipeline/review/manual_correction_handoff.py
+++ b/src/pipeline/review/manual_correction_handoff.py
@@ -1,0 +1,370 @@
+"""Review-profile manual correction handoff helpers.
+
+This module adapts the review-profile handoff contract to the current manual
+correction GUI without changing the production detector/MMR/numbering path.
+"""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, Literal, Optional
+
+from src.pipeline.steps.manual_corrections import (
+    merge_barline_overrides,
+    merge_measure_overrides,
+)
+
+HandoffMode = Literal["base_v1", "issue229_smoke_strict"]
+
+GUI_OUTPUT_KEYS = {
+    "mmr_measure_span": "mmr_measure_spans.json",
+    "measure_construction": "measure_construction_overrides.json",
+    "barline_construction": "barline_construction_overrides.json",
+}
+
+STAGING_TO_CANONICAL_FILENAMES = {
+    "mmr_measure_span": "mmr_measure_spans.json",
+    "measure_construction": "measure_construction_overrides.json",
+    "barline_construction": "barline_construction_overrides.json",
+}
+
+_REQUIRED_TOP_LEVEL_FIELDS = ("schema_version", "pages")
+_REQUIRED_PAGE_FIELDS = ("page_id", "page_number", "source_image", "numbering_final")
+_STRICT_PAGE_FIELDS = ("review_overlay", "mmr_overrides", "barlines_review")
+
+
+class ManualCorrectionHandoffError(ValueError):
+    """Raised when a manual-correction handoff is unsafe or malformed."""
+
+
+def load_manual_correction_handoff(path: str | Path) -> Dict[str, Any]:
+    """Load a ``review/manual_correction_input.json`` handoff file."""
+
+    handoff_path = Path(path)
+    with handoff_path.open(encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if not isinstance(payload, dict):
+        raise ManualCorrectionHandoffError("manual correction handoff must be a JSON object")
+    return payload
+
+
+def _is_missing(value: Any) -> bool:
+    return value is None or value == ""
+
+
+def _as_page_number(value: Any, *, page_id: str) -> int:
+    try:
+        page_number = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ManualCorrectionHandoffError(f"{page_id}: page_number must be an integer") from exc
+    if page_number < 1:
+        raise ManualCorrectionHandoffError(f"{page_id}: page_number must be >= 1")
+    return page_number
+
+
+def _package_root(handoff_path: str | Path | None) -> Optional[Path]:
+    if handoff_path is None:
+        return None
+    return Path(handoff_path).resolve().parent
+
+
+def _resolve_package_path(
+    raw_path: Any,
+    *,
+    package_root: Optional[Path],
+    field: str,
+    required: bool,
+) -> Optional[Path]:
+    if _is_missing(raw_path):
+        if required:
+            raise ManualCorrectionHandoffError(f"{field} is required")
+        return None
+    if not isinstance(raw_path, str):
+        raise ManualCorrectionHandoffError(f"{field} must be a path string")
+
+    candidate = Path(raw_path)
+    if package_root is None:
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise ManualCorrectionHandoffError(
+                f"{field} must stay inside the review package"
+            )
+        return candidate
+
+    resolved = candidate if candidate.is_absolute() else package_root / candidate
+    resolved = resolved.resolve()
+    try:
+        resolved.relative_to(package_root)
+    except ValueError as exc:
+        raise ManualCorrectionHandoffError(
+            f"{field} must stay inside the review package: {raw_path}"
+        ) from exc
+    return resolved
+
+
+def _validate_existing_path(
+    raw_path: Any,
+    *,
+    package_root: Optional[Path],
+    field: str,
+    required: bool,
+    require_exists: bool,
+) -> Optional[Path]:
+    resolved = _resolve_package_path(
+        raw_path,
+        package_root=package_root,
+        field=field,
+        required=required,
+    )
+    if resolved is not None and package_root is not None and require_exists and not resolved.exists():
+        raise ManualCorrectionHandoffError(f"{field} does not exist: {raw_path}")
+    return resolved
+
+
+def _relative_for_gui(path: Optional[Path], *, package_root: Optional[Path]) -> Optional[str]:
+    if path is None:
+        return None
+    if package_root is not None:
+        try:
+            return path.relative_to(package_root).as_posix()
+        except ValueError:
+            pass
+    return path.as_posix()
+
+
+def _manual_output_paths(page: Dict[str, Any], *, package_root: Optional[Path]) -> Dict[str, str]:
+    configured = page.get("correction_outputs")
+    if configured is not None:
+        if not isinstance(configured, dict):
+            raise ManualCorrectionHandoffError("correction_outputs must be an object")
+        output_paths: Dict[str, str] = {}
+        for key in GUI_OUTPUT_KEYS:
+            if key not in configured:
+                raise ManualCorrectionHandoffError(f"correction_outputs.{key} is required")
+            resolved = _resolve_package_path(
+                configured[key],
+                package_root=package_root,
+                field=f"correction_outputs.{key}",
+                required=True,
+            )
+            assert resolved is not None
+            output_paths[key] = _relative_for_gui(resolved, package_root=package_root)
+        return output_paths
+
+    output_dir = page.get("correction_output")
+    if _is_missing(output_dir):
+        output_dir = "corrections"
+    output_root = _resolve_package_path(
+        output_dir,
+        package_root=package_root,
+        field="correction_output",
+        required=True,
+    )
+    assert output_root is not None
+    return {
+        key: _relative_for_gui(output_root / filename, package_root=package_root)
+        for key, filename in GUI_OUTPUT_KEYS.items()
+    }
+
+
+def validate_manual_correction_handoff(
+    payload: Dict[str, Any],
+    *,
+    handoff_path: str | Path | None = None,
+    mode: HandoffMode = "base_v1",
+    require_existing_artifacts: bool = False,
+) -> Dict[str, Any]:
+    """Validate a review manual-correction handoff.
+
+    ``base_v1`` accepts optional MMR/barline/review-overlay evidence so older
+    review-profile producers can be adapted. ``issue229_smoke_strict`` requires
+    the artifacts needed by the #215/#229 GUI smoke path.
+    """
+
+    if not isinstance(payload, dict):
+        raise ManualCorrectionHandoffError("manual correction handoff must be a JSON object")
+    for field in _REQUIRED_TOP_LEVEL_FIELDS:
+        if field not in payload:
+            raise ManualCorrectionHandoffError(f"{field} is required")
+    if mode not in {"base_v1", "issue229_smoke_strict"}:
+        raise ManualCorrectionHandoffError(f"unsupported handoff validation mode: {mode}")
+
+    pages = payload.get("pages")
+    if not isinstance(pages, list) or not pages:
+        raise ManualCorrectionHandoffError("pages must be a non-empty list")
+
+    package_root = _package_root(handoff_path)
+    normalized = deepcopy(payload)
+    normalized_pages = []
+
+    for index, page in enumerate(pages):
+        if not isinstance(page, dict):
+            raise ManualCorrectionHandoffError(f"pages[{index}] must be an object")
+        page_id = str(page.get("page_id") or f"pages[{index}]")
+        for field in _REQUIRED_PAGE_FIELDS:
+            if field not in page or _is_missing(page.get(field)):
+                raise ManualCorrectionHandoffError(f"{page_id}: {field} is required")
+        if mode == "issue229_smoke_strict":
+            for field in _STRICT_PAGE_FIELDS:
+                if field not in page or _is_missing(page.get(field)):
+                    raise ManualCorrectionHandoffError(
+                        f"{page_id}: {field} is required in strict mode"
+                    )
+
+        page_number = _as_page_number(page.get("page_number"), page_id=page_id)
+        normalized_page = deepcopy(page)
+        normalized_page["page_id"] = page_id
+        normalized_page["page_number"] = page_number
+        normalized_page["gui_page_index_zero_based"] = page_number - 1
+        normalized_page["source_page_number_one_based"] = page_number
+
+        for field in (
+            "source_image",
+            "numbering_final",
+            "review_overlay",
+            "mmr_overrides",
+            "barlines_review",
+        ):
+            required = field in _REQUIRED_PAGE_FIELDS or (
+                mode == "issue229_smoke_strict" and field in _STRICT_PAGE_FIELDS
+            )
+            resolved = _validate_existing_path(
+                page.get(field),
+                package_root=package_root,
+                field=f"{page_id}.{field}",
+                required=required,
+                require_exists=require_existing_artifacts,
+            )
+            if resolved is not None:
+                normalized_page[field] = _relative_for_gui(resolved, package_root=package_root)
+
+        normalized_page["manual_outputs"] = _manual_output_paths(page, package_root=package_root)
+        normalized_pages.append(normalized_page)
+
+    normalized["pages"] = normalized_pages
+    return normalized
+
+
+def build_manual_gui_config(
+    payload: Dict[str, Any],
+    *,
+    handoff_path: str | Path | None = None,
+    mode: HandoffMode = "base_v1",
+    require_existing_artifacts: bool = False,
+) -> Dict[str, Any]:
+    """Build the current GUI config from a review manual-correction handoff."""
+
+    normalized = validate_manual_correction_handoff(
+        payload,
+        handoff_path=handoff_path,
+        mode=mode,
+        require_existing_artifacts=require_existing_artifacts,
+    )
+    pages = []
+    for page in normalized["pages"]:
+        gui_page = {
+            "name": page["page_id"],
+            "page": page["gui_page_index_zero_based"],
+            "source_page_number": page["source_page_number_one_based"],
+            "image": page["source_image"],
+            "numbering": page["numbering_final"],
+            "manual_outputs": page["manual_outputs"],
+        }
+        if not _is_missing(page.get("mmr_overrides")):
+            gui_page["mmr"] = page["mmr_overrides"]
+        if not _is_missing(page.get("barlines_review")):
+            gui_page["barlines"] = page["barlines_review"]
+        if not _is_missing(page.get("review_overlay")):
+            gui_page["review_overlay"] = page["review_overlay"]
+        pages.append(gui_page)
+
+    return {
+        "schema_version": 1,
+        "source": "manual_correction_input",
+        "pages": pages,
+    }
+
+
+def write_manual_gui_config(
+    handoff_path: str | Path,
+    output_path: str | Path,
+    *,
+    mode: HandoffMode = "base_v1",
+    require_existing_artifacts: bool = False,
+    overwrite: bool = False,
+) -> Dict[str, Any]:
+    """Load a handoff file, write a GUI config, and return the config."""
+
+    output = Path(output_path)
+    if output.exists() and not overwrite:
+        raise FileExistsError(f"Refusing to overwrite existing GUI config: {output}")
+    config = build_manual_gui_config(
+        load_manual_correction_handoff(handoff_path),
+        handoff_path=handoff_path,
+        mode=mode,
+        require_existing_artifacts=require_existing_artifacts,
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(config, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return config
+
+
+def _read_json_object_if_exists(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    with path.open(encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if not isinstance(payload, dict):
+        raise ManualCorrectionHandoffError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _write_json_object(path: Path, payload: Dict[str, Any], *, overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"Refusing to overwrite existing correction file: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def canonicalize_manual_correction_outputs(
+    corrections_dir: str | Path,
+    *,
+    overwrite: bool = False,
+) -> Dict[str, Path]:
+    """Convert GUI staging correction files into pipeline canonical override files.
+
+    The current manual GUI writes one file per correction surface. The pipeline
+    consumes canonical ``measure_overrides.json`` and ``barline_overrides.json``
+    payloads. This helper keeps that conversion outside the production run path
+    and refuses to overwrite user-edited canonical files unless explicitly asked.
+    """
+
+    root = Path(corrections_dir)
+    measure_output = root / "measure_overrides.json"
+    barline_output = root / "barline_overrides.json"
+
+    existing_outputs = [path for path in (measure_output, barline_output) if path.exists()]
+    if existing_outputs and not overwrite:
+        paths = ", ".join(str(path) for path in existing_outputs)
+        raise FileExistsError(f"Refusing to overwrite existing correction file(s): {paths}")
+
+    mmr_measure_span = _read_json_object_if_exists(
+        root / STAGING_TO_CANONICAL_FILENAMES["mmr_measure_span"]
+    )
+    measure_construction = _read_json_object_if_exists(
+        root / STAGING_TO_CANONICAL_FILENAMES["measure_construction"]
+    )
+    barline_construction = _read_json_object_if_exists(
+        root / STAGING_TO_CANONICAL_FILENAMES["barline_construction"]
+    )
+
+    measure_payload = merge_measure_overrides(measure_construction, mmr_measure_span)
+    barline_payload = merge_barline_overrides(barline_construction)
+
+    _write_json_object(measure_output, measure_payload, overwrite=overwrite)
+    _write_json_object(barline_output, barline_payload, overwrite=overwrite)
+    return {
+        "measure_overrides": measure_output,
+        "barline_overrides": barline_output,
+    }

--- a/src/pipeline/review/manual_correction_handoff.py
+++ b/src/pipeline/review/manual_correction_handoff.py
@@ -344,6 +344,10 @@ def canonicalize_manual_correction_outputs(
     """
 
     root = Path(corrections_dir)
+    if not root.is_dir():
+        raise FileNotFoundError(
+            f"Corrections directory does not exist or is not a directory: {root}"
+        )
     measure_output = root / "measure_overrides.json"
     barline_output = root / "barline_overrides.json"
 

--- a/src/pipeline/review/manual_correction_handoff.py
+++ b/src/pipeline/review/manual_correction_handoff.py
@@ -46,7 +46,9 @@ def load_manual_correction_handoff(path: str | Path) -> Dict[str, Any]:
     with handoff_path.open(encoding="utf-8") as fh:
         payload = json.load(fh)
     if not isinstance(payload, dict):
-        raise ManualCorrectionHandoffError("manual correction handoff must be a JSON object")
+        raise ManualCorrectionHandoffError(
+            "manual correction handoff must be a JSON object"
+        )
     return payload
 
 
@@ -58,7 +60,9 @@ def _as_page_number(value: Any, *, page_id: str) -> int:
     try:
         page_number = int(value)
     except (TypeError, ValueError) as exc:
-        raise ManualCorrectionHandoffError(f"{page_id}: page_number must be an integer") from exc
+        raise ManualCorrectionHandoffError(
+            f"{page_id}: page_number must be an integer"
+        ) from exc
     if page_number < 1:
         raise ManualCorrectionHandoffError(f"{page_id}: page_number must be >= 1")
     return page_number
@@ -127,7 +131,9 @@ def _validate_existing_path(
     return resolved
 
 
-def _relative_for_gui(path: Optional[Path], *, package_root: Optional[Path]) -> Optional[str]:
+def _relative_for_gui(
+    path: Optional[Path], *, package_root: Optional[Path]
+) -> Optional[str]:
     if path is None:
         return None
     if package_root is not None:
@@ -148,7 +154,9 @@ def _manual_output_paths(
         output_paths: Dict[str, str] = {}
         for key in GUI_OUTPUT_KEYS:
             if key not in configured:
-                raise ManualCorrectionHandoffError(f"correction_outputs.{key} is required")
+                raise ManualCorrectionHandoffError(
+                    f"correction_outputs.{key} is required"
+                )
             resolved = _resolve_package_path(
                 configured[key],
                 package_root=package_root,
@@ -190,12 +198,16 @@ def validate_manual_correction_handoff(
     """
 
     if not isinstance(payload, dict):
-        raise ManualCorrectionHandoffError("manual correction handoff must be a JSON object")
+        raise ManualCorrectionHandoffError(
+            "manual correction handoff must be a JSON object"
+        )
     for field in _REQUIRED_TOP_LEVEL_FIELDS:
         if field not in payload:
             raise ManualCorrectionHandoffError(f"{field} is required")
     if mode not in {"base_v1", "issue229_smoke_strict"}:
-        raise ManualCorrectionHandoffError(f"unsupported handoff validation mode: {mode}")
+        raise ManualCorrectionHandoffError(
+            f"unsupported handoff validation mode: {mode}"
+        )
 
     pages = payload.get("pages")
     if not isinstance(pages, list) or not pages:
@@ -244,7 +256,9 @@ def validate_manual_correction_handoff(
                 require_exists=require_existing_artifacts,
             )
             if resolved is not None:
-                normalized_page[field] = _relative_for_gui(resolved, package_root=package_root)
+                normalized_page[field] = _relative_for_gui(
+                    resolved, package_root=package_root
+                )
 
         normalized_page["manual_outputs"] = _manual_output_paths(
             page, package_root=package_root
@@ -357,10 +371,14 @@ def canonicalize_manual_correction_outputs(
     measure_output = root / "measure_overrides.json"
     barline_output = root / "barline_overrides.json"
 
-    existing_outputs = [path for path in (measure_output, barline_output) if path.exists()]
+    existing_outputs = [
+        path for path in (measure_output, barline_output) if path.exists()
+    ]
     if existing_outputs and not overwrite:
         paths = ", ".join(str(path) for path in existing_outputs)
-        raise FileExistsError(f"Refusing to overwrite existing correction file(s): {paths}")
+        raise FileExistsError(
+            f"Refusing to overwrite existing correction file(s): {paths}"
+        )
 
     mmr_measure_span = _read_json_object_if_exists(
         root / STAGING_TO_CANONICAL_FILENAMES["mmr_measure_span"]

--- a/src/pipeline/review/manual_correction_handoff.py
+++ b/src/pipeline/review/manual_correction_handoff.py
@@ -46,9 +46,7 @@ def load_manual_correction_handoff(path: str | Path) -> Dict[str, Any]:
     with handoff_path.open(encoding="utf-8") as fh:
         payload = json.load(fh)
     if not isinstance(payload, dict):
-        raise ManualCorrectionHandoffError(
-            "manual correction handoff must be a JSON object"
-        )
+        raise ManualCorrectionHandoffError("manual correction handoff must be a JSON object")
     return payload
 
 
@@ -60,9 +58,7 @@ def _as_page_number(value: Any, *, page_id: str) -> int:
     try:
         page_number = int(value)
     except (TypeError, ValueError) as exc:
-        raise ManualCorrectionHandoffError(
-            f"{page_id}: page_number must be an integer"
-        ) from exc
+        raise ManualCorrectionHandoffError(f"{page_id}: page_number must be an integer") from exc
     if page_number < 1:
         raise ManualCorrectionHandoffError(f"{page_id}: page_number must be >= 1")
     return page_number
@@ -91,9 +87,7 @@ def _resolve_package_path(
     candidate = Path(raw_path)
     if package_root is None:
         if candidate.is_absolute() or ".." in candidate.parts:
-            raise ManualCorrectionHandoffError(
-                f"{field} must stay inside the review package"
-            )
+            raise ManualCorrectionHandoffError(f"{field} must stay inside the review package")
         return candidate
 
     resolved = candidate if candidate.is_absolute() else package_root / candidate
@@ -131,9 +125,7 @@ def _validate_existing_path(
     return resolved
 
 
-def _relative_for_gui(
-    path: Optional[Path], *, package_root: Optional[Path]
-) -> Optional[str]:
+def _relative_for_gui(path: Optional[Path], *, package_root: Optional[Path]) -> Optional[str]:
     if path is None:
         return None
     if package_root is not None:
@@ -144,9 +136,7 @@ def _relative_for_gui(
     return path.as_posix()
 
 
-def _manual_output_paths(
-    page: Dict[str, Any], *, package_root: Optional[Path]
-) -> Dict[str, str]:
+def _manual_output_paths(page: Dict[str, Any], *, package_root: Optional[Path]) -> Dict[str, str]:
     configured = page.get("correction_outputs")
     if configured is not None:
         if not isinstance(configured, dict):
@@ -154,9 +144,7 @@ def _manual_output_paths(
         output_paths: Dict[str, str] = {}
         for key in GUI_OUTPUT_KEYS:
             if key not in configured:
-                raise ManualCorrectionHandoffError(
-                    f"correction_outputs.{key} is required"
-                )
+                raise ManualCorrectionHandoffError(f"correction_outputs.{key} is required")
             resolved = _resolve_package_path(
                 configured[key],
                 package_root=package_root,
@@ -198,16 +186,12 @@ def validate_manual_correction_handoff(
     """
 
     if not isinstance(payload, dict):
-        raise ManualCorrectionHandoffError(
-            "manual correction handoff must be a JSON object"
-        )
+        raise ManualCorrectionHandoffError("manual correction handoff must be a JSON object")
     for field in _REQUIRED_TOP_LEVEL_FIELDS:
         if field not in payload:
             raise ManualCorrectionHandoffError(f"{field} is required")
     if mode not in {"base_v1", "issue229_smoke_strict"}:
-        raise ManualCorrectionHandoffError(
-            f"unsupported handoff validation mode: {mode}"
-        )
+        raise ManualCorrectionHandoffError(f"unsupported handoff validation mode: {mode}")
 
     pages = payload.get("pages")
     if not isinstance(pages, list) or not pages:
@@ -256,13 +240,9 @@ def validate_manual_correction_handoff(
                 require_exists=require_existing_artifacts,
             )
             if resolved is not None:
-                normalized_page[field] = _relative_for_gui(
-                    resolved, package_root=package_root
-                )
+                normalized_page[field] = _relative_for_gui(resolved, package_root=package_root)
 
-        normalized_page["manual_outputs"] = _manual_output_paths(
-            page, package_root=package_root
-        )
+        normalized_page["manual_outputs"] = _manual_output_paths(page, package_root=package_root)
         normalized_pages.append(normalized_page)
 
     normalized["pages"] = normalized_pages
@@ -329,9 +309,7 @@ def write_manual_gui_config(
         require_existing_artifacts=require_existing_artifacts,
     )
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(
-        json.dumps(config, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
-    )
+    output.write_text(json.dumps(config, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     return config
 
 
@@ -349,9 +327,7 @@ def _write_json_object(path: Path, payload: Dict[str, Any], *, overwrite: bool) 
     if path.exists() and not overwrite:
         raise FileExistsError(f"Refusing to overwrite existing correction file: {path}")
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
-    )
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
 def canonicalize_manual_correction_outputs(
@@ -371,14 +347,10 @@ def canonicalize_manual_correction_outputs(
     measure_output = root / "measure_overrides.json"
     barline_output = root / "barline_overrides.json"
 
-    existing_outputs = [
-        path for path in (measure_output, barline_output) if path.exists()
-    ]
+    existing_outputs = [path for path in (measure_output, barline_output) if path.exists()]
     if existing_outputs and not overwrite:
         paths = ", ".join(str(path) for path in existing_outputs)
-        raise FileExistsError(
-            f"Refusing to overwrite existing correction file(s): {paths}"
-        )
+        raise FileExistsError(f"Refusing to overwrite existing correction file(s): {paths}")
 
     mmr_measure_span = _read_json_object_if_exists(
         root / STAGING_TO_CANONICAL_FILENAMES["mmr_measure_span"]

--- a/src/pipeline/review/manual_correction_materializer.py
+++ b/src/pipeline/review/manual_correction_materializer.py
@@ -29,6 +29,16 @@ def _load_json_object(path: Path, *, description: str) -> dict[str, Any]:
     return payload
 
 
+def _load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
 def _require_inside(path: Path, *, root: Path, description: str) -> Path:
     resolved = path.resolve()
     try:
@@ -112,6 +122,10 @@ def _select_pages(
         page_id = page.get("page_id")
         if not isinstance(page_id, str) or not page_id:
             raise ManualCorrectionMaterializerError(f"manifest pages[{index}].page_id is required")
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", page_id):
+            raise ManualCorrectionMaterializerError(
+                f"manifest pages[{index}].page_id contains invalid characters: {page_id}"
+            )
         by_id[page_id] = page
 
     if requested_pages is None:
@@ -167,6 +181,22 @@ def _resolve_barlines_review_source(
         f"{', '.join(_BARLINES_MANIFEST_FIELDS)}; searched current-run page artifact: "
         f"{page_local}; follow-up PR should connect a stable page-local barlines_review.json "
         f"or manifest-resolved detector geometry artifact."
+    )
+
+
+def _extract_review_barline_records(payload: Any, *, source: Path) -> list[Any]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        if isinstance(payload.get("predictions"), list):
+            return payload["predictions"]
+        if isinstance(payload.get("boxes"), list):
+            return payload["boxes"]
+        raise ManualCorrectionMaterializerError(
+            f"barlines review source has no predictions or boxes list: {source}"
+        )
+    raise ManualCorrectionMaterializerError(
+        f"barlines review source must be a JSON list or object: {source}"
     )
 
 
@@ -250,7 +280,10 @@ def materialize_manual_correction_review_package(
         _copy_run_artifact(numbering_final, page_dir / "numbering_final.json")
         _copy_run_artifact(review_overlay, page_dir / "review_overlay.png")
         _copy_run_artifact(mmr_overrides, page_dir / "mmr_overrides.json")
-        _copy_run_artifact(barlines_source, page_dir / "barlines_review.json")
+        _write_json(
+            page_dir / "barlines_review.json",
+            _extract_review_barline_records(_load_json(barlines_source), source=barlines_source),
+        )
 
         handoff_pages.append(
             {

--- a/src/pipeline/review/manual_correction_materializer.py
+++ b/src/pipeline/review/manual_correction_materializer.py
@@ -1,0 +1,287 @@
+"""Materialize manual-correction review packages from pipeline run artifacts."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+class ManualCorrectionMaterializerError(ValueError):
+    """Raised when a review package cannot be built from a pipeline run."""
+
+
+_BARLINES_MANIFEST_FIELDS = (
+    "barlines_json",
+    "resolved_barlines_json",
+    "barlines_review",
+    "barlines_corrected",
+)
+
+
+def _load_json_object(path: Path, *, description: str) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if not isinstance(payload, dict):
+        raise ManualCorrectionMaterializerError(f"{description} must be a JSON object: {path}")
+    return payload
+
+
+def _require_inside(path: Path, *, root: Path, description: str) -> Path:
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ManualCorrectionMaterializerError(
+            f"{description} must stay inside current pipeline run root: {path} (run root: {root})"
+        ) from exc
+    return resolved
+
+
+def _resolve_run_artifact(
+    raw_path: Any,
+    *,
+    run_root: Path,
+    page_id: str,
+    manifest_path: Path,
+    field: str,
+) -> Path:
+    if not isinstance(raw_path, str) or not raw_path:
+        raise ManualCorrectionMaterializerError(
+            f"{page_id}: manifest field {field} must be a non-empty artifact path "
+            f"(run root: {run_root}, manifest: {manifest_path})"
+        )
+
+    raw = Path(raw_path)
+    candidates = [raw] if raw.is_absolute() else [run_root / raw]
+    if not raw.is_absolute() and run_root.name in raw.parts:
+        run_root_index = len(raw.parts) - 1 - raw.parts[::-1].index(run_root.name)
+        candidates.append(run_root.joinpath(*raw.parts[run_root_index + 1 :]))
+    if not raw.is_absolute():
+        candidates.append(raw)
+    checked: list[str] = []
+    inside_candidates: list[Path] = []
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        checked.append(str(candidate))
+        try:
+            resolved.relative_to(run_root)
+        except ValueError:
+            continue
+        inside_candidates.append(resolved)
+        if resolved.exists():
+            return resolved
+
+    if inside_candidates:
+        raise ManualCorrectionMaterializerError(
+            f"{page_id}: manifest field {field} points inside the current run but does not exist: "
+            f"{raw_path} (run root: {run_root}, manifest: {manifest_path})"
+        )
+    raise ManualCorrectionMaterializerError(
+        f"{page_id}: manifest field {field} points outside the current pipeline run: {raw_path} "
+        f"(run root: {run_root}, manifest: {manifest_path}, checked: {checked})"
+    )
+
+
+def _page_number_from_manifest(page: dict[str, Any], *, page_id: str) -> int:
+    status = page.get("status")
+    if isinstance(status, dict):
+        page_index = status.get("page_index")
+        if isinstance(page_index, int) and page_index >= 1:
+            return page_index
+
+    match = re.search(r"(\d+)$", page_id)
+    if match:
+        return int(match.group(1))
+    raise ManualCorrectionMaterializerError(f"{page_id}: cannot determine one-based page number")
+
+
+def _select_pages(
+    manifest: dict[str, Any], requested_pages: list[str] | None
+) -> list[dict[str, Any]]:
+    manifest_pages = manifest.get("pages")
+    if not isinstance(manifest_pages, list) or not manifest_pages:
+        raise ManualCorrectionMaterializerError("manifest pages must be a non-empty list")
+
+    by_id: dict[str, dict[str, Any]] = {}
+    for index, page in enumerate(manifest_pages):
+        if not isinstance(page, dict):
+            raise ManualCorrectionMaterializerError(f"manifest pages[{index}] must be an object")
+        page_id = page.get("page_id")
+        if not isinstance(page_id, str) or not page_id:
+            raise ManualCorrectionMaterializerError(f"manifest pages[{index}].page_id is required")
+        by_id[page_id] = page
+
+    if requested_pages is None:
+        return list(by_id.values())
+
+    selected = []
+    for page_id in requested_pages:
+        if page_id not in by_id:
+            raise ManualCorrectionMaterializerError(f"page not found in manifest: {page_id}")
+        selected.append(by_id[page_id])
+    return selected
+
+
+def _copy_run_artifact(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+
+
+def _resolve_barlines_review_source(
+    page: dict[str, Any],
+    *,
+    run_root: Path,
+    page_id: str,
+    manifest_path: Path,
+) -> tuple[Path, str, str]:
+    for field in _BARLINES_MANIFEST_FIELDS:
+        if field in page and page[field]:
+            source = _resolve_run_artifact(
+                page[field],
+                run_root=run_root,
+                page_id=page_id,
+                manifest_path=manifest_path,
+                field=field,
+            )
+            source_kind = (
+                "manifest_resolved_detector_output"
+                if field == "barlines_json"
+                else f"manifest_{field}"
+            )
+            return source, source_kind, field
+
+    page_local = run_root / "intermediate" / page_id / "barlines_corrected.json"
+    if page_local.exists():
+        return (
+            page_local.resolve(),
+            "current_run_page_artifact",
+            "intermediate/page_id/barlines_corrected.json",
+        )
+
+    raise ManualCorrectionMaterializerError(
+        f"{page_id}: cannot materialize barlines_review.json from current run. "
+        f"run root: {run_root}; manifest: {manifest_path}; searched manifest fields: "
+        f"{', '.join(_BARLINES_MANIFEST_FIELDS)}; searched current-run page artifact: "
+        f"{page_local}; follow-up PR should connect a stable page-local barlines_review.json "
+        f"or manifest-resolved detector geometry artifact."
+    )
+
+
+def materialize_manual_correction_review_package(
+    *,
+    run_root: str | Path,
+    review_root: str | Path,
+    pages: list[str] | None = None,
+    source_pipeline_command: str | None = None,
+    overwrite: bool = True,
+) -> dict[str, Any]:
+    """Create a review manual-correction package from one pipeline run.
+
+    The materializer only consumes artifacts inside ``run_root`` and manifest
+    paths resolved from that same run. It intentionally does not search global
+    ``logs/`` directories or fall back to older run artifacts.
+    """
+
+    run_root_path = Path(run_root).resolve()
+    review_root_path = Path(review_root).resolve()
+    manifest_path = run_root_path / "manifest.json"
+    if not manifest_path.exists():
+        raise ManualCorrectionMaterializerError(f"manifest does not exist: {manifest_path}")
+    if review_root_path.exists() and any(review_root_path.iterdir()) and not overwrite:
+        raise FileExistsError(f"Refusing to overwrite existing review package: {review_root_path}")
+
+    manifest = _load_json_object(manifest_path, description="pipeline manifest")
+    selected_pages = _select_pages(manifest, pages)
+
+    handoff_pages: list[dict[str, Any]] = []
+    for page in selected_pages:
+        page_id = str(page["page_id"])
+        page_number = _page_number_from_manifest(page, page_id=page_id)
+
+        image_source = _resolve_run_artifact(
+            page.get("image_path"),
+            run_root=run_root_path,
+            page_id=page_id,
+            manifest_path=manifest_path,
+            field="image_path",
+        )
+        numbering_final = _require_inside(
+            run_root_path / "outputs" / page_id / "numbering_final.json",
+            root=run_root_path,
+            description=f"{page_id}.numbering_final",
+        )
+        review_overlay = _require_inside(
+            run_root_path / "outputs" / page_id / "numbering_overlay.png",
+            root=run_root_path,
+            description=f"{page_id}.review_overlay",
+        )
+        mmr_overrides = _require_inside(
+            run_root_path / "intermediate" / page_id / "overrides_mmr.json",
+            root=run_root_path,
+            description=f"{page_id}.mmr_overrides",
+        )
+        barlines_source, barlines_source_kind, barlines_source_field = (
+            _resolve_barlines_review_source(
+                page,
+                run_root=run_root_path,
+                page_id=page_id,
+                manifest_path=manifest_path,
+            )
+        )
+
+        required = {
+            "numbering_final": numbering_final,
+            "review_overlay": review_overlay,
+            "mmr_overrides": mmr_overrides,
+            "barlines_review source": barlines_source,
+        }
+        missing = [f"{label}: {path}" for label, path in required.items() if not path.exists()]
+        if missing:
+            raise ManualCorrectionMaterializerError(
+                f"{page_id}: required current-run artifact(s) missing; run root: {run_root_path}; "
+                f"manifest: {manifest_path}; " + "; ".join(missing)
+            )
+
+        page_dir = review_root_path / "pages" / page_id
+        _copy_run_artifact(image_source, page_dir / "source.png")
+        _copy_run_artifact(numbering_final, page_dir / "numbering_final.json")
+        _copy_run_artifact(review_overlay, page_dir / "review_overlay.png")
+        _copy_run_artifact(mmr_overrides, page_dir / "mmr_overrides.json")
+        _copy_run_artifact(barlines_source, page_dir / "barlines_review.json")
+
+        handoff_pages.append(
+            {
+                "page_id": page_id,
+                "page_number": page_number,
+                "source_image": f"pages/{page_id}/source.png",
+                "numbering_final": f"pages/{page_id}/numbering_final.json",
+                "review_overlay": f"pages/{page_id}/review_overlay.png",
+                "mmr_overrides": f"pages/{page_id}/mmr_overrides.json",
+                "barlines_review": f"pages/{page_id}/barlines_review.json",
+                "barlines_review_source": barlines_source.relative_to(run_root_path).as_posix(),
+                "barlines_review_source_kind": barlines_source_kind,
+                "barlines_review_source_manifest_field": barlines_source_field,
+                "correction_output": "corrections",
+            }
+        )
+
+    (review_root_path / "corrections").mkdir(parents=True, exist_ok=True)
+    handoff = {
+        "schema_version": 1,
+        "kind": "manual_correction_input",
+        "source_artifact_root": str(run_root_path),
+        "source_manifest": "manifest.json",
+        "pages": handoff_pages,
+    }
+    if source_pipeline_command:
+        handoff["source_pipeline_command"] = source_pipeline_command
+
+    handoff_path = review_root_path / "manual_correction_input.json"
+    handoff_path.parent.mkdir(parents=True, exist_ok=True)
+    handoff_path.write_text(
+        json.dumps(handoff, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return handoff

--- a/tests/test_manual_correction_handoff.py
+++ b/tests/test_manual_correction_handoff.py
@@ -156,7 +156,7 @@ def test_canonicalize_manual_correction_outputs_writes_pipeline_payloads(tmp_pat
                     "op": "force_measure",
                     "page": 2,
                     "system": 1,
-                    "interval": 5,
+                    "interval": 4,
                     "reason": "manual measure construction",
                 }
             ],
@@ -206,7 +206,7 @@ def test_canonicalize_manual_correction_outputs_writes_pipeline_payloads(tmp_pat
         {
             "page": 2,
             "system": 1,
-            "measure": 5,
+            "measure": 4,
             "force_measure": True,
             "comment": "manual measure construction",
             "source": "manual:measure_construction",

--- a/tests/test_manual_correction_handoff.py
+++ b/tests/test_manual_correction_handoff.py
@@ -245,6 +245,13 @@ def test_canonicalize_refuses_to_overwrite_existing_outputs(tmp_path):
         canonicalize_manual_correction_outputs(corrections)
 
 
+def test_canonicalize_requires_existing_corrections_directory(tmp_path):
+    missing = tmp_path / "missing_corrections"
+
+    with pytest.raises(FileNotFoundError, match="Corrections directory"):
+        canonicalize_manual_correction_outputs(missing)
+
+
 def test_canonicalize_allows_explicit_overwrite(tmp_path):
     corrections = tmp_path / "review" / "corrections"
     _write_json(corrections / "mmr_measure_spans.json", {"correction_type": "mmr_measure_span"})

--- a/tests/test_manual_correction_handoff.py
+++ b/tests/test_manual_correction_handoff.py
@@ -1,0 +1,257 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.pipeline.review.manual_correction_handoff import (
+    ManualCorrectionHandoffError,
+    build_manual_gui_config,
+    canonicalize_manual_correction_outputs,
+    validate_manual_correction_handoff,
+)
+
+
+def _write_json(path: Path, payload: dict | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload or {}, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str = "placeholder") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _review_package(tmp_path: Path, *, include_strict: bool = True) -> tuple[Path, dict]:
+    review_root = tmp_path / "output" / "review"
+    page_root = review_root / "pages" / "page_003"
+    _write_text(page_root / "source.png")
+    _write_json(page_root / "numbering_final.json")
+    if include_strict:
+        _write_text(page_root / "review_overlay.png")
+        _write_json(page_root / "mmr_overrides.json")
+        _write_json(page_root / "barlines_review.json")
+
+    page = {
+        "page_id": "page_003",
+        "page_number": 3,
+        "source_image": "pages/page_003/source.png",
+        "numbering_final": "pages/page_003/numbering_final.json",
+        "correction_output": "corrections",
+    }
+    if include_strict:
+        page.update(
+            {
+                "review_overlay": "pages/page_003/review_overlay.png",
+                "mmr_overrides": "pages/page_003/mmr_overrides.json",
+                "barlines_review": "pages/page_003/barlines_review.json",
+            }
+        )
+
+    handoff = {
+        "schema_version": 1,
+        "kind": "manual_correction_input",
+        "pages": [page],
+    }
+    handoff_path = review_root / "manual_correction_input.json"
+    _write_json(handoff_path, handoff)
+    return handoff_path, handoff
+
+
+def test_build_manual_gui_config_maps_handoff_to_current_gui_config(tmp_path):
+    handoff_path, handoff = _review_package(tmp_path)
+
+    config = build_manual_gui_config(
+        handoff,
+        handoff_path=handoff_path,
+        mode="issue229_smoke_strict",
+        require_existing_artifacts=True,
+    )
+
+    assert config["source"] == "manual_correction_input"
+    assert config["pages"] == [
+        {
+            "name": "page_003",
+            "page": 2,
+            "source_page_number": 3,
+            "image": "pages/page_003/source.png",
+            "numbering": "pages/page_003/numbering_final.json",
+            "manual_outputs": {
+                "mmr_measure_span": "corrections/mmr_measure_spans.json",
+                "measure_construction": "corrections/measure_construction_overrides.json",
+                "barline_construction": "corrections/barline_construction_overrides.json",
+            },
+            "mmr": "pages/page_003/mmr_overrides.json",
+            "barlines": "pages/page_003/barlines_review.json",
+            "review_overlay": "pages/page_003/review_overlay.png",
+        }
+    ]
+    assert "_staging" not in json.dumps(config)
+
+
+def test_handoff_base_mode_allows_missing_optional_review_evidence(tmp_path):
+    handoff_path, handoff = _review_package(tmp_path, include_strict=False)
+
+    normalized = validate_manual_correction_handoff(
+        handoff,
+        handoff_path=handoff_path,
+        mode="base_v1",
+        require_existing_artifacts=True,
+    )
+
+    assert normalized["pages"][0]["gui_page_index_zero_based"] == 2
+    assert "mmr_overrides" not in normalized["pages"][0]
+
+
+def test_handoff_strict_mode_requires_review_evidence(tmp_path):
+    handoff_path, handoff = _review_package(tmp_path, include_strict=False)
+
+    with pytest.raises(ManualCorrectionHandoffError, match="required in strict mode"):
+        validate_manual_correction_handoff(
+            handoff,
+            handoff_path=handoff_path,
+            mode="issue229_smoke_strict",
+        )
+
+
+def test_handoff_rejects_package_escape_paths(tmp_path):
+    handoff_path, handoff = _review_package(tmp_path)
+    handoff["pages"][0]["source_image"] = "../logs/unrelated/source.png"
+
+    with pytest.raises(ManualCorrectionHandoffError, match="inside the review package"):
+        validate_manual_correction_handoff(handoff, handoff_path=handoff_path)
+
+
+def test_handoff_rejects_non_positive_page_number(tmp_path):
+    handoff_path, handoff = _review_package(tmp_path)
+    handoff["pages"][0]["page_number"] = 0
+
+    with pytest.raises(ManualCorrectionHandoffError, match="page_number must be >= 1"):
+        validate_manual_correction_handoff(handoff, handoff_path=handoff_path)
+
+
+def test_handoff_uses_explicit_correction_outputs_without_staging_suffix(tmp_path):
+    handoff_path, handoff = _review_package(tmp_path)
+    handoff["pages"][0].pop("correction_output")
+    handoff["pages"][0]["correction_outputs"] = {
+        "mmr_measure_span": "corrections/custom_mmr.json",
+        "measure_construction": "corrections/custom_measure.json",
+        "barline_construction": "corrections/custom_barline.json",
+    }
+
+    config = build_manual_gui_config(handoff, handoff_path=handoff_path)
+
+    assert config["pages"][0]["manual_outputs"] == handoff["pages"][0]["correction_outputs"]
+    assert all("_staging" not in key for key in config["pages"][0]["manual_outputs"])
+
+
+def test_canonicalize_manual_correction_outputs_writes_pipeline_payloads(tmp_path):
+    corrections = tmp_path / "review" / "corrections"
+    _write_json(
+        corrections / "measure_construction_overrides.json",
+        {
+            "schema_version": 1,
+            "correction_type": "measure_construction",
+            "items": [
+                {
+                    "op": "force_measure",
+                    "page": 2,
+                    "system": 1,
+                    "interval": 5,
+                    "reason": "manual measure construction",
+                }
+            ],
+        },
+    )
+    _write_json(
+        corrections / "mmr_measure_spans.json",
+        {
+            "schema_version": 1,
+            "correction_type": "mmr_measure_span",
+            "items": [
+                {
+                    "op": "set_measure_span",
+                    "page": 2,
+                    "system": 1,
+                    "measure": 5,
+                    "measure_span": 4,
+                    "reason": "manual MMR span",
+                }
+            ],
+        },
+    )
+    _write_json(
+        corrections / "barline_construction_overrides.json",
+        {
+            "schema_version": 1,
+            "correction_type": "barline_construction",
+            "items": [
+                {
+                    "op": "add_barline",
+                    "page": 2,
+                    "bbox": [10, 20, 12, 100],
+                    "reason": "manual barline",
+                }
+            ],
+        },
+    )
+
+    outputs = canonicalize_manual_correction_outputs(corrections)
+
+    assert outputs == {
+        "measure_overrides": corrections / "measure_overrides.json",
+        "barline_overrides": corrections / "barline_overrides.json",
+    }
+    measure_payload = json.loads((corrections / "measure_overrides.json").read_text())
+    assert measure_payload["measure_overrides"] == [
+        {
+            "page": 2,
+            "system": 1,
+            "measure": 5,
+            "force_measure": True,
+            "comment": "manual measure construction",
+            "source": "manual:measure_construction",
+        },
+        {
+            "page": 2,
+            "system": 1,
+            "measure": 5,
+            "skip": 3,
+            "comment": "manual MMR span",
+            "source": "manual:mmr_measure_span",
+        },
+    ]
+    assert measure_payload["overrides"] == measure_payload["measure_overrides"]
+
+    barline_payload = json.loads((corrections / "barline_overrides.json").read_text())
+    assert barline_payload == {
+        "barline_overrides": [
+            {
+                "page": 2,
+                "op": "add",
+                "bbox": [10, 20, 12, 100],
+                "comment": "manual barline",
+                "source": "manual:barline_construction",
+            }
+        ]
+    }
+
+
+def test_canonicalize_refuses_to_overwrite_existing_outputs(tmp_path):
+    corrections = tmp_path / "review" / "corrections"
+    _write_json(corrections / "mmr_measure_spans.json", {"correction_type": "mmr_measure_span"})
+    _write_json(corrections / "measure_overrides.json", {"measure_overrides": []})
+
+    with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+        canonicalize_manual_correction_outputs(corrections)
+
+
+def test_canonicalize_allows_explicit_overwrite(tmp_path):
+    corrections = tmp_path / "review" / "corrections"
+    _write_json(corrections / "mmr_measure_spans.json", {"correction_type": "mmr_measure_span"})
+    _write_json(corrections / "measure_overrides.json", {"measure_overrides": []})
+    _write_json(corrections / "barline_overrides.json", {"barline_overrides": []})
+
+    outputs = canonicalize_manual_correction_outputs(corrections, overwrite=True)
+
+    assert outputs["measure_overrides"].exists()
+    assert outputs["barline_overrides"].exists()

--- a/tests/test_manual_correction_materializer.py
+++ b/tests/test_manual_correction_materializer.py
@@ -1,0 +1,140 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.pipeline.review.manual_correction_handoff import (
+    build_manual_gui_config,
+    validate_manual_correction_handoff,
+)
+from src.pipeline.review.manual_correction_materializer import (
+    ManualCorrectionMaterializerError,
+    materialize_manual_correction_review_package,
+)
+
+
+def _write_json(path: Path, payload: dict | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload or {}, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str = "placeholder") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _fake_run_root(tmp_path: Path, *, barlines_outside: Path | None = None) -> Path:
+    run_root = tmp_path / "source_run"
+    _write_text(run_root / "inputs" / "images" / "page_001.png")
+    _write_json(run_root / "outputs" / "page_001" / "numbering_final.json")
+    _write_text(run_root / "outputs" / "page_001" / "numbering_overlay.png")
+    _write_json(run_root / "intermediate" / "page_001" / "overrides_mmr.json")
+    detector_output = run_root / "intermediate" / "probe_scan" / "page_001" / "filtered.json"
+    _write_json(detector_output, {"boxes": [{"bbox": [1, 2, 3, 4]}]})
+
+    barlines_json = barlines_outside if barlines_outside is not None else detector_output
+    _write_json(
+        run_root / "manifest.json",
+        {
+            "run_id": "source_run",
+            "pages": [
+                {
+                    "page_id": "page_001",
+                    "image_path": str(run_root / "inputs" / "images" / "page_001.png"),
+                    "barlines_json": str(barlines_json),
+                    "status": {"page_index": 1},
+                }
+            ],
+        },
+    )
+    return run_root
+
+
+def test_materializes_review_package_from_manifest_resolved_barlines(tmp_path):
+    run_root = _fake_run_root(tmp_path)
+    review_root = tmp_path / "review"
+
+    handoff = materialize_manual_correction_review_package(
+        run_root=run_root,
+        review_root=review_root,
+        pages=["page_001"],
+        source_pipeline_command="make run-pipeline CONFIG=smoke.yaml",
+    )
+
+    page = handoff["pages"][0]
+    assert page["barlines_review"] == "pages/page_001/barlines_review.json"
+    assert page["barlines_review_source"] == "intermediate/probe_scan/page_001/filtered.json"
+    assert page["barlines_review_source_kind"] == "manifest_resolved_detector_output"
+    assert page["barlines_review_source_manifest_field"] == "barlines_json"
+
+    copied_barlines = json.loads(
+        (review_root / "pages" / "page_001" / "barlines_review.json").read_text()
+    )
+    assert copied_barlines == {"boxes": [{"bbox": [1, 2, 3, 4]}]}
+    assert (review_root / "corrections").is_dir()
+
+    handoff_on_disk = json.loads((review_root / "manual_correction_input.json").read_text())
+    assert handoff_on_disk["source_pipeline_command"] == "make run-pipeline CONFIG=smoke.yaml"
+    assert handoff_on_disk["pages"][0]["barlines_review_source"] == page["barlines_review_source"]
+
+
+def test_materialized_handoff_validates_and_builds_page_local_gui_config(tmp_path):
+    run_root = _fake_run_root(tmp_path)
+    review_root = tmp_path / "review"
+
+    materialize_manual_correction_review_package(run_root=run_root, review_root=review_root)
+    handoff_path = review_root / "manual_correction_input.json"
+    payload = json.loads(handoff_path.read_text())
+
+    validated = validate_manual_correction_handoff(
+        payload,
+        handoff_path=handoff_path,
+        mode="issue229_smoke_strict",
+        require_existing_artifacts=True,
+    )
+    config = build_manual_gui_config(
+        validated,
+        handoff_path=handoff_path,
+        mode="issue229_smoke_strict",
+        require_existing_artifacts=True,
+    )
+
+    assert config["pages"][0]["page"] == 0
+    assert config["pages"][0]["manual_outputs"] == {
+        "mmr_measure_span": "corrections/mmr_measure_spans.json",
+        "measure_construction": "corrections/measure_construction_overrides.json",
+        "barline_construction": "corrections/barline_construction_overrides.json",
+    }
+
+
+def test_materializer_errors_when_manifest_has_no_barlines_source(tmp_path):
+    run_root = _fake_run_root(tmp_path)
+    manifest_path = run_root / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["pages"][0].pop("barlines_json")
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ManualCorrectionMaterializerError) as exc_info:
+        materialize_manual_correction_review_package(
+            run_root=run_root,
+            review_root=tmp_path / "review",
+        )
+
+    message = str(exc_info.value)
+    assert "page_001" in message
+    assert str(run_root.resolve()) in message
+    assert str((run_root / "manifest.json").resolve()) in message
+    assert "barlines_json" in message
+    assert "barlines_review.json" in message
+
+
+def test_materializer_rejects_run_root_external_barlines_artifact(tmp_path):
+    outside = tmp_path / "old_run" / "filtered.json"
+    _write_json(outside, {"boxes": []})
+    run_root = _fake_run_root(tmp_path, barlines_outside=outside)
+
+    with pytest.raises(ManualCorrectionMaterializerError, match="outside the current pipeline run"):
+        materialize_manual_correction_review_package(
+            run_root=run_root,
+            review_root=tmp_path / "review",
+        )

--- a/tests/test_manual_correction_materializer.py
+++ b/tests/test_manual_correction_materializer.py
@@ -13,7 +13,7 @@ from src.pipeline.review.manual_correction_materializer import (
 )
 
 
-def _write_json(path: Path, payload: dict | None = None) -> None:
+def _write_json(path: Path, payload: object | None = None) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload or {}, indent=2) + "\n", encoding="utf-8")
 
@@ -23,14 +23,20 @@ def _write_text(path: Path, text: str = "placeholder") -> None:
     path.write_text(text, encoding="utf-8")
 
 
-def _fake_run_root(tmp_path: Path, *, barlines_outside: Path | None = None) -> Path:
+def _fake_run_root(
+    tmp_path: Path,
+    *,
+    barlines_outside: Path | None = None,
+    barlines_payload: object | None = None,
+    page_id: str = "page_001",
+) -> Path:
     run_root = tmp_path / "source_run"
-    _write_text(run_root / "inputs" / "images" / "page_001.png")
-    _write_json(run_root / "outputs" / "page_001" / "numbering_final.json")
-    _write_text(run_root / "outputs" / "page_001" / "numbering_overlay.png")
-    _write_json(run_root / "intermediate" / "page_001" / "overrides_mmr.json")
-    detector_output = run_root / "intermediate" / "probe_scan" / "page_001" / "filtered.json"
-    _write_json(detector_output, {"boxes": [{"bbox": [1, 2, 3, 4]}]})
+    _write_text(run_root / "inputs" / "images" / f"{page_id}.png")
+    _write_json(run_root / "outputs" / page_id / "numbering_final.json")
+    _write_text(run_root / "outputs" / page_id / "numbering_overlay.png")
+    _write_json(run_root / "intermediate" / page_id / "overrides_mmr.json")
+    detector_output = run_root / "intermediate" / "probe_scan" / page_id / "filtered.json"
+    _write_json(detector_output, barlines_payload or {"boxes": [{"bbox": [1, 2, 3, 4]}]})
 
     barlines_json = barlines_outside if barlines_outside is not None else detector_output
     _write_json(
@@ -39,8 +45,8 @@ def _fake_run_root(tmp_path: Path, *, barlines_outside: Path | None = None) -> P
             "run_id": "source_run",
             "pages": [
                 {
-                    "page_id": "page_001",
-                    "image_path": str(run_root / "inputs" / "images" / "page_001.png"),
+                    "page_id": page_id,
+                    "image_path": str(run_root / "inputs" / "images" / f"{page_id}.png"),
                     "barlines_json": str(barlines_json),
                     "status": {"page_index": 1},
                 }
@@ -70,7 +76,7 @@ def test_materializes_review_package_from_manifest_resolved_barlines(tmp_path):
     copied_barlines = json.loads(
         (review_root / "pages" / "page_001" / "barlines_review.json").read_text()
     )
-    assert copied_barlines == {"boxes": [{"bbox": [1, 2, 3, 4]}]}
+    assert copied_barlines == [{"bbox": [1, 2, 3, 4]}]
     assert (review_root / "corrections").is_dir()
 
     handoff_on_disk = json.loads((review_root / "manual_correction_input.json").read_text())
@@ -126,6 +132,61 @@ def test_materializer_errors_when_manifest_has_no_barlines_source(tmp_path):
     assert str((run_root / "manifest.json").resolve()) in message
     assert "barlines_json" in message
     assert "barlines_review.json" in message
+
+
+def test_materializer_normalizes_predictions_barlines_source(tmp_path):
+    run_root = _fake_run_root(
+        tmp_path,
+        barlines_payload={"predictions": [{"bbox": [1, 2, 3, 4]}]},
+    )
+    review_root = tmp_path / "review"
+
+    materialize_manual_correction_review_package(run_root=run_root, review_root=review_root)
+
+    copied_barlines = json.loads(
+        (review_root / "pages" / "page_001" / "barlines_review.json").read_text()
+    )
+    assert copied_barlines == [{"bbox": [1, 2, 3, 4]}]
+
+
+def test_materializer_preserves_top_level_list_barlines_source(tmp_path):
+    run_root = _fake_run_root(tmp_path, barlines_payload=[{"bbox": [1, 2, 3, 4]}])
+    review_root = tmp_path / "review"
+
+    materialize_manual_correction_review_package(run_root=run_root, review_root=review_root)
+
+    copied_barlines = json.loads(
+        (review_root / "pages" / "page_001" / "barlines_review.json").read_text()
+    )
+    assert copied_barlines == [{"bbox": [1, 2, 3, 4]}]
+
+
+def test_materializer_errors_when_barlines_source_has_no_records(tmp_path):
+    run_root = _fake_run_root(tmp_path, barlines_payload={"metadata": {}})
+
+    with pytest.raises(ManualCorrectionMaterializerError, match="no predictions or boxes list"):
+        materialize_manual_correction_review_package(
+            run_root=run_root,
+            review_root=tmp_path / "review",
+        )
+
+
+def test_materializer_rejects_invalid_page_id(tmp_path):
+    run_root = _fake_run_root(tmp_path)
+    manifest_path = run_root / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["pages"][0]["page_id"] = "../page_001"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ManualCorrectionMaterializerError) as exc_info:
+        materialize_manual_correction_review_package(
+            run_root=run_root,
+            review_root=tmp_path / "review",
+        )
+
+    message = str(exc_info.value)
+    assert "page_id" in message
+    assert "invalid characters" in message
 
 
 def test_materializer_rejects_run_root_external_barlines_artifact(tmp_path):

--- a/tests/test_manual_gui_server.py
+++ b/tests/test_manual_gui_server.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+from tools.gt_relabel_gui.server import _manual_output_for, _page_config_for
+
+
+def test_manual_output_for_uses_page_local_manual_outputs_by_page_index():
+    server = SimpleNamespace(
+        gt_config=[
+            {
+                "name": "page_001",
+                "page": 0,
+                "manual_outputs": {
+                    "mmr_measure_span": "pages/page_001/corrections/mmr.json",
+                },
+            },
+            {
+                "name": "page_003",
+                "page": 2,
+                "manual_outputs": {
+                    "mmr_measure_span": "corrections/mmr_measure_spans.json",
+                    "barline_construction": "corrections/barline_construction_overrides.json",
+                },
+            },
+        ]
+    )
+
+    assert _page_config_for(server, 2)["name"] == "page_003"
+    assert _manual_output_for(server, "mmr_measure_span", 2) == "corrections/mmr_measure_spans.json"
+    assert (
+        _manual_output_for(server, "barline_construction", "2")
+        == "corrections/barline_construction_overrides.json"
+    )
+
+
+def test_manual_output_for_matches_page_name_and_rejects_missing_outputs():
+    server = SimpleNamespace(
+        gt_config=[
+            {"name": "page_003", "page_index": 2},
+            {
+                "name": "page_004",
+                "page_index": 3,
+                "manual_outputs": {
+                    "measure_construction": "corrections/measure_construction_overrides.json",
+                },
+            },
+        ]
+    )
+
+    assert _page_config_for(server, "page_004")["page_index"] == 3
+    assert (
+        _manual_output_for(server, "measure_construction", "page_004")
+        == "corrections/measure_construction_overrides.json"
+    )
+    assert _manual_output_for(server, "measure_construction", "page_003") is None
+    assert _manual_output_for(server, "mmr_measure_span", "page_004") is None
+    assert _manual_output_for(server, "mmr_measure_span", "missing") is None

--- a/tools/gt_relabel_gui/app_manual.js
+++ b/tools/gt_relabel_gui/app_manual.js
@@ -494,9 +494,12 @@ function deleteSelectedItem() {
 
 function loadCorrections() {
   const types = Object.keys(correctionsByType);
+  const page = pageValue();
   return Promise.all(
     types.map((type) =>
-      fetchJSON(`/api/manual_corrections?type=${encodeURIComponent(type)}`)
+      fetchJSON(
+        `/api/manual_corrections?type=${encodeURIComponent(type)}&page=${encodeURIComponent(page)}`
+      )
         .then((data) => {
           correctionsByType[type] = Array.isArray(data.items) ? data.items : [];
         })

--- a/tools/gt_relabel_gui/server.py
+++ b/tools/gt_relabel_gui/server.py
@@ -16,12 +16,6 @@ from urllib.parse import parse_qs, urlparse
 REPO_ROOT = Path(__file__).resolve().parents[2]
 Box = tuple[int, int, int, int]
 
-MANUAL_CORRECTION_OUTPUTS = {
-    "mmr_measure_span": "data/evaluation2/manual_corrections/mmr_measure_spans.json",
-    "barline_construction": "data/evaluation2/manual_corrections/barline_construction_overrides.json",
-    "measure_construction": "data/evaluation2/manual_corrections/measure_construction_overrides.json",
-}
-
 
 @dataclass
 class Item:
@@ -182,8 +176,23 @@ def parse_payload_boxes(payload: list) -> list[dict]:
     return boxes
 
 
-def _manual_output_for(server, correction_type: str) -> str | None:
-    outputs = getattr(server, "manual_outputs", MANUAL_CORRECTION_OUTPUTS)
+def _page_config_for(server, page) -> dict | None:
+    for config in getattr(server, "gt_config", []):
+        if not isinstance(config, dict):
+            continue
+        for key in ("page", "page_index", "name"):
+            if key in config and str(config.get(key)) == str(page):
+                return config
+    return None
+
+
+def _manual_output_for(server, correction_type: str, page) -> str | None:
+    config = _page_config_for(server, page)
+    if not config:
+        return None
+    outputs = config.get("manual_outputs")
+    if not isinstance(outputs, dict):
+        return None
     value = outputs.get(correction_type)
     return str(value) if value else None
 
@@ -239,19 +248,21 @@ class Handler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/api/pages" and self.server.mode in {"gt", "rest", "manual"}:
             payload = {"pages": self.server.gt_config}
-            if self.server.mode == "manual":
-                payload["manual_outputs"] = self.server.manual_outputs
             self._serve_json(payload)
             return
         if parsed.path == "/api/manual_corrections" and self.server.mode == "manual":
             qs = parse_qs(parsed.query)
             correction_type = qs.get("type", [None])[0]
+            page = qs.get("page", [None])[0]
             if not correction_type:
                 self.send_error(400, "Missing correction type")
                 return
-            output_rel = _manual_output_for(self.server, correction_type)
+            if page is None:
+                self.send_error(400, "Missing page")
+                return
+            output_rel = _manual_output_for(self.server, correction_type, page)
             if not output_rel:
-                self.send_error(400, "Unknown correction type")
+                self.send_error(400, "Unknown page or correction type")
                 return
             try:
                 output_path = safe_path(self.server.root, output_rel)
@@ -382,9 +393,9 @@ class Handler(BaseHTTPRequestHandler):
             if not isinstance(correction_type, str):
                 self.send_error(400, "Missing correction_type")
                 return
-            output_rel = _manual_output_for(self.server, correction_type)
+            output_rel = _manual_output_for(self.server, correction_type, page)
             if not output_rel:
-                self.send_error(400, "Unknown correction_type")
+                self.send_error(400, "Unknown page or correction_type")
                 return
 
             output_path = safe_path(self.server.root, output_rel)
@@ -474,10 +485,6 @@ def main() -> None:
         server.root = (args.root or REPO_ROOT).resolve()
         config_data = json.loads(args.config.read_text())
         server.gt_config = config_data.get("pages", config_data)
-        server.manual_outputs = {
-            **MANUAL_CORRECTION_OUTPUTS,
-            **config_data.get("manual_outputs", {}),
-        }
     else:
         if not args.root:
             raise SystemExit("--root is required in relabel mode")


### PR DESCRIPTION
## Summary

Refs #236.

This PR implements the first review-package boundary for the manual correction workflow under #225/#236. It does **not** close #236.

Included changes:

- Add `src/pipeline/review/manual_correction_handoff.py`.
  - Validates `review/manual_correction_input.json`.
  - Builds the current manual GUI config from the handoff.
  - Converts GUI staging correction files into canonical pipeline override files.
- Add `src/pipeline/review/manual_correction_materializer.py`.
  - Builds a manual-correction review package from one current pipeline run.
  - Reads the run `manifest.json` deterministically.
  - Materializes `barlines_review.json` from manifest-resolved barline geometry.
  - Rejects artifacts outside the current run root.
- Update manual GUI routing.
  - Treats page-local `manual_outputs` as the canonical design.
  - Removes the need for a server-specific top-level `manual_outputs` config.
  - Requires page-aware manual correction load/save routing.
- Add focused tests for the handoff, materializer, and GUI server routing.

## Scope / non-goals

This PR is the first implementation slice for #236. It intentionally does not wire the review package generation into the production pipeline entrypoint yet.

Still left for later PRs:

- Orchestrator / review-profile integration that emits `review/manual_correction_input.json` during normal runs.
- Corrected rerun path using saved canonical overrides.
- Corrected final PDF regeneration.
- #215 GUI smoke retry through the intended user-facing workflow.
- Full regression gates for #221 MMR, #120/#137 detector/barline behavior, and #206 guard cases.

## Validation

Targeted checks:

```text
make lint
# All checks passed!
# 378 files already formatted

PYTHONPATH=. python3 -m pytest \
  tests/test_manual_corrections.py \
  tests/test_manual_correction_handoff.py \
  tests/test_manual_gui_server.py \
  tests/test_manual_correction_materializer.py
# 26 passed in 0.09s
```

Fresh current-pipeline smoke:

- Smoke root: `logs/issue236_current_pipeline_handoff_smoke/`
- Source PDF: `data/evaluation2/pdfs/Va_Prokofiev_Symphony1.pdf`
- Command:

```text
make run-pipeline CONFIG=logs/issue236_current_pipeline_handoff_smoke/current_pipeline_smoke.yaml LOG_FILE=logs/issue236_current_pipeline_handoff_smoke/pipeline_command.log
```

This smoke was a fresh one-page PDF-based current-pipeline run, not a full-score/full-page regression.

Evidence recorded in local `SMOKE_REPORT.md`:

- `source_run`, `review`, GUI config, and pipeline log were removed before running.
- Pipeline log confirms PDF rendering into `source_run/inputs/images`.
- Manifest records `pages[0].barlines_json` under the same `source_run`.
- The new materializer created `review/manual_correction_input.json` and page-local review artifacts.
- Strict handoff validation passed.
- Helper-generated `manual_gui_config.json` worked directly with the manual GUI server.
- GUI/API load/save passed for source image, numbering, MMR, barlines, MMR correction, barline correction, and measure-construction correction.
- Canonicalization produced `measure_overrides.json` and `barline_overrides.json`.

## Notes

The current pipeline does not yet emit a stable page-local `intermediate/<page_id>/barlines_corrected.json` or direct review artifact during normal runs. This PR solves the review-package boundary by materializing `barlines_review.json` from the current run manifest, without arbitrary `logs/` search or old-artifact fallback.

Later PRs should connect this materializer from the orchestrator/review profile and then run the broader regression suite.