### PR TITLE
chore: add PR slice validation workflow for issue #241

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,29 @@
+name: PR validation
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: make lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install uv for ruff entrypoints
+        run: python -m pip install --upgrade pip uv
+
+      - name: Run ruff lint and format check
+        run: make lint

--- a/docs/dev/PR_SLICE_VALIDATION.md
+++ b/docs/dev/PR_SLICE_VALIDATION.md
@@ -1,0 +1,101 @@
+# PR slice validation workflow
+
+This document defines the lightweight local validation path for focused PRs.
+It is intended to prevent formatter-only follow-up commits and to make focused pytest sets reusable across review iterations.
+
+## Before pushing a focused PR
+
+Run the slice validation command from the repository root:
+
+```bash
+bash scripts/check_pr_slice.sh issue236-apply-corrections
+```
+
+The command runs:
+
+1. `make lint`
+2. the pytest entries listed in `scripts/pr_validation_profiles/issue236-apply-corrections.txt`
+
+A run summary and logs are written under `artifacts/pr_slice_validation/`.
+
+## Avoiding formatter-only commits
+
+Before committing or before pushing review updates, run:
+
+```bash
+make format
+bash scripts/check_pr_slice.sh issue236-apply-corrections
+```
+
+or use the runner's mutating convenience option:
+
+```bash
+bash scripts/check_pr_slice.sh issue236-apply-corrections --fix
+```
+
+`--fix` runs `make format` before validation. It may modify files, so inspect `git diff` before committing.
+
+For a lint-only check, use:
+
+```bash
+bash scripts/check_pr_slice.sh issue236-apply-corrections --lint-only
+```
+
+For a focused pytest rerun after lint is already known to pass, use:
+
+```bash
+bash scripts/check_pr_slice.sh issue236-apply-corrections --pytest-only
+```
+
+## Adding a focused test profile
+
+Create a new text file under `scripts/pr_validation_profiles/`:
+
+```text
+scripts/pr_validation_profiles/<profile-name>.txt
+```
+
+Rules:
+
+- Use one pytest argument per line.
+- Blank lines and lines starting with `#` are ignored.
+- Keep profile names tied to issue or feature scope, for example `issue241-pr-validation` or `issue236-apply-corrections`.
+- Prefer stable, lightweight tests that do not require GPU, Docker, model artifacts, or full evaluation data.
+- If a slice needs heavier validation, keep that requirement in the PR body and in `docs/dev/VALIDATION_POLICY.md` terms instead of hiding it inside the lightweight profile.
+
+List available profiles with:
+
+```bash
+bash scripts/check_pr_slice.sh --list-profiles
+```
+
+## Optional local hook
+
+Hooks are opt-in. Do not commit `.git/hooks/` files.
+
+A local pre-push hook can run a lint-only check:
+
+```bash
+cat > .git/hooks/pre-push <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+bash scripts/check_pr_slice.sh issue236-apply-corrections --lint-only
+HOOK
+chmod +x .git/hooks/pre-push
+```
+
+Use a full profile hook only when the focused pytest set is fast enough for normal pushes.
+
+## GitHub Actions coverage
+
+The PR validation workflow in `.github/workflows/pr-validation.yml` currently runs `make lint` on pull requests and manual dispatches.
+
+Focused pytest is intentionally not enabled in GitHub Actions yet. This repository can require optional or heavy dependencies such as PyMuPDF, OpenCV, torch-related packages, OCR backends, Docker, GPU, or model artifacts depending on which tests are selected. Until a stable CI dependency layer is defined, focused pytest remains a local profile-based check.
+
+When CI dependency setup becomes reliable, extend the workflow with a profile command such as:
+
+```bash
+bash scripts/check_pr_slice.sh issue236-apply-corrections --pytest-only
+```
+
+Document the selected profile and dependency assumptions in the same PR.

--- a/scripts/check_pr_slice.sh
+++ b/scripts/check_pr_slice.sh
@@ -49,7 +49,11 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --python)
-      python_bin="${2:?missing python path}"
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --python requires an argument." >&2
+        exit 2
+      fi
+      python_bin="$2"
       shift 2
       ;;
     --list-profiles)
@@ -77,8 +81,8 @@ if [[ "$list_profiles" -eq 1 ]]; then
     echo "No profile directory found: ${profile_dir}" >&2
     exit 1
   fi
-  find "$profile_dir" -maxdepth 1 -type f -name '*.txt' -printf '%f\n' \
-    | sed 's/\.txt$//' \
+  find "$profile_dir" -maxdepth 1 -type f -name '*.txt' \
+    | sed -e 's|.*/||' -e 's/\.txt$//' \
     | sort
   exit 0
 fi
