### PR TITLE
Record detector input provenance contract

### DIFF
--- a/docs/ISSUE245_REPRODUCIBILITY_ROOT_CAUSE.md
+++ b/docs/ISSUE245_REPRODUCIBILITY_ROOT_CAUSE.md
@@ -1,0 +1,221 @@
+# Issue #245 detector reproducibility root cause
+
+## Status
+
+This document records why accepted detector accuracy has repeatedly failed to
+reproduce from newly supplied PDFs even though earlier Issue #120 work reported a
+successful 68-page Stage E contract.
+
+The central finding is that two different contracts were repeatedly discussed
+under similar names:
+
+1. **Checkpoint reconstruction**: rebuild probe candidates from an inventory that
+   references retained `hybrid_predictions`, then inject those candidates into the
+   detector/CNN route.
+2. **Fresh upstream regeneration**: start from canonical PDF images and make the
+   current HOMR/SR/OMR hybrid output authoritative for probe generation and CNN
+   band geometry.
+
+Only the first contract had reached the historical detector metrics. It does not
+establish that the second contract is reproducible.
+
+## Evidence from the Issue history
+
+### #147: the fresh Stage D boundary was already unresolved
+
+Issue #147 started because regenerated upstream artifacts did not preserve the
+historical Stage D target. A historical worktree could reproduce raw probe
+candidate generation byte-for-byte, but filtered output initially diverged. The
+remaining filter difference was traced to historical execution details such as
+clef-mask resolution.
+
+This was an artifact-provenance recovery result. It was not evidence that current
+HOMR/SR/OMR outputs matched the historical detector sources.
+
+### #149: the accepted detector target came from an inventory route
+
+Issue #149 recovered this chain:
+
+```text
+20260208 bench inventory
+  -> generate_probe_candidates_from_inventory.py
+  -> clef-mask-aware candidate filtering
+  -> probe-rescue reconstruction
+  -> CNN scoring
+  -> TP=3580 / FP=0 / FN=1
+```
+
+The candidate generator reads these paths directly from each inventory record:
+
+```text
+record["image"]
+record["staff_mask"]
+record["hybrid_predictions"]
+```
+
+The `hybrid_predictions` value is the authoritative existing-box input to probe
+candidate generation. Therefore the route reproduces a retained detector
+checkpoint; it does not regenerate those hybrid predictions from a new PDF.
+
+### #151: productionization preserved a partial route
+
+Issue #151 explicitly described the formal dense route as a detector-level
+partial route. It did not run the slow HOMR/SR/OMR upstream pipeline or prove
+fresh source equivalence.
+
+### #141/#156/#158: terminology obscured the remaining boundary
+
+The first real HOMR/SR/OMR-inclusive Stage E run failed substantially:
+
+```text
+TP=3359 FP=145 FN=222
+FN_det=222 FN_cnn=0
+```
+
+The later Stage E repair reached the accepted metrics by reconstructing candidates
+from the inventory route and assigning:
+
+```text
+detection.precomputed_probe_candidates_root = reconstructed probe root
+detection.cnn_bands_from = reconstructed filtered root
+```
+
+The orchestrator still ran hybrid detection, but the current hybrid output was no
+longer authoritative for probe candidates or CNN band geometry. As a result,
+phrases such as "full pipeline", "freshly reconstructed", and
+"production-oriented route" were technically true only for execution/wiring,
+not for detector input provenance.
+
+Issue #158 generalized the route names but did not remove these candidate-source
+overrides. This made the checkpoint route easier to mistake for the fresh user
+route.
+
+### #244: the unresolved boundary reappeared in the user workflow
+
+Issue #244 compared retained and current source layers and found the first
+semantic divergence at baseline HOMR on all 68 pages. Historical candidate
+replay reproduced expected numbering, while current fresh HOMR/SR/OMR did not.
+
+This was not a new regression. It exposed the same fresh/checkpoint distinction
+that had remained unresolved after #147 and #141.
+
+### #245: a focused rescue was promoted too early
+
+The aligned-expansion rescue restored two focused CNN targets. It was then enabled
+in canonical configs before a source-general safety gate passed.
+
+On fresh `Va_Prokofiev_Symphony1/page_004`, it selected 131 rescues for 155
+existing boxes, produced two focused false positives, and still did not restore
+the remaining detector target. This demonstrates why focused-page success cannot
+serve as a production promotion gate.
+
+The rescue implementation remains available for controlled experiments, but the
+canonical configs keep it disabled until a fresh full-68 and downstream gate
+passes.
+
+## Why the same failure kept recurring
+
+### 1. Metrics did not identify the authoritative detector source
+
+The machine-readable evaluation contract recorded page counts, TP/FP/FN, and CNN
+settings, but did not state whether probe candidates came from current hybrid
+outputs or a precomputed root. Two runs with fundamentally different source
+contracts could therefore be compared as if they were equivalent.
+
+### 2. Candidate-source overrides were silent
+
+`precomputed_probe_candidates_root` bypasses probe generation from current hybrid
+outputs. `cnn_bands_from` can separately replace current hybrid band geometry for
+CNN scoring. The orchestrator still executes hybrid detection, so logs alone can
+make the run appear fresh.
+
+### 3. "Generated during this run" was confused with "generated from fresh sources"
+
+The dense candidate files were newly written under the current run directory, but
+their authoritative existing boxes came from inventory-referenced retained hybrid
+predictions. New output timestamps do not establish fresh input provenance.
+
+### 4. Durable records kept conclusions, not complete executable identity
+
+Large artifacts and detailed manifests correctly remained under ignored `logs/`,
+but later sessions often retained only metric summaries. Missing or weakly bound
+items included input artifact hashes, model hashes, environment identity, source
+mode, and the exact relationship between inventory records and generated roots.
+
+### 5. Validation was split across issues without one clean-room owner
+
+Different issues owned provenance recovery, detector-level reconstruction,
+production naming, full-pipeline execution, and accuracy repair. Each issue could
+satisfy its local acceptance criteria while the clean-checkout/new-PDF contract
+remained unproven.
+
+### 6. Tests primarily validated wiring
+
+Mocked orchestrator tests and helper tests were valuable, but did not verify that
+current HOMR/SR/OMR outputs were authoritative. The real GPU full-68 gate was
+manual and expensive, so config promotion could occur before that gate.
+
+### 7. External runtime inputs were not fully bootstrapped
+
+The OMR-DLN measure model and some SR/CNN weights live outside Git. Missing model
+weights, worktree-local paths, container mounts, and provider/runtime differences
+made reruns environment-dependent even before accuracy was evaluated.
+
+## Enforced contracts
+
+### Fresh upstream contract
+
+A run is fresh only when both conditions hold:
+
+```text
+precomputed_probe_candidates_root is unset
+cnn_bands_from is unset
+```
+
+In this mode, the current hybrid output is authoritative for both probe generation
+and CNN band geometry.
+
+`src/pipeline/detection/input_contract.py` classifies this mode as:
+
+```text
+fresh_upstream
+```
+
+The Issue #245 fresh full-68 runner rejects candidate-source overrides before it
+creates an output directory.
+
+### Checkpoint/precomputed contract
+
+A run with either candidate-source override is classified as:
+
+```text
+precomputed_candidate_route
+```
+
+Such runs remain useful for historical regression, CNN comparison, or downstream
+isolation. They must not be cited as evidence that newly supplied PDFs reproduce
+the historical detector contract.
+
+## Promotion rules
+
+1. Experimental detector changes remain default OFF.
+2. Focused pages may establish mechanism, not production safety.
+3. A canonical config change requires a fresh upstream full-68 result.
+4. Detector, physical-measure, MMR, guard-case, and corrected-final gates remain
+   separate and must all be reported.
+5. Every claimed result must state the detector input mode and candidate-source
+   override keys.
+6. A new output directory is required for each fresh validation run.
+7. Checkpoint metrics and fresh metrics must not share an unlabeled baseline name.
+
+## Current technical direction
+
+The broad aligned-expansion rescue is not the next default fix. The remaining
+Prokofiev target is absent before CNN and is not recovered by the rescue. The next
+investigation should trace that single target through fresh baseline HOMR, SR-side
+HOMR, OMR-DLN, hybrid consensus, row-band construction, existing suppression,
+and probe generation while keeping the canonical rescue disabled.
+
+The objective is to identify the first layer where the target or its containing
+row disappears. Only a source-general repair at that boundary should proceed to
+focused and full-68 gates.

