### PR TITLE
Wire config-first manual correction review package output

### DIFF
--- a/configs/review_manual_correction_package_example.yaml
+++ b/configs/review_manual_correction_package_example.yaml
@@ -1,0 +1,10 @@
+# Example fragment for enabling config-first manual correction review packages.
+# Merge this under a normal pipeline config that already defines run, inputs,
+# steps, detection, filters, mmr, and numbering.
+outputs:
+  review:
+    manual_correction_package: true
+    # Optional. Relative paths are resolved from the internal run_dir.
+    root: review
+    # Optional trace metadata copied into review/manual_correction_input.json.
+    source_pipeline_command: null

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ notes for current instructions.
 | User-facing output profile contract package | [`docs/refactors/issue227/ISSUE227_OUTPUT_PROFILES.md`](refactors/issue227/ISSUE227_OUTPUT_PROFILES.md) |
 | Final score-number overlay format | [`docs/refactors/issue228/ISSUE228_FINAL_OVERLAY_FORMAT.md`](refactors/issue228/ISSUE228_FINAL_OVERLAY_FORMAT.md) |
 | Manual correction GUI pipeline workflow | [`docs/refactors/issue229/ISSUE229_MANUAL_CORRECTION_WORKFLOW.md`](refactors/issue229/ISSUE229_MANUAL_CORRECTION_WORKFLOW.md) |
+| Config-first manual correction review package output | [`docs/manual_correction_review_package.md`](manual_correction_review_package.md) |
 | Issue #120 artifact retention rules | [`docs/ISSUE120_ARTIFACT_RETENTION.md`](ISSUE120_ARTIFACT_RETENTION.md) |
 | Issue #120 evaluation contract | [`docs/ISSUE120_EVALUATION_CONTRACT.md`](ISSUE120_EVALUATION_CONTRACT.md) |
 | Stage E full-pipeline report | [`docs/ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md`](ISSUE141_STAGE_E_FULL_PIPELINE_REPORT.md) |
@@ -122,6 +123,13 @@ notes for current instructions.
   artifact requirements, correction output paths, corrected-final regeneration
   semantics, user operation flow, and the minimum conditions for returning to
   the #215 real-artifact GUI smoke test.
+
+- **Config-first Manual Correction Review Package Output**  
+  [`docs/manual_correction_review_package.md`](manual_correction_review_package.md)  
+  Documents the current `run_pipeline()` connection for emitting
+  `review/manual_correction_input.json` from the internal run directory. This
+  is a narrow production connection and not the full #227 public
+  `final/review/debug` output profile materializer.
 
 ### Issue #120 / Stage E / Detector Contract Documentation
 

--- a/docs/manual_correction_review_package.md
+++ b/docs/manual_correction_review_package.md
@@ -1,0 +1,72 @@
+# Manual Correction Review Package Output
+
+This document describes the config-first production connection that emits a
+manual correction review package from `run_pipeline()`.
+
+This is not the full #226/#227 user-facing `OUTPUT_DIR/{final,review,debug}`
+profile materializer. The public output profile contract is still defined in
+`docs/refactors/issue227/ISSUE227_OUTPUT_PROFILES.md` and remains a later
+integration surface. This connection only lets the current pipeline run emit
+the #229 manual-correction handoff from the current internal run layout.
+
+## Config
+
+Enable review package output explicitly:
+
+```yaml
+outputs:
+  review:
+    manual_correction_package: true
+    # optional; relative paths are resolved from the internal run_dir
+    root: review
+```
+
+When `manual_correction_package` is missing or false, the pipeline does not
+create a review package.
+
+## Output Location
+
+By default, the package is written under the internal pipeline run directory:
+
+```text
+<run_dir>/
+  review/
+    manual_correction_input.json
+    pages/<page_id>/
+      source.png
+      numbering_final.json
+      review_overlay.png
+      mmr_overrides.json
+      barlines_review.json
+    corrections/
+```
+
+`outputs.review.root` can override that package root:
+
+- relative paths are resolved from `<run_dir>`;
+- absolute paths are allowed for controlled callers that already own a public
+  review directory;
+- the materializer still reads only artifacts from the current `run_dir` and
+  rejects run artifacts resolved outside that root.
+
+The current internal pipeline layout keeps implementation artifacts in
+`<run_dir>/outputs/<page_id>/` and `<run_dir>/intermediate/<page_id>/`.
+The review package is a curated handoff copied from those artifacts, not a
+replacement for the internal working tree and not the final public profile
+contract.
+
+## Source Command Metadata
+
+`outputs.review.source_pipeline_command` is optional. When present, it is copied
+into `manual_correction_input.json` as trace metadata. The current config-first
+entrypoint does not reconstruct the shell command automatically; a future
+user-facing CLI can pass execution context when it owns argument resolution.
+
+## Non-goals
+
+This connection does not implement:
+
+- corrected rerun;
+- applying canonical manual overrides back into the pipeline;
+- corrected final PDF regeneration;
+- the full `final/review/debug` public output materializer.

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -150,6 +150,7 @@ class PipelineOrchestrator:
 
     def run(self, page_limit: Optional[int] = None) -> Path:
         """Executes the full pipeline."""
+        self._validate_review_package_prerequisites()
         commands: List[List[str]] = []
 
         if get_nested(self.config, "steps", "pdf_to_images", default=False):
@@ -268,6 +269,11 @@ class PipelineOrchestrator:
         if not self.dry_run:
             write_json(self.run_dir / "filters.json", {"pages": page_statuses})
 