@@ -94,8 +98,9 @@ if [[ ! -f "$profile_file" ]]; then
   echo "Expected profile file: ${profile_file}" >&2
   echo "Available profiles:" >&2
   if [[ -d "$profile_dir" ]]; then
-    find "$profile_dir" -maxdepth 1 -type f -name '*.txt' -printf '  %f\n' \
-      | sed 's/\.txt$//'
+    find "$profile_dir" -maxdepth 1 -type f -name '*.txt' \
+      | sed -e 's|.*/|  |' -e 's/\.txt$//' \
+      | sort >&2
   else
     echo "  <none>" >&2
   fi

--- a/scripts/check_pr_slice.sh
+++ b/scripts/check_pr_slice.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/check_pr_slice.sh [PROFILE] [--fix] [--lint-only] [--pytest-only] [--list-profiles]
+
+Runs the local validation set for a focused PR slice.
+
+Default PROFILE:
+  issue236-apply-corrections
+
+Options:
+  --fix           Run make format before validation. This may modify files.
+  --lint-only     Run only make lint. Useful for lightweight CI or format checks.
+  --pytest-only   Run only the focused pytest set from the selected profile.
+  --python PATH   Python executable for pytest. Defaults to $PYTHON or python3.
+  --list-profiles List available profile names and exit.
+  -h, --help      Show this help.
+
+Profiles are plain text files under scripts/pr_validation_profiles/.
+Each non-empty, non-comment line is passed to pytest as one argument.
+USAGE
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+profile_dir="${script_dir}/pr_validation_profiles"
+
+profile="${PR_SLICE:-issue236-apply-corrections}"
+python_bin="${PYTHON:-python3}"
+run_fix=0
+lint_only=0
+pytest_only=0
+list_profiles=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix|--format)
+      run_fix=1
+      shift
+      ;;
+    --lint-only)
+      lint_only=1
+      shift
+      ;;
+    --pytest-only)
+      pytest_only=1
+      shift
+      ;;
+    --python)
+      python_bin="${2:?missing python path}"
+      shift 2
+      ;;
+    --list-profiles)
+      list_profiles=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      profile="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ "$list_profiles" -eq 1 ]]; then
+  if [[ ! -d "$profile_dir" ]]; then
+    echo "No profile directory found: ${profile_dir}" >&2
+    exit 1
+  fi
+  find "$profile_dir" -maxdepth 1 -type f -name '*.txt' -printf '%f\n' \
+    | sed 's/\.txt$//' \
+    | sort
+  exit 0
+fi
+
+if [[ "$lint_only" -eq 1 && "$pytest_only" -eq 1 ]]; then
+  echo "--lint-only and --pytest-only cannot be combined." >&2
+  exit 2
+fi
+
+profile_file="${profile_dir}/${profile}.txt"
+if [[ ! -f "$profile_file" ]]; then
+  echo "Unknown PR slice profile: ${profile}" >&2
+  echo "Expected profile file: ${profile_file}" >&2
+  echo "Available profiles:" >&2
+  if [[ -d "$profile_dir" ]]; then
+    find "$profile_dir" -maxdepth 1 -type f -name '*.txt' -printf '  %f\n' \
+      | sed 's/\.txt$//'
+  else
+    echo "  <none>" >&2
+  fi
+  exit 2
+fi
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+tests=()
+while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+  line="${raw_line%%#*}"
+  line="$(trim "$line")"
+  [[ -z "$line" ]] && continue
+  tests+=("$line")
+done <"$profile_file"
+
+if [[ "$lint_only" -ne 1 && "${#tests[@]}" -eq 0 ]]; then
+  echo "Profile contains no pytest entries: ${profile_file}" >&2
+  exit 2
+fi
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+log_dir="${LOG_DIR:-artifacts/pr_slice_validation/${profile}_${timestamp}}"
+summary_file="${log_dir}/summary.md"
+mkdir -p "$log_dir"
+
+cd "$repo_root"
+
+overall_status=0
+format_status="skipped"
+lint_status="skipped"
+pytest_status="skipped"
+
+run_and_log() {
+  local label="$1"
+  local outfile="$2"
+  shift 2
+
+  echo "==> ${label}: $*"
+  set +e
+  "$@" 2>&1 | tee "$outfile"
+  local status=${PIPESTATUS[0]}
+  set -e
+  echo "${label}_exit_code=${status}" | tee -a "$outfile"
+  return "$status"
+}
+
+if [[ "$run_fix" -eq 1 ]]; then
+  if run_and_log "make_format" "${log_dir}/format.log" make format; then
+    format_status="passed"
+  else
+    format_status="failed"
+    overall_status=1
+  fi
+else
+  format_status="skipped: --fix was not set"
+fi
+
+if [[ "$pytest_only" -ne 1 ]]; then
+  if run_and_log "make_lint" "${log_dir}/lint.log" make lint; then
+    lint_status="passed"
+  else
+    lint_status="failed"
+    overall_status=1
+  fi
+fi
+
+if [[ "$lint_only" -ne 1 ]]; then
+  if run_and_log "focused_pytest" "${log_dir}/focused_pytest.log" env PYTHONPATH=. "$python_bin" -m pytest "${tests[@]}"; then
+    pytest_status="passed"
+  else
+    pytest_status="failed"
+    overall_status=1
+  fi
+fi
+
+{
+  echo "## PR slice validation"
+  echo
+  echo "- Profile: \`${profile}\`"
+  echo "- Profile file: \`${profile_file#${repo_root}/}\`"
+  echo "- Format fix: ${format_status}"
+  echo "- Lint: ${lint_status}"
+  echo "- Focused pytest: ${pytest_status}"
+  echo "- Python: \`${python_bin}\`"
+  echo "- Log path: \`${log_dir}\`"
+  echo "- Overall exit code: ${overall_status}"
+  echo
+  echo "### Focused pytest set"
+  echo
+  if [[ "${#tests[@]}" -eq 0 ]]; then
+    echo "- Not run"
+  else
+    printf -- '- `%s`\n' "${tests[@]}"
+  fi
+  echo
+  echo "### Commands"
+  echo
+  if [[ "$run_fix" -eq 1 ]]; then
+    echo "- \`make format\`"
+  else
+    echo "- Format fix skipped. Run \`bash scripts/check_pr_slice.sh ${profile} --fix\` before commit when formatter-only churn is likely."
+  fi
+  if [[ "$pytest_only" -ne 1 ]]; then
+    echo "- \`make lint\`"
+  fi
+  if [[ "$lint_only" -ne 1 ]]; then
+    echo "- \`PYTHONPATH=. ${python_bin} -m pytest <profile tests>\`"
+  fi
+} >"$summary_file"
+
+cat "$summary_file"
+exit "$overall_status"