--- a/docs/ISSUE245_REPRODUCIBILITY_ROOT_CAUSE.md
+++ b/docs/ISSUE245_REPRODUCIBILITY_ROOT_CAUSE.md
@@ -2,220 +2,172 @@
 
 ## Status
 
-This document records why accepted detector accuracy has repeatedly failed to
-reproduce from newly supplied PDFs even though earlier Issue #120 work reported a
-successful 68-page Stage E contract.
+Issue #245 established that two different detector input contracts had repeatedly
+been discussed under similar names. This made a retained checkpoint regression look
+like proof that newly supplied PDFs could reproduce the same detector accuracy.
 
-The central finding is that two different contracts were repeatedly discussed
-under similar names:
-
-1. **Checkpoint reconstruction**: rebuild probe candidates from an inventory that
-   references retained `hybrid_predictions`, then inject those candidates into the
-   detector/CNN route.
-2. **Fresh upstream regeneration**: start from canonical PDF images and make the
-   current HOMR/SR/OMR hybrid output authoritative for probe generation and CNN
-   band geometry.
-
-Only the first contract had reached the historical detector metrics. It does not
-establish that the second contract is reproducible.
-
-## Evidence from the Issue history
-
-### #147: the fresh Stage D boundary was already unresolved
-
-Issue #147 started because regenerated upstream artifacts did not preserve the
-historical Stage D target. A historical worktree could reproduce raw probe
-candidate generation byte-for-byte, but filtered output initially diverged. The
-remaining filter difference was traced to historical execution details such as
-clef-mask resolution.
-
-This was an artifact-provenance recovery result. It was not evidence that current
-HOMR/SR/OMR outputs matched the historical detector sources.
-
-### #149: the accepted detector target came from an inventory route
-
-Issue #149 recovered this chain:
+The large investigation history is preserved at:
 
 ```text
-20260208 bench inventory
-  -> generate_probe_candidates_from_inventory.py
-  -> clef-mask-aware candidate filtering
-  -> probe-rescue reconstruction
+archive/issue245-investigation-20260719
+```
+
+The durable changes extracted from that branch are limited to an explicit detector
+input contract, a per-run manifest, focused tests, and this record.
+
+## The two contracts
+
+### Checkpoint reconstruction
+
+The accepted Issue #120 detector metrics were recovered through a route equivalent
+to:
+
+```text
+benchmark inventory
+  -> retained hybrid_predictions
+  -> dense candidate reconstruction
+  -> candidate filtering and probe rescue
   -> CNN scoring
-  -> TP=3580 / FP=0 / FN=1
 ```
 