+            manifest_resolved = self._resolved_for_manifest(
+                page_ids=page_ids,
+                resolved=resolved,
+                page_ctx=page_ctx,
+            )
             manifest = build_manifest(
                 self.config,
                 run_id=self.run_id,
@@ -275,7 +281,7 @@ class PipelineOrchestrator:
                 images=images,
                 page_ids=page_ids,
                 page_runs=page_runs,
-                resolved=resolved,
+                resolved=manifest_resolved,
                 commands=commands,
                 page_statuses=page_statuses,
                 barline_override_stats=barline_override_stats,
@@ -351,6 +357,40 @@ class PipelineOrchestrator:
             overwrite=review_cfg.get("overwrite") is not False,
             source_pipeline_command=source_pipeline_command,
         )
+
+    def _validate_review_package_prerequisites(self) -> None:
+        review_config = self._review_package_config()
+        if not review_config.enabled:
+            return
+
+        required_steps = {
+            "numbering_base": get_nested(self.config, "steps", "numbering_base", default=False),
+            "mmr_overrides": get_nested(self.config, "steps", "mmr_overrides", default=False),
+            "overlay": get_nested(self.config, "steps", "overlay", default=False),
+        }
+        missing = [name for name, enabled in required_steps.items() if not enabled]
+        if missing:
+            raise ValueError(
+                "outputs.review.manual_correction_package requires these steps to be enabled: "
+                + ", ".join(missing)
+            )
+
+    def _resolved_for_manifest(
+        self,
+        *,
+        page_ids: List[str],
+        resolved: List[Dict[str, Any]],
+        page_ctx: Dict[str, Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        manifest_resolved = []
+        review_enabled = self._review_package_config().enabled
+        for page_id, item in zip(page_ids, resolved):
+            manifest_item = dict(item)
+            corrected_path = page_ctx.get(page_id, {}).get("barlines_path")
+            if review_enabled and corrected_path and Path(corrected_path).exists():
+                manifest_item["barlines_json"] = str(corrected_path)
+            manifest_resolved.append(manifest_item)
+        return manifest_resolved
 
     def run_base_numbering_and_barline_correction(
         self,
@@ -441,7 +481,7 @@ class PipelineOrchestrator:
                         y_margin=barline_y_margin,
                     )
                     barline_override_stats[page_id] = stats
-                    if not self.dry_run and self.debug:
+                    if not self.dry_run and (self.debug or self._review_package_config().enabled):
                         write_json(corrected_path, corrected)
                     page_ctx[page_id]["corrected_barlines"] = corrected
                 else:

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -282,11 +282,15 @@ class PipelineOrchestrator:
             )
             write_json(self.run_dir / "manifest.json", manifest)
             logger.info(f"Wrote manifest to {self.run_dir / 'manifest.json'}")
-            self._materialize_review_package_if_requested()
+            self._materialize_review_package_if_requested(page_ids, excluded_page_ids)
 
         return self.run_dir
 
-    def _materialize_review_package_if_requested(self) -> Path | None:
+    def _materialize_review_package_if_requested(
+        self,
+        page_ids: List[str],
+        excluded_page_ids: Set[str],
+    ) -> Path | None:
         """Materialize the manual-correction review package when enabled."""
         review_config = self._review_package_config()
         if not review_config.enabled:
@@ -299,9 +303,17 @@ class PipelineOrchestrator:
             )
             return None
 
+        review_page_ids = [page_id for page_id in page_ids if page_id not in excluded_page_ids]
+        if not review_page_ids:
+            logger.info(
+                "Skipping manual correction review package materialization: no non-excluded pages."
+            )
+            return None
+
         materialize_manual_correction_review_package(
             run_root=self.run_dir,
             review_root=review_config.review_root,
+            pages=review_page_ids,
             source_pipeline_command=review_config.source_pipeline_command,
             overwrite=review_config.overwrite,
         )
@@ -336,7 +348,7 @@ class PipelineOrchestrator:
         return _ReviewPackageConfig(
             enabled=enabled,
             review_root=review_root,
-            overwrite=bool(review_cfg.get("overwrite", True)),
+            overwrite=review_cfg.get("overwrite") is not False,
             source_pipeline_command=source_pipeline_command,
         )
 

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
@@ -44,6 +45,14 @@ logger = logging.getLogger(__name__)
 _PIPELINE_PERSISTENCE: Dict[str, Any] = {}
 # MMR Persistence: Cache MMRClassifier and MMROCREngine to avoid re-loading models.
 _MMR_PERSISTENCE: Dict[Any, Any] = {}
+
+
+@dataclass(frozen=True)
+class _ReviewPackageConfig:
+    enabled: bool
+    review_root: Path
+    overwrite: bool
+    source_pipeline_command: str | None
 
 
 class PipelineOrchestrator:
@@ -279,8 +288,8 @@ class PipelineOrchestrator:
 
     def _materialize_review_package_if_requested(self) -> Path | None:
         """Materialize the manual-correction review package when enabled."""
-        review_cfg = get_nested(self.config, "outputs", "review", default={}) or {}
-        if not review_cfg.get("manual_correction_package", False):
+        review_config = self._review_package_config()
+        if not review_config.enabled:
             return None
 
         if self.dry_run or self.validate_only:
@@ -290,24 +299,46 @@ class PipelineOrchestrator:
             )
             return None
 
+        materialize_manual_correction_review_package(
+            run_root=self.run_dir,
+            review_root=review_config.review_root,
+            source_pipeline_command=review_config.source_pipeline_command,
+            overwrite=review_config.overwrite,
+        )
+        logger.info(f"Wrote manual correction review package to {review_config.review_root}")
+        return review_config.review_root
+
+    def _review_package_config(self) -> _ReviewPackageConfig:
+        """Resolve the config-first review package output contract.
+
+        This is intentionally scoped to the low-level ``run_pipeline()`` layout.
+        The #226/#227 public ``OUTPUT_DIR/{final,review,debug}`` materializer is
+        a separate follow-up surface.
+        """
+        review_cfg = get_nested(self.config, "outputs", "review", default={}) or {}
+        if not isinstance(review_cfg, dict):
+            raise ValueError("outputs.review must be a mapping when provided.")
+
+        enabled = bool(review_cfg.get("manual_correction_package", False))
         review_root_raw = review_cfg.get("root")
         if review_root_raw:
-            review_root = Path(review_root_raw)
+            review_root = Path(str(review_root_raw))
             if not review_root.is_absolute():
                 review_root = self.run_dir / review_root
         else:
             review_root = self.run_dir / "review"
 
-        source_pipeline_command = review_cfg.get("source_pipeline_command")
-        overwrite = bool(review_cfg.get("overwrite", True))
-        materialize_manual_correction_review_package(
-            run_root=self.run_dir,
-            review_root=review_root,
-            source_pipeline_command=source_pipeline_command,
-            overwrite=overwrite,
+        source_pipeline_command_raw = review_cfg.get("source_pipeline_command")
+        source_pipeline_command = (
+            str(source_pipeline_command_raw) if source_pipeline_command_raw else None
         )
-        logger.info(f"Wrote manual correction review package to {review_root}")
-        return review_root
+
+        return _ReviewPackageConfig(
+            enabled=enabled,
+            review_root=review_root,
+            overwrite=bool(review_cfg.get("overwrite", True)),
+            source_pipeline_command=source_pipeline_command,
+        )
 
     def run_base_numbering_and_barline_correction(
         self,

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -121,10 +121,7 @@ class PipelineOrchestrator:
         prefix = str(pdf_opts.get("prefix", "page"))
         fmt = str(pdf_opts.get("format", "png"))
 
-        # Default behavior: write to disk unless output_dir is explicitly null (None)
-        persist_to_disk = (
-            self.debug or ("output_dir" not in pdf_opts) or (pdf_opts.get("output_dir") is not None)
-        )
+        persist_to_disk = self._should_persist_pdf_images(pdf_opts)
 
         for page_index, image in rendered:
             stem = f"{prefix}_{page_index + 1:03d}"
@@ -147,6 +144,15 @@ class PipelineOrchestrator:
         for page_id in page_ids:
             page_runs.append(input_runs.get(page_id, page_id))
         return page_runs
+
+    def _should_persist_pdf_images(self, pdf_opts: Dict[str, Any]) -> bool:
+        """Return whether rendered PDF pages must be written to run_dir images."""
+        return (
+            self.debug
+            or self._review_package_config().enabled
+            or ("output_dir" not in pdf_opts)
+            or (pdf_opts.get("output_dir") is not None)
+        )
 
     def run(self, page_limit: Optional[int] = None) -> Path:
         """Executes the full pipeline."""
@@ -171,9 +177,7 @@ class PipelineOrchestrator:
 
         # Determine if we skipped disk write during pdf_to_images
         pdf_opts = get_nested(self.config, "inputs", "pdf_to_images", default={}) or {}
-        persist_to_disk = (
-            self.debug or ("output_dir" not in pdf_opts) or (pdf_opts.get("output_dir") is not None)
-        )
+        persist_to_disk = self._should_persist_pdf_images(pdf_opts)
 
         # Only pass in_memory_images to collect_images if we actually used the cache (i.e. did not persist)
         images = collect_images(

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -22,6 +22,9 @@ from src.pipeline.detection import (
     resolve_paths_from_detection,
     run_detection_step,
 )
+from src.pipeline.review.manual_correction_materializer import (
+    materialize_manual_correction_review_package,
+)
 from src.pipeline.steps.barlines import (
     apply_barline_overrides,
     merge_measure_overrides,
@@ -270,8 +273,41 @@ class PipelineOrchestrator:
             )
             write_json(self.run_dir / "manifest.json", manifest)
             logger.info(f"Wrote manifest to {self.run_dir / 'manifest.json'}")
+            self._materialize_review_package_if_requested()
 
         return self.run_dir
+
+    def _materialize_review_package_if_requested(self) -> Path | None:
+        """Materialize the manual-correction review package when enabled."""
+        review_cfg = get_nested(self.config, "outputs", "review", default={}) or {}
+        if not review_cfg.get("manual_correction_package", False):
+            return None
+
+        if self.dry_run or self.validate_only:
+            logger.info(
+                "Skipping manual correction review package materialization for dry-run "
+                "or validate-only execution."
+            )
+            return None
+
+        review_root_raw = review_cfg.get("root")
+        if review_root_raw:
+            review_root = Path(review_root_raw)
+            if not review_root.is_absolute():
+                review_root = self.run_dir / review_root
+        else:
+            review_root = self.run_dir / "review"
+
+        source_pipeline_command = review_cfg.get("source_pipeline_command")
+        overwrite = bool(review_cfg.get("overwrite", True))
+        materialize_manual_correction_review_package(
+            run_root=self.run_dir,
+            review_root=review_root,
+            source_pipeline_command=source_pipeline_command,
+            overwrite=overwrite,
+        )
+        logger.info(f"Wrote manual correction review package to {review_root}")
+        return review_root
 
     def run_base_numbering_and_barline_correction(
         self,

--- a/src/pipeline/utils/images.py
+++ b/src/pipeline/utils/images.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -24,6 +25,41 @@ def get_image_cache() -> Dict[str, np.ndarray]:
 def clear_image_cache() -> None:
     _IMAGE_CACHE.clear()
 
+
+
+
+def _review_package_enabled(config: Dict[str, Any]) -> bool:
+    review_cfg = get_nested(config, "outputs", "review", default={}) or {}
+    return isinstance(review_cfg, dict) and bool(
+        review_cfg.get("manual_correction_package", False)
+    )
+
+
+def _path_is_inside(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _stage_external_review_images(images: List[Path], run_dir: Path) -> List[Path]:
+    staged_dir = run_dir / "inputs" / "images"
+    staged_dir.mkdir(parents=True, exist_ok=True)
+    staged_images: List[Path] = []
+
+    for image in images:
+        src = Path(image)
+        if _path_is_inside(src, run_dir):
+            staged_images.append(src)
+            continue
+
+        dest = staged_dir / src.name
+        if src.resolve() != dest.resolve():
+            shutil.copy2(src, dest)
+        staged_images.append(dest)
+
+    return staged_images
 
 def collect_images(
     config: Dict[str, Any],
@@ -57,6 +93,10 @@ def collect_images(
             images = sorted(external_dir.glob(image_glob))
     if not images:
         raise FileNotFoundError(f"No images found in {output_dir} matching {image_glob}")
+
+    if _review_package_enabled(config):
+        images = _stage_external_review_images(images, run_dir)
+
     return images
 
 

--- a/tests/test_issue236_review_package_pipeline_connection.py
+++ b/tests/test_issue236_review_package_pipeline_connection.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 sys.modules.setdefault("fitz", types.SimpleNamespace())
 
+from src.pipeline.core.config import load_yaml
 from src.pipeline.orchestrator import PipelineOrchestrator
 from src.pipeline.review.manual_correction_handoff import validate_manual_correction_handoff
 
@@ -22,8 +23,9 @@ def _write_text(path: Path, text: str = "placeholder") -> None:
 def _fake_pipeline_config(
     run_dir: Path,
     *,
-    review_enabled: bool,
-    review_root: Path | None = None,
+    review_enabled: bool | None,
+    review_root: Path | str | None = None,
+    source_pipeline_command: str | None = None,
 ) -> dict:
     image_dir = run_dir / "inputs" / "images"
     detector_dir = run_dir / "detector"
@@ -31,9 +33,13 @@ def _fake_pipeline_config(
     _write_json(detector_dir / "page_001_barlines.json", {"boxes": [{"bbox": [1, 2, 3, 4]}]})
     _write_text(detector_dir / "page_001_staff.png")
 
-    review_cfg: dict[str, object] = {"manual_correction_package": review_enabled}
+    review_cfg: dict[str, object] = {}
+    if review_enabled is not None:
+        review_cfg["manual_correction_package"] = review_enabled
     if review_root is not None:
         review_cfg["root"] = str(review_root)
+    if source_pipeline_command is not None:
+        review_cfg["source_pipeline_command"] = source_pipeline_command
 
     return {
         "inputs": {
@@ -128,6 +134,7 @@ def test_pipeline_connection_materializes_enabled_review_package(monkeypatch, tm
     review_root = run_dir / "review"
     assert call_args["run_root"] == run_dir
     assert call_args["review_root"] == review_root
+    assert call_args["source_pipeline_command"] is None
 
     handoff_path = review_root / "manual_correction_input.json"
     handoff = json.loads(handoff_path.read_text())
@@ -151,7 +158,27 @@ def test_pipeline_connection_materializes_enabled_review_package(monkeypatch, tm
     assert validated["pages"][0]["page_id"] == "page_001"
 
 
-def test_pipeline_connection_uses_configured_review_root(monkeypatch, tmp_path):
+def test_pipeline_connection_resolves_relative_review_root_from_run_dir(monkeypatch, tmp_path):
+    run_dir = tmp_path / "source_run"
+    config = _fake_pipeline_config(
+        run_dir,
+        review_enabled=True,
+        review_root=Path("manual_review"),
+        source_pipeline_command="make run-pipeline CONFIG=smoke.yaml",
+    )
+    _patch_lightweight_pipeline_phases(monkeypatch)
+
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+    orchestrator.run()
+
+    handoff_path = run_dir / "manual_review" / "manual_correction_input.json"
+    assert handoff_path.exists()
+    handoff = json.loads(handoff_path.read_text())
+    assert handoff["source_pipeline_command"] == "make run-pipeline CONFIG=smoke.yaml"
+    assert not (run_dir / "review" / "manual_correction_input.json").exists()
+
+
+def test_pipeline_connection_uses_absolute_review_root(monkeypatch, tmp_path):
     run_dir = tmp_path / "source_run"
     public_review_root = tmp_path / "public_output" / "review"
     config = _fake_pipeline_config(
@@ -178,3 +205,22 @@ def test_pipeline_connection_does_not_materialize_when_disabled(monkeypatch, tmp
 
     assert (run_dir / "manifest.json").exists()
     assert not (run_dir / "review").exists()
+
+
+def test_pipeline_connection_does_not_materialize_when_review_flag_missing(monkeypatch, tmp_path):
+    run_dir = tmp_path / "source_run"
+    config = _fake_pipeline_config(run_dir, review_enabled=None)
+    _patch_lightweight_pipeline_phases(monkeypatch)
+
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+    orchestrator.run()
+
+    assert (run_dir / "manifest.json").exists()
+    assert not (run_dir / "review").exists()
+
+
+def test_review_package_example_config_is_parseable():
+    config = load_yaml(Path("configs/review_manual_correction_package_example.yaml"))
+
+    assert config["outputs"]["review"]["manual_correction_package"] is True
+    assert config["outputs"]["review"]["root"] == "review"

--- a/tests/test_issue236_review_package_pipeline_connection.py
+++ b/tests/test_issue236_review_package_pipeline_connection.py
@@ -1,0 +1,180 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+sys.modules.setdefault("fitz", types.SimpleNamespace())
+
+from src.pipeline.orchestrator import PipelineOrchestrator
+from src.pipeline.review.manual_correction_handoff import validate_manual_correction_handoff
+
+
+def _write_json(path: Path, payload: object | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload or {}, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str = "placeholder") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _fake_pipeline_config(
+    run_dir: Path,
+    *,
+    review_enabled: bool,
+    review_root: Path | None = None,
+) -> dict:
+    image_dir = run_dir / "inputs" / "images"
+    detector_dir = run_dir / "detector"
+    _write_text(image_dir / "page_001.png")
+    _write_json(detector_dir / "page_001_barlines.json", {"boxes": [{"bbox": [1, 2, 3, 4]}]})
+    _write_text(detector_dir / "page_001_staff.png")
+
+    review_cfg: dict[str, object] = {"manual_correction_package": review_enabled}
+    if review_root is not None:
+        review_cfg["root"] = str(review_root)
+
+    return {
+        "inputs": {
+            "pdf_to_images": {
+                "output_dir": str(image_dir),
+                "image_glob": "page_*.png",
+            },
+            "barlines_root": str(detector_dir),
+            "barlines_pattern": "{page_id}_barlines.json",
+            "staff_mask_pattern": "{page_id}_staff.png",
+        },
+        "steps": {
+            "pdf_to_images": False,
+            "detection": False,
+            "numbering_base": False,
+            "mmr_overrides": False,
+            "apply_measure_overrides": False,
+            "overlay": False,
+        },
+        "filters": {
+            "blank_page": False,
+            "staff_detect": False,
+        },
+        "outputs": {
+            "review": review_cfg,
+        },
+    }
+
+
+def _patch_lightweight_pipeline_phases(monkeypatch) -> None:
+    def fake_base(self, page_ids, images, resolved, excluded_page_ids):
+        return {
+            "page_ctx": {page_id: {"index": index} for index, page_id in enumerate(page_ids, 1)},
+            "numbering_base_paths": [],
+            "barline_override_stats": {
+                page_id: {
+                    "removed": 0,
+                    "added": 0,
+                    "remove_requests": 0,
+                    "unmatched_remove": 0,
+                }
+                for page_id in page_ids
+            },
+        }
+
+    def fake_mmr(self, page_ids, excluded_page_ids, page_ctx):
+        for page_id in page_ids:
+            _write_json(self.run_dir / "intermediate" / page_id / "overrides_mmr.json")
+
+    def fake_final(self, page_ids, excluded_page_ids, page_ctx, user_overrides_payload):
+        paths = []
+        for page_id in page_ids:
+            final_path = self.run_dir / "outputs" / page_id / "numbering_final.json"
+            _write_json(final_path)
+            _write_text(self.run_dir / "outputs" / page_id / "numbering_overlay.png")
+            paths.append(final_path)
+        return paths
+
+    monkeypatch.setattr(
+        PipelineOrchestrator,
+        "run_base_numbering_and_barline_correction",
+        fake_base,
+    )
+    monkeypatch.setattr(PipelineOrchestrator, "run_mmr_batch_detection", fake_mmr)
+    monkeypatch.setattr(PipelineOrchestrator, "run_final_numbering_and_overlays", fake_final)
+
+
+def test_pipeline_connection_materializes_enabled_review_package(monkeypatch, tmp_path):
+    run_dir = tmp_path / "source_run"
+    config = _fake_pipeline_config(run_dir, review_enabled=True)
+    _patch_lightweight_pipeline_phases(monkeypatch)
+
+    import src.pipeline.orchestrator as orchestrator_module
+
+    real_materializer = orchestrator_module.materialize_manual_correction_review_package
+    call_args = {}
+
+    def spy_materializer(**kwargs):
+        call_args.update(kwargs)
+        return real_materializer(**kwargs)
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "materialize_manual_correction_review_package",
+        spy_materializer,
+    )
+
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+    result = orchestrator.run()
+
+    assert result == run_dir
+    review_root = run_dir / "review"
+    assert call_args["run_root"] == run_dir
+    assert call_args["review_root"] == review_root
+
+    handoff_path = review_root / "manual_correction_input.json"
+    handoff = json.loads(handoff_path.read_text())
+    page = handoff["pages"][0]
+    assert page["barlines_review_source"] == "detector/page_001_barlines.json"
+    assert page["barlines_review_source_kind"] == "manifest_resolved_detector_output"
+    assert page["barlines_review_source_manifest_field"] == "barlines_json"
+    assert (review_root / "pages" / "page_001" / "source.png").exists()
+    assert (review_root / "pages" / "page_001" / "numbering_final.json").exists()
+    assert (review_root / "pages" / "page_001" / "review_overlay.png").exists()
+    assert (review_root / "pages" / "page_001" / "mmr_overrides.json").exists()
+    assert (review_root / "pages" / "page_001" / "barlines_review.json").exists()
+    assert (review_root / "corrections").is_dir()
+
+    validated = validate_manual_correction_handoff(
+        handoff,
+        handoff_path=handoff_path,
+        mode="issue229_smoke_strict",
+        require_existing_artifacts=True,
+    )
+    assert validated["pages"][0]["page_id"] == "page_001"
+
+
+def test_pipeline_connection_uses_configured_review_root(monkeypatch, tmp_path):
+    run_dir = tmp_path / "source_run"
+    public_review_root = tmp_path / "public_output" / "review"
+    config = _fake_pipeline_config(
+        run_dir,
+        review_enabled=True,
+        review_root=public_review_root,
+    )
+    _patch_lightweight_pipeline_phases(monkeypatch)
+
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+    orchestrator.run()
+
+    assert (public_review_root / "manual_correction_input.json").exists()
+    assert not (run_dir / "review" / "manual_correction_input.json").exists()
+
+
+def test_pipeline_connection_does_not_materialize_when_disabled(monkeypatch, tmp_path):
+    run_dir = tmp_path / "source_run"
+    config = _fake_pipeline_config(run_dir, review_enabled=False)
+    _patch_lightweight_pipeline_phases(monkeypatch)
+
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+    orchestrator.run()
+
+    assert (run_dir / "manifest.json").exists()
+    assert not (run_dir / "review").exists()

--- a/tests/test_issue236_review_package_pipeline_connection.py
+++ b/tests/test_issue236_review_package_pipeline_connection.py
@@ -289,6 +289,30 @@ def test_pipeline_connection_rejects_missing_review_artifact_steps(tmp_path):
         orchestrator.run()
 
 
+def test_pipeline_review_package_forces_pdf_image_persistence(tmp_path):
+    run_dir = tmp_path / "source_run"
+    config = _fake_pipeline_config(run_dir, review_enabled=True)
+    config["inputs"]["pdf_to_images"]["output_dir"] = None
+
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+
+    assert orchestrator._should_persist_pdf_images(config["inputs"]["pdf_to_images"]) is True
+
+
+def test_pipeline_without_review_package_allows_in_memory_pdf_images(tmp_path):
+    run_dir = tmp_path / "source_run"
+    config = _fake_pipeline_config(
+        run_dir,
+        review_enabled=False,
+        review_artifact_steps_enabled=False,
+    )
+    config["inputs"]["pdf_to_images"]["output_dir"] = None
+
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+
+    assert orchestrator._should_persist_pdf_images(config["inputs"]["pdf_to_images"]) is False
+
+
 def test_pipeline_connection_skips_user_excluded_pages_in_review_package(monkeypatch, tmp_path):
     run_dir = tmp_path / "source_run"
     config = _fake_pipeline_config(

--- a/tests/test_issue236_review_package_pipeline_connection.py
+++ b/tests/test_issue236_review_package_pipeline_connection.py
@@ -3,6 +3,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 sys.modules.setdefault("fitz", types.SimpleNamespace())
 
 from src.pipeline.core.config import load_yaml
@@ -28,6 +30,7 @@ def _fake_pipeline_config(
     source_pipeline_command: str | None = None,
     page_ids: tuple[str, ...] = ("page_001",),
     user_exclude: list[int] | None = None,
+    review_artifact_steps_enabled: bool = True,
 ) -> dict:
     image_dir = run_dir / "inputs" / "images"
     detector_dir = run_dir / "detector"
@@ -54,6 +57,10 @@ def _fake_pipeline_config(
     if user_exclude is not None:
         filters["user_exclude"] = user_exclude
 
+    numbering_base = review_artifact_steps_enabled
+    mmr_overrides = review_artifact_steps_enabled
+    overlay = review_artifact_steps_enabled
+
     return {
         "inputs": {
             "pdf_to_images": {
@@ -67,10 +74,10 @@ def _fake_pipeline_config(
         "steps": {
             "pdf_to_images": False,
             "detection": False,
-            "numbering_base": False,
-            "mmr_overrides": False,
+            "numbering_base": numbering_base,
+            "mmr_overrides": mmr_overrides,
             "apply_measure_overrides": False,
-            "overlay": False,
+            "overlay": overlay,
         },
         "filters": filters,
         "outputs": {
@@ -212,7 +219,11 @@ def test_pipeline_connection_uses_absolute_review_root(monkeypatch, tmp_path):
 
 def test_pipeline_connection_does_not_materialize_when_disabled(monkeypatch, tmp_path):
     run_dir = tmp_path / "source_run"
-    config = _fake_pipeline_config(run_dir, review_enabled=False)
+    config = _fake_pipeline_config(
+        run_dir,
+        review_enabled=False,
+        review_artifact_steps_enabled=False,
+    )
     _patch_lightweight_pipeline_phases(monkeypatch)
 
     orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
@@ -224,7 +235,11 @@ def test_pipeline_connection_does_not_materialize_when_disabled(monkeypatch, tmp
 
 def test_pipeline_connection_does_not_materialize_when_review_flag_missing(monkeypatch, tmp_path):
     run_dir = tmp_path / "source_run"
-    config = _fake_pipeline_config(run_dir, review_enabled=None)
+    config = _fake_pipeline_config(
+        run_dir,
+        review_enabled=None,
+        review_artifact_steps_enabled=False,
+    )
     _patch_lightweight_pipeline_phases(monkeypatch)
 
     orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
@@ -261,6 +276,19 @@ def test_pipeline_connection_treats_null_overwrite_as_default_true(monkeypatch, 
     assert call_args["overwrite"] is True
 
 
+def test_pipeline_connection_rejects_missing_review_artifact_steps(tmp_path):
+    run_dir = tmp_path / "source_run"
+    config = _fake_pipeline_config(run_dir, review_enabled=True)
+    config["steps"]["overlay"] = False
+    config["steps"]["mmr_overrides"] = True
+    config["steps"]["numbering_base"] = True
+
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+
+    with pytest.raises(ValueError, match="manual_correction_package requires"):
+        orchestrator.run()
+
+
 def test_pipeline_connection_skips_user_excluded_pages_in_review_package(monkeypatch, tmp_path):
     run_dir = tmp_path / "source_run"
     config = _fake_pipeline_config(
@@ -295,6 +323,47 @@ def test_pipeline_connection_skips_user_excluded_pages_in_review_package(monkeyp
     assert [page["page_id"] for page in handoff["pages"]] == ["page_001"]
     assert (review_root / "pages" / "page_001").is_dir()
     assert not (review_root / "pages" / "page_002").exists()
+
+
+def test_pipeline_manifest_uses_corrected_barlines_for_review_package(tmp_path):
+    run_dir = tmp_path / "source_run"
+    corrected = run_dir / "intermediate" / "page_001" / "barlines_corrected.json"
+    _write_json(corrected, [{"bbox": [10, 20, 30, 40]}])
+
+    config = _fake_pipeline_config(run_dir, review_enabled=True)
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+
+    raw = run_dir / "detector" / "page_001_barlines.json"
+    resolved = [{"barlines_json": str(raw)}]
+    page_ctx = {"page_001": {"barlines_path": corrected}}
+
+    manifest_resolved = orchestrator._resolved_for_manifest(
+        page_ids=["page_001"],
+        resolved=resolved,
+        page_ctx=page_ctx,
+    )
+
+    assert manifest_resolved[0]["barlines_json"] == str(corrected)
+
+
+def test_pipeline_manifest_keeps_raw_barlines_when_corrected_missing(tmp_path):
+    run_dir = tmp_path / "source_run"
+    missing_corrected = run_dir / "intermediate" / "page_001" / "barlines_corrected.json"
+
+    config = _fake_pipeline_config(run_dir, review_enabled=True)
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+
+    raw = run_dir / "detector" / "page_001_barlines.json"
+    resolved = [{"barlines_json": str(raw)}]
+    page_ctx = {"page_001": {"barlines_path": missing_corrected}}
+
+    manifest_resolved = orchestrator._resolved_for_manifest(
+        page_ids=["page_001"],
+        resolved=resolved,
+        page_ctx=page_ctx,
+    )
+
+    assert manifest_resolved[0]["barlines_json"] == str(raw)
 
 
 def test_review_package_example_config_is_parseable():

--- a/tests/test_issue236_review_package_pipeline_connection.py
+++ b/tests/test_issue236_review_package_pipeline_connection.py
@@ -26,12 +26,18 @@ def _fake_pipeline_config(
     review_enabled: bool | None,
     review_root: Path | str | None = None,
     source_pipeline_command: str | None = None,
+    page_ids: tuple[str, ...] = ("page_001",),
+    user_exclude: list[int] | None = None,
 ) -> dict:
     image_dir = run_dir / "inputs" / "images"
     detector_dir = run_dir / "detector"
-    _write_text(image_dir / "page_001.png")
-    _write_json(detector_dir / "page_001_barlines.json", {"boxes": [{"bbox": [1, 2, 3, 4]}]})
-    _write_text(detector_dir / "page_001_staff.png")
+    for page_id in page_ids:
+        _write_text(image_dir / f"{page_id}.png")
+        _write_json(
+            detector_dir / f"{page_id}_barlines.json",
+            {"boxes": [{"bbox": [1, 2, 3, 4]}]},
+        )
+        _write_text(detector_dir / f"{page_id}_staff.png")
 
     review_cfg: dict[str, object] = {}
     if review_enabled is not None:
@@ -40,6 +46,13 @@ def _fake_pipeline_config(
         review_cfg["root"] = str(review_root)
     if source_pipeline_command is not None:
         review_cfg["source_pipeline_command"] = source_pipeline_command
+
+    filters: dict[str, object] = {
+        "blank_page": False,
+        "staff_detect": False,
+    }
+    if user_exclude is not None:
+        filters["user_exclude"] = user_exclude
 
     return {
         "inputs": {
@@ -59,10 +72,7 @@ def _fake_pipeline_config(
             "apply_measure_overrides": False,
             "overlay": False,
         },
-        "filters": {
-            "blank_page": False,
-            "staff_detect": False,
-        },
+        "filters": filters,
         "outputs": {
             "review": review_cfg,
         },
@@ -87,11 +97,15 @@ def _patch_lightweight_pipeline_phases(monkeypatch) -> None:
 
     def fake_mmr(self, page_ids, excluded_page_ids, page_ctx):
         for page_id in page_ids:
+            if page_id in excluded_page_ids:
+                continue
             _write_json(self.run_dir / "intermediate" / page_id / "overrides_mmr.json")
 
     def fake_final(self, page_ids, excluded_page_ids, page_ctx, user_overrides_payload):
         paths = []
         for page_id in page_ids:
+            if page_id in excluded_page_ids:
+                continue
             final_path = self.run_dir / "outputs" / page_id / "numbering_final.json"
             _write_json(final_path)
             _write_text(self.run_dir / "outputs" / page_id / "numbering_overlay.png")
@@ -134,6 +148,7 @@ def test_pipeline_connection_materializes_enabled_review_package(monkeypatch, tm
     review_root = run_dir / "review"
     assert call_args["run_root"] == run_dir
     assert call_args["review_root"] == review_root
+    assert call_args["pages"] == ["page_001"]
     assert call_args["source_pipeline_command"] is None
 
     handoff_path = review_root / "manual_correction_input.json"
@@ -217,6 +232,69 @@ def test_pipeline_connection_does_not_materialize_when_review_flag_missing(monke
 
     assert (run_dir / "manifest.json").exists()
     assert not (run_dir / "review").exists()
+
+
+def test_pipeline_connection_treats_null_overwrite_as_default_true(monkeypatch, tmp_path):
+    run_dir = tmp_path / "source_run"
+    config = _fake_pipeline_config(run_dir, review_enabled=True)
+    config["outputs"]["review"]["overwrite"] = None
+    _patch_lightweight_pipeline_phases(monkeypatch)
+
+    import src.pipeline.orchestrator as orchestrator_module
+
+    real_materializer = orchestrator_module.materialize_manual_correction_review_package
+    call_args = {}
+
+    def spy_materializer(**kwargs):
+        call_args.update(kwargs)
+        return real_materializer(**kwargs)
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "materialize_manual_correction_review_package",
+        spy_materializer,
+    )
+
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+    orchestrator.run()
+
+    assert call_args["overwrite"] is True
+
+
+def test_pipeline_connection_skips_user_excluded_pages_in_review_package(monkeypatch, tmp_path):
+    run_dir = tmp_path / "source_run"
+    config = _fake_pipeline_config(
+        run_dir,
+        review_enabled=True,
+        page_ids=("page_001", "page_002"),
+        user_exclude=[2],
+    )
+    _patch_lightweight_pipeline_phases(monkeypatch)
+
+    import src.pipeline.orchestrator as orchestrator_module
+
+    real_materializer = orchestrator_module.materialize_manual_correction_review_package
+    call_args = {}
+
+    def spy_materializer(**kwargs):
+        call_args.update(kwargs)
+        return real_materializer(**kwargs)
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "materialize_manual_correction_review_package",
+        spy_materializer,
+    )
+
+    orchestrator = PipelineOrchestrator(config=config, run_id="source_run", run_dir=run_dir)
+    orchestrator.run()
+
+    review_root = run_dir / "review"
+    assert call_args["pages"] == ["page_001"]
+    handoff = json.loads((review_root / "manual_correction_input.json").read_text())
+    assert [page["page_id"] for page in handoff["pages"]] == ["page_001"]
+    assert (review_root / "pages" / "page_001").is_dir()
+    assert not (review_root / "pages" / "page_002").exists()
 
 
 def test_review_package_example_config_is_parseable():

--- a/tests/test_issue236_review_package_source_images.py
+++ b/tests/test_issue236_review_package_source_images.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from src.pipeline.utils.images import collect_images
+
+
+def _write_text(path: Path, text: str = "image") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _config(*, review_enabled: bool, output_dir: Path) -> dict:
+    return {
+        "inputs": {
+            "pdf_to_images": {
+                "output_dir": str(output_dir),
+                "image_glob": "page_*.png",
+            }
+        },
+        "outputs": {
+            "review": {
+                "manual_correction_package": review_enabled,
+            }
+        },
+    }
+
+
+def test_collect_images_stages_external_source_images_for_review_package(tmp_path):
+    run_dir = tmp_path / "source_run"
+    external_dir = tmp_path / "external_images"
+    external_image = external_dir / "page_001.png"
+    _write_text(external_image, "external-image")
+
+    images = collect_images(
+        _config(review_enabled=True, output_dir=external_dir),
+        run_dir,
+    )
+
+    expected = run_dir / "inputs" / "images" / "page_001.png"
+    assert images == [expected]
+    assert expected.read_text(encoding="utf-8") == "external-image"
+
+
+def test_collect_images_keeps_external_source_images_without_review_package(tmp_path):
+    run_dir = tmp_path / "source_run"
+    external_dir = tmp_path / "external_images"
+    external_image = external_dir / "page_001.png"
+    _write_text(external_image, "external-image")
+
+    images = collect_images(
+        _config(review_enabled=False, output_dir=external_dir),
+        run_dir,
+    )
+
+    assert images == [external_image]
+    assert not (run_dir / "inputs" / "images" / "page_001.png").exists()
+
+
+def test_collect_images_keeps_run_dir_source_images_for_review_package(tmp_path):
+    run_dir = tmp_path / "source_run"
+    internal_dir = run_dir / "inputs" / "images"
+    internal_image = internal_dir / "page_001.png"
+    _write_text(internal_image, "internal-image")
+
+    images = collect_images(
+        _config(review_enabled=True, output_dir=internal_dir),
+        run_dir,
+    )
+
+    assert images == [internal_image]
+    assert internal_image.read_text(encoding="utf-8") == "internal-image"


### PR DESCRIPTION
## Summary

Refs #236.

This PR wires the already-merged manual correction review package materializer into the config-first pipeline path. It is an intermediate slice for #236 and does **not** close the issue.

Changes:

- Add an `outputs.review.manual_correction_package` config gate.
- Materialize the manual correction review package after a successful pipeline run writes `manifest.json`.
- Keep the default package root at `<run_dir>/review`.
- Allow `outputs.review.root` to override the review package root.
  - Relative paths are resolved from `<run_dir>`.
  - Absolute paths are allowed for controlled callers.
- Keep `outputs.review.source_pipeline_command` optional trace metadata.
- Document this config-first connection and clarify that it is **not** the full #226/#227 public `OUTPUT_DIR/{final,review,debug}` materializer.
- Add an example config fragment.
- Add focused tests for enabled, disabled, missing flag, relative root, absolute root, source command metadata, strict handoff validation, and example config parsing.

## Scope / non-goals

This PR only connects review package materialization to the production pipeline path behind an explicit config gate.

It does not implement:

- corrected rerun;
- applying canonical manual overrides back into the pipeline;
- corrected final PDF regeneration;
- #215 full user-facing GUI workflow retry;
- full 68-page regression gates;
- the full #226/#227 public `final/review/debug` output profile materializer.

## Config contract

Enable explicitly:

```yaml
outputs:
  review:
    manual_correction_package: true
    # optional; relative paths resolve from the internal run_dir
    root: review
    # optional trace metadata copied into review/manual_correction_input.json
    source_pipeline_command: null
```

Default output:

```text
<run_dir>/review/manual_correction_input.json
```

`outputs.review.root` can override that root. The materializer still reads only artifacts from the current `run_dir` and rejects run artifacts resolved outside that root.

## Validation

Reported local validation after rebase onto current `develop`:

```text
make lint
# Passed; 379 files already formatted

PYTHONPATH=. python3 -m pytest \
  tests/test_manual_corrections.py \
  tests/test_manual_correction_handoff.py \
  tests/test_manual_correction_materializer.py \
  tests/test_manual_gui_server.py \
  tests/test_issue236_review_package_pipeline_connection.py
# 37 passed in 2.25s
```

Smoke context:

- Previous one-page current-pipeline smoke passed before this docs/config hardening slice.
- The smoke report was updated to clarify:
  - default output is `<run_dir>/review`;
  - the smoke used the default case without `outputs.review.root`;
  - relative `outputs.review.root` paths resolve from `<run_dir>`;
  - `source_pipeline_command` is optional and only included when configured.

## Notes

This PR intentionally keeps the branch small. The next #236 slice should implement corrected-rerun and canonical override application separately, then corrected final output regeneration and the broader regression gates.