--- a/scripts/pr_validation_profiles/issue236-apply-corrections.txt
+++ b/scripts/pr_validation_profiles/issue236-apply-corrections.txt
@@ -1,0 +1,9 @@
+# Focused pytest set for PR #240 / Issue #236 apply-corrections workflow.
+# Keep one pytest argument per line so future PR slices can be updated by editing
+# or adding a profile file without changing the runner script.
+tests/test_apply_corrections.py
+tests/test_apply_corrections_mmr_suppressions.py
+tests/test_apply_corrections_existing_overrides.py
+tests/test_manual_correction_handoff.py
+tests/test_manual_corrections.py
+tests/test_issue236_review_package_pipeline_connection.py


### PR DESCRIPTION
## Summary

Implements the first workflow slice for #241, separate from the #236 manual-correction feature work.

- Add `scripts/check_pr_slice.sh` as a focused PR validation entrypoint.
- Add `scripts/pr_validation_profiles/issue236-apply-corrections.txt` for the PR #240 / #236 focused pytest set.
- Add `docs/dev/PR_SLICE_VALIDATION.md` with the local workflow, formatter-only commit avoidance steps, profile extension rules, and optional hook example.
- Add a lightweight GitHub Actions workflow for pull-request `make lint`.

## Local commands

Primary focused check:

```bash
bash scripts/check_pr_slice.sh issue236-apply-corrections
```

Formatter/fix-first local workflow:

```bash
make format
bash scripts/check_pr_slice.sh issue236-apply-corrections
```

Equivalent mutating convenience command:

```bash
bash scripts/check_pr_slice.sh issue236-apply-corrections --fix
```

Focused pytest profile only:

```bash
bash scripts/check_pr_slice.sh issue236-apply-corrections --pytest-only
```

Lint-only profile command:

```bash
bash scripts/check_pr_slice.sh issue236-apply-corrections --lint-only
```

## CI scope

This PR adds `.github/workflows/pr-validation.yml`, currently limited to:

```bash
make lint
```

Focused pytest is intentionally not enabled in GitHub Actions in this slice. The repository can involve optional/heavy dependency paths such as PyMuPDF, OpenCV, torch-related packages, OCR backends, Docker/GPU, and model artifacts depending on selected tests. The focused pytest set is therefore kept as a local profile until a stable CI dependency layer is defined.

## Validation

Repository runtime validation was not executed from this ChatGPT session because the WSL / venv / Docker environment is local-only. I did perform a syntax check for the new shell script outside the repository context:

```bash
bash -n scripts/check_pr_slice.sh
```

Expected local validation command before merge:

```bash
bash scripts/check_pr_slice.sh issue236-apply-corrections
```

Closes #241.