-The candidate generator reads these paths directly from each inventory record:
+The generated candidate files were new, but their authoritative existing boxes came
+from retained `hybrid_predictions` referenced by the inventory.
+
+The Stage E wrapper then configured:
 
 ```text
-record["image"]
-record["staff_mask"]
-record["hybrid_predictions"]
+detection.precomputed_probe_candidates_root
+detection.cnn_bands_from
 ```
 
-The `hybrid_predictions` value is the authoritative existing-box input to probe
-candidate generation. Therefore the route reproduces a retained detector
-checkpoint; it does not regenerate those hybrid predictions from a new PDF.
+This route remains useful for historical checkpoint regression, CNN comparison, and
+downstream isolation. It does not demonstrate that current HOMR/SR/OMR output from
+a newly supplied PDF reproduces the checkpoint.
 
-### #151: productionization preserved a partial route
+### Fresh upstream regeneration
 
-Issue #151 explicitly described the formal dense route as a detector-level
-partial route. It did not run the slow HOMR/SR/OMR upstream pipeline or prove
-fresh source equivalence.
+A fresh detector run starts from the input images and makes the current
+HOMR/SR/OMR hybrid output authoritative for both:
 
-### #141/#156/#158: terminology obscured the remaining boundary
+- probe candidate generation;
+- CNN band geometry.
 
-The first real HOMR/SR/OMR-inclusive Stage E run failed substantially:
-
-```text
-TP=3359 FP=145 FN=222
-FN_det=222 FN_cnn=0
-```
-
-The later Stage E repair reached the accepted metrics by reconstructing candidates
-from the inventory route and assigning:
-
-```text
-detection.precomputed_probe_candidates_root = reconstructed probe root
-detection.cnn_bands_from = reconstructed filtered root
-```
-
-The orchestrator still ran hybrid detection, but the current hybrid output was no
-longer authoritative for probe candidates or CNN band geometry. As a result,
-phrases such as "full pipeline", "freshly reconstructed", and
-"production-oriented route" were technically true only for execution/wiring,
-not for detector input provenance.
-
-Issue #158 generalized the route names but did not remove these candidate-source
-overrides. This made the checkpoint route easier to mistake for the fresh user
-route.
-
-### #244: the unresolved boundary reappeared in the user workflow
-
-Issue #244 compared retained and current source layers and found the first
-semantic divergence at baseline HOMR on all 68 pages. Historical candidate
-replay reproduced expected numbering, while current fresh HOMR/SR/OMR did not.
-
-This was not a new regression. It exposed the same fresh/checkpoint distinction
-that had remained unresolved after #147 and #141.
-
-### #245: a focused rescue was promoted too early
-
-The aligned-expansion rescue restored two focused CNN targets. It was then enabled
-in canonical configs before a source-general safety gate passed.
-
-On fresh `Va_Prokofiev_Symphony1/page_004`, it selected 131 rescues for 155
-existing boxes, produced two focused false positives, and still did not restore
-the remaining detector target. This demonstrates why focused-page success cannot
-serve as a production promotion gate.
-
-The rescue implementation remains available for controlled experiments, but the
-canonical configs keep it disabled until a fresh full-68 and downstream gate
-passes.
-
-## Why the same failure kept recurring
-
-### 1. Metrics did not identify the authoritative detector source
-
-The machine-readable evaluation contract recorded page counts, TP/FP/FN, and CNN
-settings, but did not state whether probe candidates came from current hybrid
-outputs or a precomputed root. Two runs with fundamentally different source
-contracts could therefore be compared as if they were equivalent.
-
-### 2. Candidate-source overrides were silent
-
-`precomputed_probe_candidates_root` bypasses probe generation from current hybrid
-outputs. `cnn_bands_from` can separately replace current hybrid band geometry for
-CNN scoring. The orchestrator still executes hybrid detection, so logs alone can
-make the run appear fresh.
-
-### 3. "Generated during this run" was confused with "generated from fresh sources"
-
-The dense candidate files were newly written under the current run directory, but
-their authoritative existing boxes came from inventory-referenced retained hybrid
-predictions. New output timestamps do not establish fresh input provenance.
-
-### 4. Durable records kept conclusions, not complete executable identity
-
-Large artifacts and detailed manifests correctly remained under ignored `logs/`,
-but later sessions often retained only metric summaries. Missing or weakly bound
-items included input artifact hashes, model hashes, environment identity, source
-mode, and the exact relationship between inventory records and generated roots.
-
-### 5. Validation was split across issues without one clean-room owner
-
-Different issues owned provenance recovery, detector-level reconstruction,
-production naming, full-pipeline execution, and accuracy repair. Each issue could
-satisfy its local acceptance criteria while the clean-checkout/new-PDF contract
-remained unproven.
-
-### 6. Tests primarily validated wiring
-
-Mocked orchestrator tests and helper tests were valuable, but did not verify that
-current HOMR/SR/OMR outputs were authoritative. The real GPU full-68 gate was
-manual and expensive, so config promotion could occur before that gate.
-
-### 7. External runtime inputs were not fully bootstrapped
-
-The OMR-DLN measure model and some SR/CNN weights live outside Git. Missing model
-weights, worktree-local paths, container mounts, and provider/runtime differences
-made reruns environment-dependent even before accuracy was evaluated.
-
-## Enforced contracts
-
-### Fresh upstream contract
-
-A run is fresh only when both conditions hold:
+For this contract, both candidate-source overrides must be unset:
 
 ```text
 precomputed_probe_candidates_root is unset
 cnn_bands_from is unset
 ```
 
-In this mode, the current hybrid output is authoritative for both probe generation
-and CNN band geometry.
+## Why the distinction was repeatedly lost
 
-`src/pipeline/detection/input_contract.py` classifies this mode as:
+### Similar route names
+
+Terms such as “full pipeline”, “freshly reconstructed”, and “production-oriented”
+described execution or wiring, but did not identify which artifact was authoritative
+for detector candidates.
+
+### Silent candidate-source overrides
+
+The orchestrator can run HOMR/SR/OMR and then bypass the resulting hybrid geometry by
+copying precomputed probe candidates. `cnn_bands_from` can separately replace the
+current hybrid bands used during CNN scoring. Console logs alone therefore cannot
+prove that a run is fresh.
+
+### New output was confused with fresh input
+
+Writing candidate JSON into a new run directory does not prove fresh provenance when
+the seed geometry comes from a retained inventory record.
+
+### Metrics omitted source identity
+
+TP/FP/FN, page counts, thresholds, and NMS settings were recorded, but the
+machine-readable result did not identify the authoritative candidate source. Runs
+with different input contracts could therefore be compared under the same baseline
+name.
+
+### Focused success was promoted too early
+
+The Issue #245 aligned-expansion experiment restored focused Shostakovich and
+Sibelius targets. On fresh `Va_Prokofiev_Symphony1/page_004`, however, it selected
+131 rescues for 155 existing boxes, introduced two false positives, and still did
+not restore the remaining detector target.
+
+That experiment is retained only on the archive branch. It is not included in the
+clean remediation branch and must not be enabled in a canonical config without a
+fresh full-68 and downstream regression.
+
+## Historical boundary
+
+The earlier Issue #244 investigation had already shown that:
+
+- the first semantic divergence between retained and current source layers occurred
+  at baseline HOMR;
+- retained candidate replay reproduced the expected numbering;
+- current fresh HOMR/SR/OMR did not preserve the accepted detector contract.
+
+Issue #245 did not discover a new regression. It exposed that the unresolved fresh
+boundary had been masked by the checkpoint reconstruction route.
+
+## Enforced machine contract
+
+`src/pipeline/detection/input_contract.py` classifies every detector configuration as
+one of:
 
 ```text
 fresh_upstream
-```
-
-The Issue #245 fresh full-68 runner rejects candidate-source overrides before it
-creates an output directory.
-
-### Checkpoint/precomputed contract
-
-A run with either candidate-source override is classified as:
-
-```text
 precomputed_candidate_route
 ```
 
-Such runs remain useful for historical regression, CNN comparison, or downstream
-isolation. They must not be cited as evidence that newly supplied PDFs reproduce
-the historical detector contract.
+A run is classified as `precomputed_candidate_route` when either
+`precomputed_probe_candidates_root` or `cnn_bands_from` is configured.
+
+`DetectorOrchestrator` writes the classification before detector execution to:
+
+```text
+<run_dir>/intermediate/detector_input_contract.json
+```
+
+The manifest records:
+
+- mode;
+- whether fresh upstream is authoritative;
+- whether current hybrid output is authoritative for probe generation;
+- whether current hybrid output is authoritative for CNN bands;
+- configured override paths and keys.
+
+A result must not be described as a fresh detector validation unless the manifest
+reports:
+
+```text
+mode = fresh_upstream
+fresh_upstream_authoritative = true
+override_keys = []
+```
 
 ## Promotion rules
 
 1. Experimental detector changes remain default OFF.
-2. Focused pages may establish mechanism, not production safety.
-3. A canonical config change requires a fresh upstream full-68 result.
-4. Detector, physical-measure, MMR, guard-case, and corrected-final gates remain
-   separate and must all be reported.
-5. Every claimed result must state the detector input mode and candidate-source
-   override keys.
-6. A new output directory is required for each fresh validation run.
-7. Checkpoint metrics and fresh metrics must not share an unlabeled baseline name.
+2. Focused pages establish a mechanism, not production safety.
+3. A canonical detector config change requires a fresh upstream full-68 result.
+4. Detector, physical-measure, MMR, guard-case, and corrected-final results remain
+   separate gates.
+5. Every claimed metric must state the detector input mode and override keys.
+6. Checkpoint metrics and fresh metrics must not share an unlabeled baseline name.
+7. Each fresh validation uses a new output root and records external model/runtime
+   provenance.
 
-## Current technical direction
+## Scope after branch cleanup
 
-The broad aligned-expansion rescue is not the next default fix. The remaining
-Prokofiev target is absent before CNN and is not recovered by the rescue. The next
-investigation should trace that single target through fresh baseline HOMR, SR-side
-HOMR, OMR-DLN, hybrid consensus, row-band construction, existing suppression,
-and probe generation while keeping the canonical rescue disabled.
+The clean remediation branch intentionally excludes:
 
-The objective is to identify the first layer where the target or its containing
-row disappears. Only a source-general repair at that boundary should proceed to
-focused and full-68 gates.
+- aligned-expansion production changes;
+- same-file staff/clef experiments;
+- OMR/SR bootstrap work;
+- the large `tools/issue245` investigation suite;
+- fresh Prokofiev accuracy repair.
+
+Those artifacts remain available on the archive branch. The remaining Prokofiev
+miss should be handled by a new narrow issue that identifies the first fresh layer
+where the target geometry or its containing row disappears before proposing a
+source-general repair.

--- a/scripts/pr_validation_profiles/issue245-detector-input-contract.txt
+++ b/scripts/pr_validation_profiles/issue245-detector-input-contract.txt
@@ -1,0 +1,3 @@
+# Focused validation for the Issue #245 detector input contract.
+tests/test_detector_input_contract.py
+tests/test_detector_orchestrator_input_contract.py

--- a/src/pipeline/detection/input_contract.py
+++ b/src/pipeline/detection/input_contract.py
@@ -39,9 +39,7 @@ def build_detector_input_contract(det_cfg: Mapping[str, Any]) -> dict[str, Any]:
         "precomputed_probe_candidates_root": (
             str(precomputed_probe) if uses_precomputed_probe else None
         ),
-        "cnn_bands_from_override": (
-            str(cnn_bands_override) if uses_cnn_bands_override else None
-        ),
+        "cnn_bands_from_override": (str(cnn_bands_override) if uses_cnn_bands_override else None),
         "override_keys": [
             key
             for key, enabled in (

--- a/src/pipeline/detection/input_contract.py
+++ b/src/pipeline/detection/input_contract.py
@@ -18,7 +18,8 @@ CNN_BANDS_OVERRIDE_KEY = "cnn_bands_from"
 
 
 def _configured(value: Any) -> bool:
-    return value is not None and str(value).strip() != ""
+    """Match the truthiness gate used by the detector path resolvers."""
+    return bool(value)
 
 
 def build_detector_input_contract(det_cfg: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/pipeline/detection/input_contract.py
+++ b/src/pipeline/detection/input_contract.py
@@ -1,0 +1,66 @@
+"""Classify whether detector candidates come from fresh upstream or overrides.
+
+A run may execute HOMR/SR/OMR while still replacing the authoritative probe or
+CNN inputs with precomputed artifacts.  Metrics from that route are useful as a
+checkpoint, but they are not evidence that fresh upstream regeneration works.
+This module keeps that distinction machine-readable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+FRESH_UPSTREAM_MODE = "fresh_upstream"
+PRECOMPUTED_CANDIDATE_MODE = "precomputed_candidate_route"
+PRECOMPUTED_PROBE_KEY = "precomputed_probe_candidates_root"
+CNN_BANDS_OVERRIDE_KEY = "cnn_bands_from"
+
+
+def _configured(value: Any) -> bool:
+    return value is not None and str(value).strip() != ""
+
+
+def build_detector_input_contract(det_cfg: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the authoritative candidate-source contract for one detector run."""
+    precomputed_probe = det_cfg.get(PRECOMPUTED_PROBE_KEY)
+    cnn_bands_override = det_cfg.get(CNN_BANDS_OVERRIDE_KEY)
+    uses_precomputed_probe = _configured(precomputed_probe)
+    uses_cnn_bands_override = _configured(cnn_bands_override)
+    fresh = not uses_precomputed_probe and not uses_cnn_bands_override
+
+    return {
+        "schema_version": "pipeline.detector_input_contract.v1",
+        "mode": FRESH_UPSTREAM_MODE if fresh else PRECOMPUTED_CANDIDATE_MODE,
+        "fresh_upstream_authoritative": fresh,
+        "hybrid_detection_may_execute": True,
+        "hybrid_output_authoritative_for_probe": not uses_precomputed_probe,
+        "hybrid_output_authoritative_for_cnn_bands": not uses_cnn_bands_override,
+        "precomputed_probe_candidates_root": (
+            str(precomputed_probe) if uses_precomputed_probe else None
+        ),
+        "cnn_bands_from_override": (
+            str(cnn_bands_override) if uses_cnn_bands_override else None
+        ),
+        "override_keys": [
+            key
+            for key, enabled in (
+                (PRECOMPUTED_PROBE_KEY, uses_precomputed_probe),
+                (CNN_BANDS_OVERRIDE_KEY, uses_cnn_bands_override),
+            )
+            if enabled
+        ],
+    }
+
+
+def require_fresh_detector_input_contract(det_cfg: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the contract or reject a route that substitutes candidate inputs."""
+    contract = build_detector_input_contract(det_cfg)
+    if not contract["fresh_upstream_authoritative"]:
+        keys = ", ".join(contract["override_keys"])
+        raise ValueError(
+            "Fresh detector validation rejects candidate-source overrides: "
+            f"{keys}. A run that uses these keys is a checkpoint/precomputed route, "
+            "even if HOMR/SR/OMR also execute."
+        )
+    return contract

--- a/src/pipeline/detection/orchestrator.py
+++ b/src/pipeline/detection/orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import shutil
 from pathlib import Path
@@ -15,6 +16,7 @@ from src.pipeline.utils.io import ensure_dir
 
 from .config import get_cnn_apply_nms, get_probe_kwargs
 from .hybrid import HybridDetector
+from .input_contract import build_detector_input_contract
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +84,8 @@ class DetectorOrchestrator:
         self.in_memory_images = in_memory_images
         self.det_cfg = get_nested(config, "detection", default={}) or {}
         _reject_removed_detector_route_keys(self.det_cfg)
+        self.input_contract = build_detector_input_contract(self.det_cfg)
+        self.input_contract_path = self.run_dir / "intermediate" / "detector_input_contract.json"
         self.skip_existing = bool(self.det_cfg.get("probe_skip_existing", False))
         self.enable_sr = bool(self.det_cfg.get("enable_sr", True))
         self.sr_scale = int(self.det_cfg.get("sr_scale", 2))
@@ -89,8 +93,27 @@ class DetectorOrchestrator:
         self.hybrid_output_dir: Path | None = None
         self.probe_output_dir: Path | None = None
 
+    def _record_input_contract(self) -> Path | None:
+        """Persist which detector source is authoritative before executing stages."""
+        logger.info(
+            "Detector input contract: mode=%s fresh_upstream_authoritative=%s overrides=%s",
+            self.input_contract["mode"],
+            self.input_contract["fresh_upstream_authoritative"],
+            self.input_contract["override_keys"],
+        )
+        if self.dry_run:
+            return None
+        ensure_dir(self.input_contract_path.parent)
+        self.input_contract_path.write_text(
+            json.dumps(self.input_contract, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        return self.input_contract_path
+
     def run_detection(self) -> Dict[str, Any]:
         """Executes the full detection pipeline."""
+        input_contract_path = self._record_input_contract()
+
         hybrid_result = self._run_hybrid_detection()
         self.hybrid_output_dir = hybrid_result["hybrid_output_dir"]
         self.commands.extend(hybrid_result["commands"])
@@ -106,6 +129,8 @@ class DetectorOrchestrator:
             "commands": self.commands,
             "hybrid_output_dir": self.hybrid_output_dir,
             "probe_output_dir": self.probe_output_dir,
+            "detector_input_contract": self.input_contract,
+            "detector_input_contract_path": input_contract_path,
         }
 
     def _run_hybrid_detection(self) -> Dict[str, Any]:

--- a/tests/test_detector_input_contract.py
+++ b/tests/test_detector_input_contract.py
@@ -7,6 +7,8 @@ from src.pipeline.detection.input_contract import (
     require_fresh_detector_input_contract,
 )
 
+OVERRIDE_KEYS = ("precomputed_probe_candidates_root", "cnn_bands_from")
+
 
 def test_empty_detection_config_is_fresh_upstream() -> None:
     contract = build_detector_input_contract({})
@@ -16,6 +18,26 @@ def test_empty_detection_config_is_fresh_upstream() -> None:
     assert contract["override_keys"] == []
     assert contract["hybrid_output_authoritative_for_probe"] is True
     assert contract["hybrid_output_authoritative_for_cnn_bands"] is True
+
+
+@pytest.mark.parametrize("key", OVERRIDE_KEYS)
+@pytest.mark.parametrize("value", [None, "", False])
+def test_falsey_override_values_are_unset(key: str, value: object) -> None:
+    contract = build_detector_input_contract({key: value})
+
+    assert contract["mode"] == FRESH_UPSTREAM_MODE
+    assert contract["fresh_upstream_authoritative"] is True
+    assert contract["override_keys"] == []
+
+
+@pytest.mark.parametrize("key", OVERRIDE_KEYS)
+@pytest.mark.parametrize("value", ["   ", "logs/checkpoint/input"])
+def test_truthy_path_strings_select_precomputed_route(key: str, value: str) -> None:
+    contract = build_detector_input_contract({key: value})
+
+    assert contract["mode"] == PRECOMPUTED_CANDIDATE_MODE
+    assert contract["fresh_upstream_authoritative"] is False
+    assert contract["override_keys"] == [key]
 
 
 def test_precomputed_probe_candidates_make_route_checkpoint_only() -> None:

--- a/tests/test_detector_input_contract.py
+++ b/tests/test_detector_input_contract.py
@@ -1,0 +1,51 @@
+import pytest
+
+from src.pipeline.detection.input_contract import (
+    FRESH_UPSTREAM_MODE,
+    PRECOMPUTED_CANDIDATE_MODE,
+    build_detector_input_contract,
+    require_fresh_detector_input_contract,
+)
+
+
+def test_empty_detection_config_is_fresh_upstream() -> None:
+    contract = build_detector_input_contract({})
+
+    assert contract["mode"] == FRESH_UPSTREAM_MODE
+    assert contract["fresh_upstream_authoritative"] is True
+    assert contract["override_keys"] == []
+    assert contract["hybrid_output_authoritative_for_probe"] is True
+    assert contract["hybrid_output_authoritative_for_cnn_bands"] is True
+
+
+def test_precomputed_probe_candidates_make_route_checkpoint_only() -> None:
+    contract = build_detector_input_contract(
+        {"precomputed_probe_candidates_root": "logs/checkpoint/probe"}
+    )
+
+    assert contract["mode"] == PRECOMPUTED_CANDIDATE_MODE
+    assert contract["fresh_upstream_authoritative"] is False
+    assert contract["hybrid_output_authoritative_for_probe"] is False
+    assert contract["override_keys"] == ["precomputed_probe_candidates_root"]
+
+
+def test_cnn_bands_override_makes_route_checkpoint_only() -> None:
+    contract = build_detector_input_contract({"cnn_bands_from": "logs/checkpoint/bands"})
+
+    assert contract["mode"] == PRECOMPUTED_CANDIDATE_MODE
+    assert contract["fresh_upstream_authoritative"] is False
+    assert contract["hybrid_output_authoritative_for_cnn_bands"] is False
+    assert contract["override_keys"] == ["cnn_bands_from"]
+
+
+def test_fresh_guard_names_all_candidate_source_overrides() -> None:
+    with pytest.raises(
+        ValueError,
+        match="precomputed_probe_candidates_root, cnn_bands_from",
+    ):
+        require_fresh_detector_input_contract(
+            {
+                "precomputed_probe_candidates_root": "logs/checkpoint/probe",
+                "cnn_bands_from": "logs/checkpoint/bands",
+            }
+        )

--- a/tests/test_detector_orchestrator_input_contract.py
+++ b/tests/test_detector_orchestrator_input_contract.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("homr")
+
+from src.pipeline.detection.orchestrator import DetectorOrchestrator
+
+
+def _orchestrator(tmp_path: Path, detection: dict) -> DetectorOrchestrator:
+    return DetectorOrchestrator(
+        config={"detection": detection},
+        images=[],
+        run_id="contract-test",
+        run_dir=tmp_path,
+        dry_run=False,
+    )
+
+
+def test_orchestrator_records_fresh_upstream_contract(tmp_path: Path) -> None:
+    orchestrator = _orchestrator(tmp_path, {})
+
+    path = orchestrator._record_input_contract()
+
+    assert path == tmp_path / "intermediate" / "detector_input_contract.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["mode"] == "fresh_upstream"
+    assert payload["fresh_upstream_authoritative"] is True
+    assert payload["override_keys"] == []
+
+
+def test_orchestrator_records_precomputed_candidate_contract(tmp_path: Path) -> None:
+    orchestrator = _orchestrator(
+        tmp_path,
+        {
+            "precomputed_probe_candidates_root": "logs/checkpoint/probe",
+            "cnn_bands_from": "logs/checkpoint/bands",
+        },
+    )
+
+    path = orchestrator._record_input_contract()
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["mode"] == "precomputed_candidate_route"
+    assert payload["fresh_upstream_authoritative"] is False
+    assert payload["override_keys"] == [
+        "precomputed_probe_candidates_root",
+        "cnn_bands_from",
+    ]

--- a/tests/test_detector_orchestrator_input_contract.py
+++ b/tests/test_detector_orchestrator_input_contract.py
@@ -3,18 +3,21 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("homr")
-
 from src.pipeline.detection.orchestrator import DetectorOrchestrator
 
 
-def _orchestrator(tmp_path: Path, detection: dict) -> DetectorOrchestrator:
+def _orchestrator(
+    tmp_path: Path,
+    detection: dict,
+    *,
+    dry_run: bool = False,
+) -> DetectorOrchestrator:
     return DetectorOrchestrator(
         config={"detection": detection},
         images=[],
         run_id="contract-test",
         run_dir=tmp_path,
-        dry_run=False,
+        dry_run=dry_run,
     )
 
 
@@ -48,3 +51,73 @@ def test_orchestrator_records_precomputed_candidate_contract(tmp_path: Path) -> 
         "precomputed_probe_candidates_root",
         "cnn_bands_from",
     ]
+
+
+def test_run_detection_returns_persisted_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator = _orchestrator(tmp_path, {})
+    hybrid_output_dir = tmp_path / "hybrid"
+    probe_output_dir = tmp_path / "probe"
+    monkeypatch.setattr(
+        orchestrator,
+        "_run_hybrid_detection",
+        lambda: {"hybrid_output_dir": hybrid_output_dir, "commands": []},
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "_run_probe_scan",
+        lambda: {"probe_output_dir": probe_output_dir, "commands": []},
+    )
+    monkeypatch.setattr(orchestrator, "_run_cnn_scoring", lambda: {"commands": []})
+
+    result = orchestrator.run_detection()
+
+    expected_path = tmp_path / "intermediate" / "detector_input_contract.json"
+    assert result["detector_input_contract"] == orchestrator.input_contract
+    assert result["detector_input_contract_path"] == expected_path
+    assert expected_path.is_file()
+
+
+def test_dry_run_returns_contract_without_writing_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator = _orchestrator(tmp_path, {}, dry_run=True)
+    monkeypatch.setattr(
+        orchestrator,
+        "_run_hybrid_detection",
+        lambda: {"hybrid_output_dir": tmp_path / "hybrid", "commands": []},
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "_run_probe_scan",
+        lambda: {"probe_output_dir": tmp_path / "probe", "commands": []},
+    )
+    monkeypatch.setattr(orchestrator, "_run_cnn_scoring", lambda: {"commands": []})
+
+    result = orchestrator.run_detection()
+
+    assert result["detector_input_contract"] == orchestrator.input_contract
+    assert result["detector_input_contract_path"] is None
+    assert not orchestrator.input_contract_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("key", "resolver_name"),
+    [
+        ("precomputed_probe_candidates_root", "_resolve_precomputed_probe_candidates_root"),
+        ("cnn_bands_from", "_resolve_cnn_bands_from"),
+    ],
+)
+def test_true_is_not_a_valid_path_override(
+    tmp_path: Path,
+    key: str,
+    resolver_name: str,
+) -> None:
+    orchestrator = _orchestrator(tmp_path, {key: True})
+    orchestrator.hybrid_output_dir = tmp_path / "hybrid"
+
+    with pytest.raises(TypeError):
+        getattr(orchestrator, resolver_name)()


### PR DESCRIPTION
## Summary

Issue #245 investigation showed that two different detector contracts had been reported under similar Stage E terminology:

- a checkpoint route reconstructed candidates from inventory-retained `hybrid_predictions` and injected `precomputed_probe_candidates_root` / `cnn_bands_from`;
- a fresh route makes current HOMR/SR/OMR hybrid output authoritative for probe generation and CNN band geometry.

This PR extracts only the durable recurrence-prevention work from the 180-commit investigation branch.

## Changes

- add `src.pipeline.detection.input_contract` to classify detector runs as:
  - `fresh_upstream`
  - `precomputed_candidate_route`
- record `<run_dir>/intermediate/detector_input_contract.json` before detector execution;
- include the contract and manifest path in `DetectorOrchestrator` results;
- add focused unit tests for classification and manifest output;
- document why the historical checkpoint result did not prove fresh upstream reproducibility;
- add the `issue245-detector-input-contract` PR slice validation profile.

## Explicitly excluded

This PR does **not** include:

- aligned-expansion rescue code or config promotion;
- same-file staff/clef experiments;
- OMR-DLN / Real-ESRGAN bootstrap changes;
- the large `tools/issue245` investigation suite;
- any fresh Prokofiev accuracy repair;
- any detector threshold or canonical accuracy change.

The full evidence branch is preserved as an immutable tag before investigation branch cleanup:

```text
archive/issue245-investigation-20260719
```

## Contract

A result may be described as fresh only when the generated manifest reports:

```text
mode = fresh_upstream
fresh_upstream_authoritative = true
override_keys = []
```

A route with either `precomputed_probe_candidates_root` or `cnn_bands_from` remains a valid checkpoint/precomputed regression, but is not evidence that new PDFs reproduce the historical detector contract.

The classifier follows the same truthiness gate as the route resolvers: missing keys, `null`, an empty string, and `false` are unset; truthy values select the override route. Boolean `true` is not accepted as a path by the existing resolver.

## Validation

Focused profile:

```bash
bash scripts/check_pr_slice.sh \
  issue245-detector-input-contract \
  --python /home/masaki_muramatsu/ws_PDFScoreBar/.venv_pdf/bin/python
```

Equivalent focused pytest:

```bash
PYTHONPATH=. /home/masaki_muramatsu/ws_PDFScoreBar/.venv_pdf/bin/python -m pytest \
  tests/test_detector_input_contract.py \
  tests/test_detector_orchestrator_input_contract.py
```

Completed on head `4df6e38`:

- GitHub Actions `PR validation`: passed;
- `make lint`: passed;
- focused PR slice validation: passed with overall exit code 0;
- focused pytest: `20 passed` with no skipped tests;
- the manifest persistence, dry-run, result payload, falsey override, and resolver-alignment cases all execute without HOMR installed;
- clean branch diff review: 6 files, no detector thresholds, model settings, or canonical configs changed.

## Follow-up

The remaining fresh Prokofiev detector miss is tracked separately in #252. It must trace the target through baseline HOMR, SR HOMR, OMR-DLN, hybrid consensus, probe generation, and CNN without enabling the rejected broad rescue.

Relates to #245.